### PR TITLE
Added parser for "interval" type

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -111,6 +111,10 @@ var parseInterval = function(val) {
       if (i.minutes) i.minutes *= -1;
       if (i.seconds) i.seconds *= -1;
   }
+  for (field in i){
+      if (i[field] == 0)
+	  delete i[field];
+  }
   return i;
 };
 

--- a/test/unit/client/typed-query-results-tests.js
+++ b/test/unit/client/typed-query-results-tests.js
@@ -117,7 +117,7 @@ test('typed results', function() {
     dataTypeID: 1186,
     actual: '1 day -00:00:03',
     expected: function(val) {
-      assert.deepEqual(val, {'days':1, 'hours': 0, 'minutes': 0, 'seconds':-3})
+      assert.deepEqual(val, {'days':1, 'seconds':-3})
     }
   }];
 


### PR DESCRIPTION
Here's a default parser for the "interval" type, with unit tests.  The parser itself is a port of one I wrote in Ruby and have been using for quite some time, so I'm pretty confident it works correctly.
