### PR TITLE
Handle "NULL" correctly in arrays

### DIFF
--- a/lib/arrayParser.js
+++ b/lib/arrayParser.js
@@ -35,7 +35,7 @@ ArrayParser.prototype.newEntry = function(includeEmpty) {
   var entry;
   if (this.recorded.length > 0 || includeEmpty) {
     entry = this.recorded.join("");
-    if (entry === "NULL") {
+    if (entry === "NULL" && !includeEmpty) {
       entry = null;
     }
     if (entry !== null) {


### PR DESCRIPTION
NULL in arrays is NULL, but "NULL" in arrays is 'NULL' (a string).

Sorry about the lack of tests for this.  I just noticed it as I was building a ruby PostgreSQL array
parser based on the code, and one of my tests wasn't working.
