### PR TITLE
fix values argument to native query

### DIFF
--- a/lib/native.js
+++ b/lib/native.js
@@ -100,9 +100,13 @@ var ctor = function(config) {
 var NativeQuery = function(text, values, callback) {
   if(typeof text == 'object') {
     this.text = text.text;
-    this.values = text.values;
+    this.values = values;
     this.name = text.name;
-    this.callback = values;
+    this.callback = callback;
+    if(typeof values == 'function') {
+      this.values = text.values || null;
+      this.callback = values;
+    }
   } else {
     this.text = text;
     this.values = values;


### PR DESCRIPTION
The native Query object was overlooking the second parameter in the case that an object was passed for the first. So passing a prepared statement object along with a values array would result in an error.

This patch brings it more inline with the js Query interface. If there's a place to put a test for this, let me know and I'll write one up.
