### PR TITLE
create-test-tables.js patch

### DIFF
--- a/script/create-test-tables.js
+++ b/script/create-test-tables.js
@@ -1,4 +1,3 @@
-var sys = require('utils');
 var args = require(__dirname + '/../test/cli');
 var pg = require(__dirname + '/../lib');
 


### PR DESCRIPTION
Removed (apparently obsolete) require('util') statement from create-test-tables so that the script could run w/o error.
