### PR TITLE
bind Buffer() parameters as binary instead of text

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -143,15 +143,27 @@ p.bind = function(config, more) {
   config.binary = config.binary || false;
   var values = config.values || [];
   var len = values.length;
+  var useBinary = false;
+  for (var j = 0; j < len; j++)
+    useBinary |= values[j] instanceof Buffer;
   var buffer = this.writer
     .addCString(config.portal)
     .addCString(config.statement)
-    .addInt16(0) //always use default text format
-    .addInt16(len); //number of parameters
+  if (!useBinary)
+    buffer.addInt16(0);
+  else {
+    buffer.addInt16(len);
+    for (var j = 0; j < len; j++)
+      buffer.addInt16(values[j] instanceof Buffer);
+  }
+  buffer.addInt16(len); //number of parameters
   for(var i = 0; i < len; i++) {
     var val = values[i];
     if(val === null || typeof val === "undefined") {
       buffer.addInt32(-1);
+    } else if (val instanceof Buffer) {
+      buffer.addInt32(val.length);
+      buffer.add(val); 
     } else {
       val = val.toString();
       buffer.addInt32(Buffer.byteLength(val));

--- a/test/unit/connection/outbound-sending-tests.js
+++ b/test/unit/connection/outbound-sending-tests.js
@@ -112,6 +112,33 @@ test('bind messages', function() {
       .join(true, 'B');
     assert.received(stream, expectedBuffer);
   });
+  
+  test('with named statement, portal, and buffer value', function() {
+    con.bind({
+      portal: 'bang',
+      statement: 'woo',
+      values: [1, 'hi', null, new Buffer('zing', 'UTF-8')]
+    });
+    var expectedBuffer = new BufferList()
+      .addCString('bang')  //portal name
+      .addCString('woo') //statement name
+      .addInt16(4)//value count
+      .addInt16(0)//string
+      .addInt16(0)//string
+      .addInt16(0)//string
+      .addInt16(1)//binary
+      .addInt16(4)
+      .addInt32(1)
+      .add(Buffer("1"))
+      .addInt32(2)
+      .add(Buffer("hi"))
+      .addInt32(-1)
+      .addInt32(4)
+      .add(new Buffer('zing', 'UTF-8'))
+      .addInt16(0)
+      .join(true, 'B');
+    assert.received(stream, expectedBuffer);
+  });
 });
 
 


### PR DESCRIPTION
Avoids having to encode blobs in queries.
