### PR TITLE
Fix handling of timestamp fields without timezone

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -97,12 +97,39 @@ var getLibpgConString = function(config, callback) {
 //for complex types, etc...
 var prepareValue = function(val) {
   if(val instanceof Date) {
-    return JSON.stringify(val);
+    return dateToString(val);
   }
   if(typeof val === 'undefined') {
     return null;
   }
   return val === null ? null : val.toString();
+}
+
+function dateToString(date) {
+  function pad(number, digits) {
+    number = ""+number;
+    while(number.length < digits)
+      number = "0"+number;
+    return number;
+  }
+
+  var offset = -date.getTimezoneOffset();
+  var ret = pad(date.getFullYear(), 4) + '-'
+    + pad(date.getMonth() + 1, 2) + '-'
+    + pad(date.getDate(), 2) + 'T'
+    + pad(date.getHours(), 2) + ':'
+    + pad(date.getMinutes(), 2) + ':'
+    + pad(date.getSeconds(), 2) + '.'
+    + pad(date.getMilliseconds(), 3);
+
+  if(offset < 0) {
+    ret += "-";
+    offset *= -1;
+  }
+  else
+    ret += "+";
+
+  return ret + pad(Math.floor(offset/60), 2) + ":" + pad(offset%60, 2);
 }
 
 function normalizeQueryConfig (config, values, callback) {


### PR DESCRIPTION
Commit b7fd9a5 fixes issue #225 but breaks the handling of timestamp fields that do not contain a timezone. The values returned by Postgres are always UTC, but the text parser assumes them to be in the timezone of the Node VM.
