### PR TITLE
force PQsetClientEncoding after connection was made

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -61,6 +61,7 @@ ConnectionParameters.prototype.getLibpqConnectionString = function(cb) {
     params.push("host=" + this.getDomainSocketName());
     return cb(null, params.join(' '));
   }
+  params.push("options=--client_encoding='utf-8'");
   dns.lookup(this.host, function(err, address) {
     if(err) return cb(err, null);
     params.push("hostaddr=" + address);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -116,6 +116,8 @@ p.startup = function(config) {
     .addCString(config.user)
     .addCString('database')
     .addCString(config.database)
+    .addCString('options')
+    .addCString("--client_encoding='utf-8'")
     .addCString('').flush();
   //this message is sent without a code
 

--- a/test/unit/connection/outbound-sending-tests.js
+++ b/test/unit/connection/outbound-sending-tests.js
@@ -23,6 +23,8 @@ test("sends startup message", function() {
                   .addCString('brian')
                   .addCString('database')
                   .addCString('bang')
+                  .addCString('options')
+                  .addCString("--client_encoding='utf-8'")
                   .addCString('').join(true))
 });
 


### PR DESCRIPTION
Hello all,

It's okay to use library when postgresql cluster is initialized with UTF-8 encoding. In other cases, only one ugly way set client encoding is perform query "set client_encoding='utf-8'". (Yep, we have some legacy applications which works with KOI8-R cluster).

So, library work's only with UTF-8 encoding and encoding is hardcoded into library, why not force to set client_encoding right after connection was made?
