### PR TITLE
Check if pg_config exists on windows.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,24 +2,29 @@
   'targets': [
     {
       'target_name': 'binding',
-      'sources': [
-        'src/binding.cc'
-      ],
       'conditions' : [
-        ['OS=="win"', {
-          'include_dirs': ['<!@(pg_config --includedir)'],
-          'libraries' : ['libpq.lib'],
-          'msvs_settings': {
-            'VCLinkerTool' : {
-              'AdditionalLibraryDirectories' : [
-                '<!@(pg_config --libdir)\\'
-              ]
-            },
+        ['OS=="win" and "<!@(cmd /C where /Q pg_config || echo n)"!="n"',
+          {
+            'sources': ['src/binding.cc'],
+            'include_dirs': ['<!@(pg_config --includedir)'],
+            'libraries' : ['libpq.lib'],
+            'msvs_settings': {
+              'VCLinkerTool' : {
+                'AdditionalLibraryDirectories' : [
+                  '<!@(pg_config --libdir)\\'
+                ]
+              },
+            }
           }
-        }, { # OS!="win"
-          'include_dirs': ['<!@(pg_config --includedir)'],
-          'libraries' : ['-lpq -L<!@(pg_config --libdir)']
-        }]
+        ],
+        
+        ['OS!="win"',
+          {
+            'sources': ['src/binding.cc'],
+            'include_dirs': ['<!@(pg_config --includedir)'],
+            'libraries' : ['-lpq -L<!@(pg_config --libdir)']
+          }
+        ]
       ]
     }
   ]


### PR DESCRIPTION
Do not compile native bindings on windows if pg_config is not available.

On my Windows 8 computer it works well.

I am sure it is possible to add similar condition for linux, but I have no computer to test it on.
