### PR TITLE
Feature request: access field names and types even when NO rows are returned

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -63,6 +63,7 @@ Query.prototype.handleRowDescription = function(msg) {
     var format = field.format;
     this._fieldNames[i] = field.name;
     this._fieldConverters[i] = Types.getTypeParser(field.dataTypeID, format);
+    this._result.addField(field);
   }
 };
 

--- a/lib/result.js
+++ b/lib/result.js
@@ -6,6 +6,7 @@ var Result = function() {
   this.rowCount = null;
   this.oid = null;
   this.rows = [];
+  this.fields = [];
 };
 
 var matchRegexp = /([A-Za-z]+) ?(\d+ )?(\d+)?/;
@@ -35,6 +36,11 @@ Result.prototype.addCommandComplete = function(msg) {
 
 Result.prototype.addRow = function(row) {
   this.rows.push(row);
+};
+
+//Add a field definition to the result
+Result.prototype.addField = function(field) {
+  this.fields.push(field);
 };
 
 module.exports = Result;

--- a/test/integration/client/no-row-result-tests.js
+++ b/test/integration/client/no-row-result-tests.js
@@ -1,0 +1,23 @@
+var helper = require(__dirname + '/test-helper');
+var pg = helper.pg;
+var config = helper.config;
+
+test('can access results when no rows are returned', function() {
+  if(config.native) return false;
+  var checkResult = function(result) {
+    assert(result.fields, 'should have fields definition');
+    assert.equal(result.fields.length, 1);
+    assert.equal(result.fields[0].name, 'val');
+    assert.equal(result.fields[0].dataTypeID, 25);
+    pg.end();
+  };
+
+  pg.connect(config, assert.success(function(client, done) {
+    var query = client.query('select $1::text as val limit 0', ['hi'], assert.success(function(result) {
+      checkResult(result);
+      done();
+    }));
+
+    assert.emits(query, 'end', checkResult);
+  }));
+});


### PR DESCRIPTION
A common trick to get information about the structure of a query result is to run the query with a LIMIT 0 thus only getting the field names and types.

This trick seems to be impossible to do with the node-postgresql module because the only place where field names are available is within a result row, so no rows means no such info.

I hope I'm missing something. If not, this would be a really useful addition.
I've been thinking the information could be passed as part of the .end() event, with information being filed names and data types.
