### PR TITLE
Add binding.gyp target for SunOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,6 +14,10 @@
           'include_dirs': ['<!@(pg_config --includedir)'],
           'libraries' : ['-lpq -L<!@(pg_config --libdir)']
         }],
+        ['OS=="solaris"', {
+          'include_dirs': ['<!@(pg_config --includedir)'],
+          'libraries' : ['-lpq -L<!@(pg_config --libdir)']
+        }],
         ['OS=="win"', {
           'include_dirs': ['<!@(pg_config --includedir)'],
           'libraries' : ['libpq.lib'],


### PR DESCRIPTION
Makes builds successful on SunOS
