### PR TITLE
Cleanly handle missing stream error on COPY operation. Closes #241

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -267,6 +267,11 @@ p.sendCopyFromChunk = function (chunk) {
 p.endCopyFrom = function () {
   this.stream.write(this.writer.add(emptyBuffer).flush(0x63));
 }
+p.sendCopyFail = function (msg) {
+  //this.stream.write(this.writer.add(emptyBuffer).flush(0x66));
+  this.writer.addCString(msg);
+  this._send(0x66);
+}
 //parsing methods
 p.setBuffer = function(buffer) {
   if(this.lastBuffer) {    //we have unfinished biznaz

--- a/lib/query.js
+++ b/lib/query.js
@@ -171,11 +171,7 @@ p.prepare = function(connection) {
 };
 p.streamData = function (connection) {
   if ( this.stream ) this.stream.startStreamingToConnection(connection);
-  else {
-    connection.endCopyFrom(); // send an EOF to connection
-    // TODO: signal the problem somehow
-    //this.handleError(new Error('No source stream defined'));
-  }
+  else connection.sendCopyFail('No source stream defined'); 
 };
 p.handleCopyFromChunk = function (chunk) {
   if ( this.stream ) this.stream.handleChunk(chunk);    


### PR DESCRIPTION
Rather than killing on uncaught exception, this patch invokes the callback with an appropriate error message when no stream is defined to copy to and from
