### PR TITLE
Expose a pass-through a logger for generic-pool and bump dependency version

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -14,7 +14,11 @@ module.exports = {
   //number of rows to return at a time from a prepared statement's
   //portal. 0 will return all rows at once
   rows: 0,
+
+  // binary result mode
+  binary: false,
   
+  //Connection pool options - see https://github.com/coopernurse/node-pool
   //number of connections to use in connection pool
   //0 will disable connection pooling
   poolSize: 10,
@@ -26,6 +30,6 @@ module.exports = {
   //frequeny to check for idle clients within the client pool
   reapIntervalMillis: 1000,
 
-  // binary result mode
-  binary: false
+  //pool log function / boolean
+  poolLog: false
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,8 @@ PG.prototype.connect = function(config, callback) {
     },
     max: defaults.poolSize,
     idleTimeoutMillis: defaults.poolIdleTimeout,
-    reapIntervalMillis: defaults.reapIntervalMillis
+    reapIntervalMillis: defaults.reapIntervalMillis,
+    log: defaults.poolLog
   });
   return pool.acquire(cb);
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author" : "Brian Carlson <brian.m.carlson@gmail.com>",
   "main" : "./lib",
   "dependencies" : {
-    "generic-pool" : "1.0.9"
+    "generic-pool" : "1.0.12"
   },
   "scripts" : { 
     "test" : "make test-all connectionString=pg://postgres@localhost:5432/postgres",


### PR DESCRIPTION
Hi ,
I'm trying to debug some issues with connection pooling and found it handy to expose generic-pool's log inside of node-postgres. Does this make sense?
-Thomas
