### PR TITLE
now resilient to exceptions thrown from callbacks

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -139,12 +139,22 @@ p.connect = function(callback) {
   });
 
   con.on('readyForQuery', function() {
+    var error = null;
+
     if(self.activeQuery) {
-      self.activeQuery.handleReadyForQuery();
+      try {
+        self.activeQuery.handleReadyForQuery();
+      }
+      catch (e) {
+        error = e;
+      }
     }
     self.activeQuery = null;
     self.readyForQuery = true;
     self._pulseQueryQueue();
+    if (error) {
+      throw error;
+    }
   });
 
   con.on('error', function(error) {
@@ -159,8 +169,17 @@ p.connect = function(callback) {
       if(self.activeQuery.isPreparedStatement) {
         con.sync();
       }
-      self.activeQuery.handleError(error);
+      var userError = null;
+      try {
+        self.activeQuery.handleError(error);
+      }
+      catch (e) {
+        userError = e;
+      }
       self.activeQuery = null;
+      if (userError) {
+        throw userError;
+      }
     }
   });
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -93,16 +93,27 @@ p.handleCommandComplete = function(msg) {
 };
 
 p.handleReadyForQuery = function() {
+  var error = null;
+
   if (this._canceledDueToError) {
     return this.handleError(this._canceledDueToError);
   }
   if(this.callback) {
-    this.callback(null, this._result);
+    try {
+      this.callback(null, this._result);
+    }
+    catch (e) {
+      error = e;
+    }
   }
   this.emit('end', this._result);
+  if (error) {
+    throw error;
+  }
 };
 
 p.handleError = function(err) {
+  var userError = null;
   if (this._canceledDueToError) {
     err = this._canceledDueToError;
     this._canceledDueToError = false;
@@ -110,11 +121,19 @@ p.handleError = function(err) {
   //if callback supplied do not emit error event as uncaught error
   //events will bubble up to node process
   if(this.callback) {
-    this.callback(err);
+    try {
+      this.callback(err);
+    }
+    catch (e) {
+      userError = e;
+    }
   } else {
     this.emit('error', err);
   }
   this.emit('end');
+  if (userError) {
+    throw userError;
+  }
 };
 
 p.submit = function(connection) {

--- a/test/integration/callback-crash-test.js
+++ b/test/integration/callback-crash-test.js
@@ -1,0 +1,45 @@
+var args = require(__dirname + '/../cli');
+var pg = require(__dirname + "/../../lib");
+
+process.on('uncaughtException', function(err) {
+  console.log(err.message);
+});
+
+var query = {
+  text: 'select * from person where id = $1'
+  , values: [1]
+};
+var queries = 0;
+
+pg.connect(args, function(err, client) {
+  setTimeout(function() {
+    throw new Error('#1');
+  }, 500);
+
+  setTimeout(function() {
+    client.query(query, function(err, result) {
+      console.log('ran first query');
+      queries++;
+      throw new Error('#2');
+    });
+  }, 1000);
+
+  setTimeout(function() {
+    client.query(query, function(err, result) {
+      console.log('ran second query');
+      queries++;
+    });
+  }, 1500);
+
+  setTimeout(function() {
+    client.end();
+    if (queries !== 2) {
+      throw new Error('test failed!');
+    }
+  }, 2000);
+
+  setTimeout(function() {
+    process.exit();
+  }, 2500);
+
+});

--- a/test/unit/client/simple-query-tests.js
+++ b/test/unit/client/simple-query-tests.js
@@ -121,6 +121,53 @@ test('executing query', function() {
       });
     });
 
+    test('handleReadyForQuery emits \'end\' even if callback throws an exception', function() {
+      var client = helper.client();
+      var query = client.query('whatever');
+
+      query.callback = function() {
+        throw new Error('blah!');
+      };
+      assert.emits(query, 'end');
+
+      try {
+        query.handleReadyForQuery();
+      }
+      catch (e) {}
+    });
+
+    test('handleError emits \'end\' even if callback throws an exception', function() {
+      var client = helper.client();
+      var query = client.query('whatever');
+
+      query.callback = function() {
+        throw new Error('blah!');
+      };
+      assert.emits(query, 'end');
+
+      try {
+        query.handleReadyForQuery();
+      }
+      catch (e) {}
+    });
+
+    test('client \'readyForQuery\' handler sets readyForQuery to true even if callback throws an exception', function() {
+      var client = helper.client();
+      var query = client.query('whatever');
+
+      query.callback = function() {
+        throw new Error('blah!');
+      };
+      client.activeQuery = query;
+      client.readyForQuery = false;
+      client._pulseQueryQueue = function() {};
+      try {
+        client.connection.emit('readyForQuery');
+      }
+      catch (e) {}
+      assert.equal(true, client.readyForQuery);
+    });
+
   });
 
 });


### PR DESCRIPTION
Because query and client both have logic they need to run, in order, after the user's callback, they are vulnerable to exceptions thrown from those callbacks. This change catches any exception thrown from user code and saves it until all necessary pg logic is complete before throwing again.

Yes, it's true that in production you should probably just restart the process if you have a top-level unhandled exception (that's what I do in production), but this is still a major pain for testing at the very least. And the existing behavior certainly prevents any kind of final app failover logic from hitting the database.

node test/integration/callback-crash-test.js <connectionString> can be run to verify that the changes work. Because all test frameworks install their own top-level uncaught exception handlers, this had to be a standalone file.
