### PR TITLE
Add default value for database host to lib/defaults.js 

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,4 +1,7 @@
 module.exports = {
+  // database host defaults to localhost
+  host: 'localhost',
+
   //database user's name
   user: process.env.USER,
 


### PR DESCRIPTION
Native binding connection tests will fail if the PGHOST environment variable is not set.

There already exists default values for user, password and port. It would make sense to have a default host value as well - localhost appears to be a reasonable default.
