### PR TITLE
Fix parsing of multidimensional integer arrays

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -51,7 +51,7 @@ var parseBool = function(val) {
 }
 
 var parseIntegerArray = function(val) {
-  return JSON.parse(val.replace("{","[").replace("}","]"));
+  return JSON.parse(val.replace(/\{/g,"[").replace(/\}/g,"]"));
 };
 
 var parseStringArray = function(val) {


### PR DESCRIPTION
Without this, node dies when you try to parse, since it transforms {{}} to [{]} instead of [[]].
