### PR TITLE
cancelAll, cancelActiveQuery methods

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -148,6 +148,9 @@ p.cancel = function(client, query) {
 
 // cancel the active query runned by the given client
 p.cancelActiveQuery = function(client) {
+	if (!client.activeQuery)
+		return;
+
 	var con = this.connection;
 
 	if(this.host && this.host.indexOf('/') === 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,17 +92,17 @@ var getClient = function(config) {
 // cancel a query runned by the given client
 PG.prototype.cancel = function(config, client, query) {
   getClient(config).cancel(client, query);
-}
+};
 
 // cancel the active query runned by the given client
 PG.prototype.cancelActiveQuery = function(config, client) {
   getClient(config).cancelActiveQuery(client);
-}
+};
 
 // cancel all the queries of the given client (active and in queue)
 PG.prototype.cancelAll = function(config, client) {
 	getClient(config).cancelAll(client);
-}
+};
 
 module.exports = new PG(Client);
 

--- a/lib/native/index.js
+++ b/lib/native/index.js
@@ -68,7 +68,8 @@ p.cancel = function(client, query) {
 
 // cancel the active query runned by the given client
 p.cancelActiveQuery = function(client) {
-	this.connect(nativeCancel.bind(client));
+	if (client._activeQuery)
+		this.connect(nativeCancel.bind(client));
 }
 
 // cancel all the queries of the given client (active and in queue)

--- a/test/integration/client/cancel-query-tests.js
+++ b/test/integration/client/cancel-query-tests.js
@@ -28,9 +28,9 @@ test("cancellation of a query", function() {
 		rows4++;
 	});
 
-	helper.pg.cancel(helper.connectionString, client, query1);
-	helper.pg.cancel(helper.connectionString, client, query2);
-	helper.pg.cancel(helper.connectionString, client, query4);
+	helper.pg.cancel(helper.config, client, query1);
+	helper.pg.cancel(helper.config, client, query2);
+	helper.pg.cancel(helper.config, client, query4);
 
 	setTimeout(function() {
 		assert.equal(rows1, 0);
@@ -67,8 +67,7 @@ test("cancellation of all queries", function() {
 	query3.on('row', function(row) {
 		rows3++;
 	});
-
-	helper.pg.cancelAll(helper.connectionString, client);
+	helper.pg.cancelAll(helper.config, client);
 
 	var query4 = client.query(qry);
 	query4.on('row', function(row) {


### PR DESCRIPTION
cancelAll cancels all the queries (active+queue)
cancelActiveQuery cancel the running query, if any

I will update the wiki for cancel, and for these two methods (if you accept the request)
