### PR TITLE
Fix client_encoding setting to support pg_bouncer when using libpq (#270)

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -61,7 +61,7 @@ ConnectionParameters.prototype.getLibpqConnectionString = function(cb) {
     params.push("host=" + this.host);
     return cb(null, params.join(' '));
   }
-  params.push("options=--client_encoding='utf-8'");
+  params.push("client_encoding='utf-8'");
   dns.lookup(this.host, function(err, address) {
     if(err) return cb(err, null);
     params.push("hostaddr=" + address);


### PR DESCRIPTION
Fix for https://github.com/brianc/node-postgres/issues/270

The same change needs to be made when using the native driver as with the JS driver.
