### PR TITLE
callback as complex object

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -75,8 +75,24 @@ p.handleCommandComplete = function(msg) {
 };
 
 p.handleReadyForQuery = function() {
+  /**
+   * The callback can be either a function or an
+   * object with the structure:
+   * {
+   *   fn: function( err, resource, params ) {},
+   *   context: this,
+   *   params: [ dummyValue1, dummyValue2 ]
+   * }
+   * The callback object can be used to run the
+   * callback function in a specific context and also
+   * to send paramaters back.
+   */
   if(this.callback) {
-    this.callback(null, this._result);
+    if(typeof this.callback === 'object') {
+      this.callback.fn.call(this.callback.context, null, this._result, this.callback.params);
+    } else {
+      this.callback(null, this._result);
+    }
   }
   this.emit('end', this._result);
 };
@@ -85,7 +101,11 @@ p.handleError = function(err) {
   //if callback supplied do not emit error event as uncaught error
   //events will bubble up to node process
   if(this.callback) {
-    this.callback(err)
+    if(typeof this.callback === 'object') {
+      this.callback.fn.call(this.callback.context, err, null, this.callback.params);
+    } else {
+      this.callback(err);
+    }
   } else {
     this.emit('error', err);
   }


### PR DESCRIPTION
The callback can now be defined as an object containing three
parameters:
- fn - a function defintion where the first parameter is the err, the
  second is the resource and the third is an array containing the optional
  parameters sent back.
- parameters - an array of values that are sent back to the callback
  function
- context - the context scope in which the function is ran

This can be used to send parameters to the callback function, others than the err and the resource.
