### PR TITLE
Loosen generic-pool dependency to ~2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Brian Carlson <brian.m.carlson@gmail.com>",
   "main": "./lib",
   "dependencies": {
-    "generic-pool": "2.0.2",
+    "generic-pool": "~2.0.2",
     "buffer-writer": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
so applications using node-pg are free to use 2.0.3 or whatever else comes in the 2.0 series
