### PR TITLE
Fix Unix domain socket setting.

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -58,7 +58,7 @@ ConnectionParameters.prototype.getLibpqConnectionString = function(cb) {
     params.push("dbname='" + this.database + "'");
   }
   if(this.isDomainSocket) {
-    params.push("host=" + this.getDomainSocketName());
+    params.push("host=" + this.host);
     return cb(null, params.join(' '));
   }
   params.push("options=--client_encoding='utf-8'");
@@ -67,16 +67,6 @@ ConnectionParameters.prototype.getLibpqConnectionString = function(cb) {
     params.push("hostaddr=" + address);
     return cb(null, params.join(' '));
   });
-};
-
-ConnectionParameters.prototype.getDomainSocketName = function() {
-  var filename =  '.s.PGSQL.' + this.port;
-
-  //if host is full path to socket fd with port number, just return it
-  if(this.host.indexOf(filename) > -1) return this.host;
-
-  //otherwise, build it from host + standard filename + port
-  return path.join(this.host, filename);
 };
 
 module.exports = ConnectionParameters;

--- a/test/unit/connection-parameters/creation-tests.js
+++ b/test/unit/connection-parameters/creation-tests.js
@@ -53,17 +53,6 @@ test('initializing with unix domain socket', function() {
   assert.equal(subject.host, '/var/run/');
 });
 
-test('builds domain socket', function() {
-  var subject = new ConnectionParameters({
-    host: '/var/run/',
-    port: 1234
-  });
-  assert.equal(subject.getDomainSocketName(), '/var/run/.s.PGSQL.1234');
-  subject.host = '/tmp';
-  assert.equal(subject.getDomainSocketName(), '/tmp/.s.PGSQL.1234');
-  assert.equal(subject.getDomainSocketName(), '/tmp/.s.PGSQL.1234');
-});
-
 test('libpq connection string building', function() {
   var checkForPart = function(array, part) {
     assert.ok(array.indexOf(part) > -1, array.join(" ") + " did not contain " + part);
@@ -131,7 +120,7 @@ test('libpq connection string building', function() {
       assert.isNull(err);
       var parts = constring.split(" ");
       checkForPart(parts, "user='brian'");
-      checkForPart(parts, "host=/tmp/.s.PGSQL.5432");
+      checkForPart(parts, "host=/tmp/");
     }));
   });
 


### PR DESCRIPTION
This code was misconceived in that the host parameter for a Unix
domain socket connection must point to the directory containing
the socket, and not to the socket itself. Libpq will look for
the socket based on the host and port settings. See
http://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS
