### PR TITLE
Native driver and database connectivity loss

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -384,6 +384,8 @@ protected:
     if(revents & EV_READ) {
       TRACE("revents & EV_READ");
       if(PQconsumeInput(connection_) == 0) {
+        End();
+	EmitLastError();
         LOG("Something happened, consume input is 0");
         return;
       }


### PR DESCRIPTION
2 line patch to detach libev from read/write events and emit an error if PQconsumeInput returns 0 as that is indicative of an error.  Allows the native driver to detect connectivity loss by catching error.
