### PR TITLE
Optional support for results as arrays.

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -21,7 +21,7 @@ var Query = function(config, values, callback) {
   //use unique portal name each time
   this.portal = config.portal || "";
   this.callback = config.callback;
-  this._fieldNames = [];
+  this.rowtype = config.rowtype;
   this._fieldConverters = [];
   this._result = new Result();
   this.isPreparedStatement = false;
@@ -56,30 +56,41 @@ var noParse = function(val) {
 //message with this query object
 //metadata used when parsing row results
 p.handleRowDescription = function(msg) {
-  this._fieldNames = [];
   this._fieldConverters = [];
   var len = msg.fields.length;
   for(var i = 0; i < len; i++) {
     var field = msg.fields[i];
     var format = field.format;
-    this._fieldNames[i] = field.name;
+    this._result.fieldNames[i] = field.name;
     this._fieldConverters[i] = Types.getTypeParser(field.dataTypeID, format);
   }
 };
 
 p.handleDataRow = function(msg) {
-  var self = this;
-  var row = {};
-  for(var i = 0; i < msg.fields.length; i++) {
-    var rawValue = msg.fields[i];
-    if(rawValue === null) {
-      //leave null values alone
-      row[self._fieldNames[i]] = null;
-    } else {
-      //convert value to javascript
-      row[self._fieldNames[i]] = self._fieldConverters[i](rawValue);
+  var self = this, row, rawValue,
+      fieldNames = this._result.fieldNames,
+      i, c = msg.fields.length;
+
+  if (this.rowtype === 'array') {
+    row = new Array(c);
+    for(i = 0; i < c; i++) {
+      rawValue = msg.fields[i];
+      row[i] = (rawValue !== null) ? self._fieldConverters[i](rawValue) : null;
+    }
+  } else {
+    row = {};
+    for(i = 0; i < c; i++) {
+      rawValue = msg.fields[i];
+      if(rawValue === null) {
+        //leave null values alone
+        row[fieldNames[i]] = null;
+      } else {
+        //convert value to javascript
+        row[fieldNames[i]] = self._fieldConverters[i](rawValue);
+      }
     }
   }
+
   self.emit('row', row, self._result);
 
   //if there is a callback collect rows

--- a/lib/result.js
+++ b/lib/result.js
@@ -5,6 +5,7 @@ var Result = function() {
   this.command = null;
   this.rowCount = null;
   this.oid = null;
+  this.fieldNames = [];
   this.rows = [];
 };
 

--- a/test/integration/client/simple-query-tests.js
+++ b/test/integration/client/simple-query-tests.js
@@ -63,3 +63,17 @@ test("multiple select statements", function() {
   });
   client.on('drain', client.end.bind(client));
 });
+
+test("array rows", function() {
+  var client = helper.client();
+  client.query("create temp table t(a integer, b varchar(5)); insert into t values (1, 'one'), (2, 'two');");
+  client.query({
+    text: "select a,b from t order by a",
+    rowtype: "array"
+  }, function(error, result) {
+    assert.deepEqual(result.fieldNames, ["a", "b"]);
+    assert.deepEqual(result.rows, [[1,"one"], [2,"two"]]);
+    client.end();
+  });
+});
+


### PR DESCRIPTION
Hi,

This commit adds support for a new config attribute `rowtype` which can be set to "array".  If done, each row is an array of values instead of a full object.  This has had enormous performance benefits for a couple of projects that sent a lot of rows to a client for processing.  (The client side also maintained the values as arrays.)  It is also much more convenient for working with some graphing libraries such as flot.

Since the field names are not part of the rows when this is enabled, the ones already attached to the result (_fieldNames) were made publicly accessible.

I've been using this for a few weeks, primarily for pages that return multiple query results in one page during initialization (lots of tables and graphs) and seems solid.
