### PR TITLE
Timestamp with timezone fails to parse minutes

### DIFF
--- a/lib/types/textParsers.js
+++ b/lib/types/textParsers.js
@@ -33,7 +33,7 @@ var parseDate = function(isoDate) {
     mili = 1000 * parseFloat(miliString);
   }
 
-  var tZone = /([Z|+\-])(\d{2})?(\d{2})?/.exec(isoDate.split(' ')[1]);
+  var tZone = /([Z|+\-])(\d{2})?:(\d{2})?/.exec(isoDate.split(' ')[1]);
   //minutes to adjust for timezone
   var tzAdjust = 0;
 


### PR DESCRIPTION
The timezone parser in text parser modules missed the `:` that appears in timezone. As a result it failed to parse the minutes component of the timezone.
