### PR TITLE
parse numeric types as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ The two share the same interface so __no other code changes should be required__
   * async notifications with `LISTEN/NOTIFY`
   * bulk import & export with `COPY TO/COPY FROM`
   * extensible js<->postgresql data-type coercion
+  
+### numeric datatype
+Since the `numeric` datatype may have an arbitrary precision,
+values of this datatype will be returned as a string from a query. If you need 
+to do any computations on the value, you should be aware of this, as you may 
+need to use a JavaScript library for handling the value of arbitrary precision.
+
+Simply taking the value and doing any computation such as addition or subtraction
+may lead to unexpected/wrong results since JavaScript will handle the value as
+a floating-point number.
 
 ## Documentation
 

--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -156,8 +156,6 @@ var parseByteA = function(val) {
   }
 };
 
-var maxLen = Number.MAX_VALUE.toString().length;
-
 var parseInteger = function(val) {
   return parseInt(val, 10);
 };
@@ -167,14 +165,6 @@ var init = function(register) {
   register(21, parseInteger);
   register(23, parseInteger);
   register(26, parseInteger);
-  register(1700, function(val){
-    if(val.length > maxLen) {
-      console.warn(
-        'WARNING: value %s is longer than max supported numeric value in ' +
-        'javascript. Possible data loss', val);
-    }
-    return parseFloat(val);
-  });
   register(700, parseFloat);
   register(701, parseFloat);
   register(16, parseBool);

--- a/test/integration/client/type-coercion-tests.js
+++ b/test/integration/client/type-coercion-tests.js
@@ -58,7 +58,7 @@ var types = [{
 },{
   //TODO get some actual huge numbers here
   name: 'numeric',
-  values: [-12.34, 0, 12.34, null]
+  values: ['-12.34', '0', '12.34', null]
 },{
   name: 'real',
   values: [101.1, 0, -101.3, null]

--- a/test/unit/client/typed-query-results-tests.js
+++ b/test/unit/client/typed-query-results-tests.js
@@ -43,7 +43,7 @@ test('typed results', function() {
     format: 'text',
     dataTypeID: 1700,
     actual: '12.34',
-    expected: 12.34
+    expected: '12.34'
   },{
     name: 'real/float4',
     dataTypeID: 700,


### PR DESCRIPTION
This is to address #266. The [binary parser for `numeric`](https://github.com/brianc/node-postgres/blob/master/lib/binaryParsers.js#L124) still needs some love.
