### PR TITLE
Query error propagation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -128,12 +128,18 @@ p.submit = function(connection) {
   var handleDatarow = function(msg) {
     self.onDataRow(msg);
   };
+  var handleError = function(msg) {
+    self.emit('error', msg);
+    connection.sync();
+  };
   connection.on('rowDescription', handleRowDescription);
   connection.on('dataRow', handleDatarow);
+  connection.on('error', handleError);
   connection.once('readyForQuery', function() {
     //remove all listeners
     connection.removeListener('rowDescription', handleRowDescription);
     connection.removeListener('dataRow', handleDatarow);
+    connection.removeListener('error', handleError);
     self.emit('end');
   });
 };

--- a/test/integration/client/error-handling-tests.js
+++ b/test/integration/client/error-handling-tests.js
@@ -2,8 +2,8 @@ var helper = require(__dirname + '/test-helper');
 
 test('error handling', function(){
   var client = helper.client();
-  client.query("select omfg from yodas_soda where pixistix = 'zoiks!!!'");
-  assert.emits(client, 'error', function(error) {
+  var query = client.query("select omfg from yodas_soda where pixistix = 'zoiks!!!'");
+  assert.emits(query, 'error', function(error) {
     assert.equal(error.severity, "ERROR");
     client.end();
   });


### PR DESCRIPTION
This patch ensures that errors during query processing are emitted by the relevant Query object. Essential for error handling on the client side. Also it does a sync() so that the connection keeps going.

The problem with it is that errors will get emitted twice, once from Query and once from Client. Not sure what to do about that—maybe temporarily suspend the Client's error listener when a query is happening?

I also updated the relevant test, but I'm not 100% on it due to both the double-error business and the fact that the type coercion tests were failing either way. Not sure what's up with that.

Thanks for your trouble!
