### PR TITLE
Add a method to connect with SSL 

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -28,7 +28,7 @@ var Client = function(config) {
   this.encoding = 'utf8';
   this.processID = null;
   this.secretKey = null;
-  this.ssl = config.ssl || false;
+  this.ssl = config.ssl || defaults.ssl;
 };
 
 util.inherits(Client, EventEmitter);

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -31,5 +31,8 @@ module.exports = {
   reapIntervalMillis: 1000,
 
   //pool log function / boolean
-  poolLog: false
+  poolLog: false,
+
+  //connect using SSL
+  ssl: false
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var Client = require(__dirname+'/client');
 var defaults =  require(__dirname + '/defaults');
+var utils = require(__dirname + '/utils');
 
 //external genericPool module
 var genericPool = require('generic-pool');
@@ -28,6 +29,19 @@ PG.prototype.end = function() {
   })
 }
 
+PG.prototype.sconnect = function(config, callback) {
+  var c = config;
+  if(typeof config === 'function') {
+    callback = config;
+    config = {};
+  }
+  else if(typeof config === 'string') {
+    config = utils.normalizeConnectionInfo(config);
+  }
+  config.ssl = true;
+  return this.connect(config, callback);
+}
+
 PG.prototype.connect = function(config, callback) {
   var self = this;
   var c = config;
@@ -37,9 +51,12 @@ PG.prototype.connect = function(config, callback) {
     cb = c;
     c = defaults;
   }
+  else if(typeof c === 'string') {
+    c = utils.normalizeConnectionInfo(c);
+  }
 
   //get unique pool name even if object was used as config
-  var poolName = typeof(c) === 'string' ? c : c.user+c.host+c.port+c.database;
+  var poolName = c.user+c.host+c.port+c.database;
   var pool = pools[poolName];
 
   if(pool) return pool.acquire(cb);


### PR DESCRIPTION
When using Heroku and trying to connect to the DB locally you must use SSL or it will give you an error.

There was a pull request (4d15a5c05f613ee9ff71db9bde02f1833c7c589e)  that allowed you to pass `ssl: true` when creating a new client, however this does not provide a way to turn on SSL when connecting via a connection string. However a connection string (verses an object of key/value pairs) is what Heroku uses.

I added the method **pg.sconnect** that does the same thing as **pg.connect** but with SSL turned on.

This allows you to connect using the ENV var set by heroku:

``` javascript
var pg = require('pg');

pg.sconnect(process.env.DATABASE_URL, function(err, client) {
  var query = client.query('SELECT * FROM your_table');

  query.on('row', function(row) {
    console.log(JSON.stringify(row));
  });
});
```

Then all you would need to do to run locally is set an ENV var _DATABASE_URL_
