### PR TITLE
Be more verbose about failures of incorrect copy usage test

### DIFF
--- a/test/integration/client/copy-tests.js
+++ b/test/integration/client/copy-tests.js
@@ -134,7 +134,7 @@ test("COPY TO incorrect usage with small data", function () {
       assert.calls(function (error) {
         assert.ok(error, "error should be reported when sending copy to query with query method");
         client.query("SELECT 1", assert.calls(function (error, result) {
-          assert.isNull(error, "incorrect copy usage should not break connection");
+          assert.isNull(error, "incorrect copy usage should not break connection: " + error);
           assert.ok(result, "incorrect copy usage should not break connection");
           done();
         }));
@@ -154,7 +154,7 @@ test("COPY FROM incorrect usage", function () {
         assert.calls(function (error) {
           assert.ok(error, "error should be reported when sending copy to query with query method");
           client.query("SELECT 1", assert.calls(function (error, result) {
-            assert.isNull(error, "incorrect copy usage should not break connection");
+            assert.isNull(error, "incorrect copy usage should not break connection: " + error);
             assert.ok(result, "incorrect copy usage should not break connection");
             done();
             pg.end(helper.config);     


### PR DESCRIPTION
These tests are unstable, sometimes fail sometime succeed. Showing the error helps figuring out the possible reason. When it fails, the error here becomes: `AssertionError: incorrect copy usage should not break connection: error: canceling statement due to user request`
