### PR TITLE
enable IPv6 support when using native bindings

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,7 +77,7 @@ var getLibpgConString = function(config, callback) {
     if(config.host) {
       if(config.host != 'localhost' && config.host != '127.0.0.1') {
         //do dns lookup
-        return require('dns').lookup(config.host, 4, function(err, address) {
+        return require('dns').lookup(config.host, function(err, address) {
           if(err) return callback(err, null);
           params.push("hostaddr="+address)
           callback(null, params.join(" "))


### PR DESCRIPTION
Currently, when using native bindings, you cannot connect to an IPv6 server by hostname.

The only reason this happens is because there is a `dns.lookup()` hard-coded for IPv4. Node’s default is to look for both IPv4 and IPv6 addresses when doing a DNS lookup. Removing the forced `4` argument allows Node’s default behavior and fixes the problem.
