### PR TITLE
Add custom row object class support?

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -24,6 +24,7 @@ var Client = function(config) {
   this.encoding = 'utf8';
   this.processID = null;
   this.secretKey = null;
+  this.rowClass = config.rowClass || defaults.rowClass;
   var self = this;
 };
 
@@ -187,6 +188,8 @@ p.query = function(config, values, callback) {
   }
 
   config.callback = callback;
+  if (!('rowClass' in config) && ('rowClass' in this))
+    config.rowClass = this.rowClass;
 
   var query = new Query(config);
   this.queryQueue.push(query);

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -27,5 +27,8 @@ module.exports = {
   reapIntervalMillis: 1000,
 
   // binary result mode
-  binary: false
+  binary: false,
+
+  // row prototype
+  rowClass: Object
 }

--- a/lib/query.js
+++ b/lib/query.js
@@ -18,6 +18,7 @@ var Query = function(config) {
   this._fieldConverters = [];
   this._result = new Result();
   this.isPreparedStatement = false;
+  this.rowClass = config.rowClass || Object;
   EventEmitter.call(this);
 };
 
@@ -50,7 +51,7 @@ p.handleRowDescription = function(msg) {
 
 p.handleDataRow = function(msg) {
   var self = this;
-  var row = {};
+  var row = new this.rowClass()
   for(var i = 0; i < msg.fields.length; i++) {
     var rawValue = msg.fields[i];
     if(rawValue === null) {


### PR DESCRIPTION
A nice feature of PHP's PDO layer is that you can specify an object class to
fetch rows as. This commit adds support for specifying either a
client-level or query-level row object to fetch them into, with a
default of a plain-jane Object.
