### PR TITLE
fixed build broken under freebsd

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,22 +6,6 @@
         'src/binding.cc'
       ],
       'conditions' : [
-        ['OS=="mac"', {
-          'include_dirs': ['<!@(pg_config --includedir)'],
-          'libraries' : ['-lpq -L<!@(pg_config --libdir)']
-        }],
-        ['OS=="linux"', {
-          'include_dirs': ['<!@(pg_config --includedir)'],
-          'libraries' : ['-lpq -L<!@(pg_config --libdir)']
-        }],
-        ['OS=="solaris"', {
-          'include_dirs': ['<!@(pg_config --includedir)'],
-          'libraries' : ['-lpq -L<!@(pg_config --libdir)']
-        }],
-        ['OS=="freebsd"', {
-          'include_dirs': ['<!@(pg_config --includedir)'],
-          'libraries' : ['-lpq -L<!@(pg_config --libdir)']
-        }],
         ['OS=="win"', {
           'include_dirs': ['<!@(pg_config --includedir)'],
           'libraries' : ['libpq.lib'],
@@ -32,6 +16,9 @@
               ]
             },
           }
+        }, { # OS!="win"
+          'include_dirs': ['<!@(pg_config --includedir)'],
+          'libraries' : ['-lpq -L<!@(pg_config --libdir)']
         }]
       ]
     }


### PR DESCRIPTION
Hello,

The first commit fix compile issue under freebsd (cflags and ldflags).
The second one updates the binding.gyp to use same conditions
under all non-windows platforms (avoids duplicates).
