### PR TITLE
Travis Nodejs 0.10 build error correction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
   - 0.8
-  - 0.10
+  - "0.10"
 before_script:
   - node script/create-test-tables.js pg://postgres@127.0.0.1:5432/postgres


### PR DESCRIPTION
Putting it between double quotes permits Travis to not see it as Node 0.1 but 0.10
