### PR TITLE
Use `(exit 0)` instead of `true` for windows install support. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts" : { 
     "test" : "make test",
-    "install" : "node-waf configure build || true"
+    "install" : "node-waf configure build || (exit 0)"
   },
   "engines" : { "node": ">= 0.4.0" }
 }


### PR DESCRIPTION
Fixes issue #72.
