### PR TITLE
Loosen generic-pool dependency to ~2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Brian Carlson <brian.m.carlson@gmail.com>",
   "main": "./lib",
   "dependencies": {
-    "generic-pool": "2.0.2",
+    "generic-pool": "~2.0.2",
     "deprecate": "~0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This allows using any version in the 2.0 series greater or equal
to 2.0.2, making it easier to use this module with others
requiring higher versions.
