### PR TITLE
Improve error message accuracy of native SendQuery

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -138,8 +138,8 @@ public:
     int result = self->Send(queryText);
     free(queryText);
     if(result == 0) {
-      lastErrorMessage = self->GetLastError();                                                                                                                                                                       
-      THROW(lastErrorMessage);   
+      lastErrorMessage = self->GetLastError();
+      THROW(lastErrorMessage);
     }
     //TODO should we flush before throw?
     self->Flush();
@@ -617,7 +617,7 @@ private:
   {
     EmitError(PQerrorMessage(connection_));
   }
- 
+
   const char *GetLastError()
   {
     return PQerrorMessage(connection_);


### PR DESCRIPTION
- add private method const char *GetLastError() to src/binding.cc
- add var const char *lastErrorMessage to SendQuery in src/binding.cc
- throw result of PQErrorMessage inside SendQuery

This commit replaces the static/vague error message "PQsendQuery
returned error code" with the actual message text of the error.
The method GetLastError() returns the text of PQErrorMessage.
GetLastError is called from within SendQuery to retrieve the message.
