### PR TITLE
Make query results act directly like an array

### DIFF
--- a/lib/result.js
+++ b/lib/result.js
@@ -2,31 +2,44 @@
 //in the 'end' event and also
 //passed as second argument to provided callback
 var Result = function() {
-  this.rows = [];
-};
+	Array.call(this);
+	// Define properties specific to this result
+	for (var prop in ['command', 'rowCount', 'oid']) {
+		Object.defineProperty(this, prop, { enumerable: false, writable: true })
+	}
+}
 
-var p = Result.prototype;
-
+Result.prototype.__proto__ = Array.prototype;
 
 var matchRegexp = /([A-Za-z]+) (\d+ )?(\d+)?/
 
-//adds a command complete message
-p.addCommandComplete = function(msg) {
-  var match = matchRegexp.exec(msg.text);
-  if(match) {
-    this.command = match[1];
-    //match 3 will only be existing on insert commands
-    if(match[3]) {
-      this.rowCount = parseInt(match[3]);
-      this.oid = parseInt(match[2]);
-    } else {
-      this.rowCount = parseInt(match[2]);
-    }
-  }
-};
-
-p.addRow = function(row) {
-  this.rows.push(row);
-};
+// Define properties that can safely exist on the prototype.
+Object.defineProperties(Result.prototype, {
+	rows: {
+		get: function () { return this },
+		enumerable: false
+	},
+	//adds a command complete message
+	addCommandComplete: {
+		value: function addCommandComplete (msg) {
+			var match = matchRegexp.exec(msg.text);
+			if(match) {
+				this.command = match[1];
+				//match 3 will only be existing on insert commands
+				if(match[3]) {
+					this.rowCount = parseInt(match[3]);
+					this.oid = parseInt(match[2]);
+				} else {
+					this.rowCount = parseInt(match[2]);
+				}
+			}
+		},
+		enumerable: false
+	},
+	addRow: {
+		value: function (row) { this.push(row) },
+		enumerable: false
+	}
+})
 
 module.exports = Result;


### PR DESCRIPTION
This is a backwards compatible change to Result that allows the result object to be iterated directly rather than having to access `result.rows`.

I'm currently writing a minimal compatibility layer for mysql/pg/sqlite3 where I'm going to be able to wrap results in something like this anyways, but since I was already writing it I thought I'd see if there was interest in having it included directly in node-postgres.
