### PR TITLE
Use 'self.activeQuery' insead of 'this.activeQuery' in readyForQueue

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -110,7 +110,7 @@ p.connect = function(callback) {
     if(self.activeQuery) {
       self.activeQuery.handleReadyForQuery();
     }
-    this.activeQuery = null;
+    self.activeQuery = null;
     self.readyForQuery = true;
     self._pulseQueryQueue();
   });


### PR DESCRIPTION
When client.connect is called, 'self' is assigned the client object, a connection is established, a number of event listeners are added to the connection. In all of those listeners, self was always used except for a single 'this.activeQuery' in the 'readyForQueue' listener.

I was running into a strange issue where handleRowDescription was getting called from a null activeQuery, crashing the application. Unfortunately, I was not able to isolate the exact circumstances in testing, as it only happened sporadically under production load.

Noticing the inconsistency in self/this usage, and assuming it was an error, I changed the readyForQueue listner to use self.activeQuery instead of this.activeQuery. Since that change, I have not had any more problems.

All tests still pass.
