### PR TITLE
Use JS Date's getFullYear() in first example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var conString = "tcp://postgres:1234@localhost/postgres";
 pg.connect(conString, function(err, client) {
   client.query("SELECT NOW() as when", function(err, result) {
     console.log("Row count: %d",result.rows.length);  // 1
-    console.log("Current year: %d", result.rows[0].when.getYear());
+    console.log("Current year: %d", result.rows[0].when.getFullYear());
   });
 });
 ```


### PR DESCRIPTION
In year 2012, seeing the output of 112 confused me, and would potentially
confuse any JS noob. I thought it was some bug in node-postgres.

Presumably, JS starts counting time from Jan 1, 1900!

Also, according to [1], getYear() is deprecated and one should use getFullYear()
instead.

[1] http://www.w3schools.com/jsref/jsref_obj_date.asp
