### PR TITLE
Add ssl query string to the connection string parser #275

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -18,7 +18,7 @@ var parse = function(str) {
   }
   // url parse expects spaces encoded as %20
   str = encodeURI(str);
-  var result = url.parse(str);
+  var result = url.parse(str, true);
   var config = {};
   config.host = result.hostname;
   config.database = result.pathname ? result.pathname.slice(1) : null;
@@ -26,6 +26,12 @@ var parse = function(str) {
   config.user = auth[0];
   config.password = auth[1];
   config.port = result.port;
+
+  var ssl = result.query.ssl;
+  if (ssl === 'true' || ssl === '1') {
+    config.ssl = true;
+  }
+
   return config;
 };
 

--- a/test/unit/connection-parameters/environment-variable-tests.js
+++ b/test/unit/connection-parameters/environment-variable-tests.js
@@ -54,6 +54,28 @@ test('connection string parsing', function(t) {
   assert.equal(subject.database, 'lala', 'string database');
 });
 
+test('connection string parsing - ssl', function(t) {
+  var string = 'postgres://brian:pw@boom:381/lala?ssl=true';
+  var subject = new ConnectionParameters(string);
+  assert.equal(subject.ssl, true, 'ssl');
+
+  string = 'postgres://brian:pw@boom:381/lala?ssl=1';
+  subject = new ConnectionParameters(string);
+  assert.equal(subject.ssl, true, 'ssl');
+
+  string = 'postgres://brian:pw@boom:381/lala?other&ssl=true';
+  subject = new ConnectionParameters(string);
+  assert.equal(subject.ssl, true, 'ssl');
+
+  string = 'postgres://brian:pw@boom:381/lala?ssl=0';
+  subject = new ConnectionParameters(string);
+  assert.equal(!!subject.ssl, false, 'ssl');
+
+  string = 'postgres://brian:pw@boom:381/lala';
+  subject = new ConnectionParameters(string);
+  assert.equal(!!subject.ssl, false, 'ssl');
+});
+
 //restore process.env
 for(var key in realEnv) {
   process.env[key] = realEnv[key];


### PR DESCRIPTION
This commit only addresses the issue in `connection-parameters.js`, which looks like it will boil up to the JavaScript client. A quick look at the native client shows that it's using `connection-parameters.js`, but I don't know enough about that part of the project to determine if that will make a difference there.
