### PR TITLE
Add all numeric array data types

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -118,8 +118,12 @@ var init = function(register) {
     register(16, parseBool);
     register(1114, parseDate);
     register(1184, parseDate);
-    register(1007, parseIntegerArray);
-    register(1016, parseIntegerArray);
+    register(1005, parseIntegerArray); // _int2
+    register(1007, parseIntegerArray); // _int4
+    register(1016, parseIntegerArray); // _int8
+    register(1021, parseIntegerArray); // _float4
+    register(1022, parseIntegerArray); // _float8
+    register(1231, parseIntegerArray); // _numeric
     register(1008, parseStringArray);
     register(1009, parseStringArray);
     register(1186, parseInterval);


### PR DESCRIPTION
We can use `parseIntegerArray` to correctly parse _any_ numeric array.
We just have to register the correct oids.
