### PR TITLE
Unable to reconnect after calling pg.end()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ PG.prototype.end = function() {
   var self = this;
   Object.keys(self.pools.all).forEach(function(key) {
     var pool = self.pools.all[key];
+    delete self.pools.all[key];
     pool.drain(function() {
       pool.destroyAllNow();
     });


### PR DESCRIPTION
I discovered this while doing tests with pg.  Between tests, pg.end() is called to clear out the pool, and then I call pg.connect() again, with the same connection string.

Is there a better way to dump the pool (e.g. any hung connections) and create a new pool?

I have not yet added additional tests, but did confirm that existing tests still pass.
