### PR TITLE
fixing support for Unix sockets in native binding (rebased)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,15 +75,19 @@ var getLibpgConString = function(config, callback) {
       params.push("dbname='" + config.database + "'");
     }
     if(config.host) {
-      if(config.host != 'localhost' && config.host != '127.0.0.1') {
-        //do dns lookup
-        return require('dns').lookup(config.host, function(err, address) {
-          if(err) return callback(err, null);
-          params.push("hostaddr="+address)
-          callback(null, params.join(" "))
-        })
+      if (!config.host.indexOf("/")) {
+        params.push("host=" + config.host);
+      } else {
+        if(config.host != 'localhost' && config.host != '127.0.0.1') {
+          //do dns lookup
+          return require('dns').lookup(config.host, function(err, address) {
+            if(err) return callback(err, null);
+            params.push("hostaddr="+address)
+            callback(null, params.join(" "))
+          })
+        }
+        params.push("hostaddr=127.0.0.1 ");
       }
-      params.push("hostaddr=127.0.0.1 ");
     }
     callback(null, params.join(" "));
   } else {


### PR DESCRIPTION
Binding natively connections to Unix sockets failed due to DNS lookups applied on pathname to Unix socket's folder.

I rebased the commit to the master branch. You should be able to merge this now.

Belongs to https://github.com/brianc/node-postgres/pull/179
