### PR TITLE
Export types module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,4 +91,6 @@ module.exports = new PG(Client);
 module.exports.__defineGetter__("native", function() {
   delete module.exports.native;
   return (module.exports.native = new PG(require(__dirname + '/native')));
-})
+});
+
+module.exports.types = require('./types');


### PR DESCRIPTION
Hang the types module on the top-level entry point for the module. [Discussion here](https://github.com/brianc/node-postgres/issues/166).
