### PR TITLE
Correctly parse numeric (non-integer) arrays

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -118,10 +118,12 @@ var init = function(register) {
     register(16, parseBool);
     register(1114, parseDate);
     register(1184, parseDate);
-    register(1007, parseIntegerArray);
-    register(1016, parseIntegerArray);
-    register(1022, parseIntegerArray);
-    register(1231, parseIntegerArray);
+    register(1005, parseIntegerArray); // _int2
+    register(1007, parseIntegerArray); // _int4
+    register(1016, parseIntegerArray); // _int8
+    register(1021, parseIntegerArray); // _float4
+    register(1022, parseIntegerArray); // _float8
+    register(1231, parseIntegerArray); // _numeric
     register(1008, parseStringArray);
     register(1009, parseStringArray);
     register(1186, parseInterval);


### PR DESCRIPTION
Handles issue #93.
