### PR TITLE
Provide affectedRows in the result

### DIFF
--- a/lib/result.js
+++ b/lib/result.js
@@ -37,6 +37,10 @@ Result.prototype.addCommandComplete = function(msg) {
     } else {
       this.rowCount = parseInt(match[2], 10);
     }
+    if ( this.command != 'SELECT' ) {
+      if ( ! this.affectedRows ) this.affectedRows = this.rowCount;
+      else this.affectedRows += this.rowCount;
+    }
   }
 };
 


### PR DESCRIPTION
This provides an "affectedRows" element in result for queries that mutate the database.
In particular, you get a cumulative sum of affected rows in case of concatenated queries.
Example:
`
INSERT INTO table1 VALUES (3);
UPDATE table2 SET id = 4 WHERE id = 3;
SELECT * from table3;
`

You'd get an `affectedRows` equal to 1 (the insert) + the number of rows in table2 that had id=3.
The rowCount would still only reflect what comes out of the select.

Actually, since a select's number of result rows can already be inspected looking at rows.length I wonder if 'rowCount' should really only be for "affectedRows" (non-select results) but this patch is trying to NOT change existing interface.

The need here is to know if any query in a concatenation changed anything, and how much.
The same need can probably be answered by allowing for multiple results (then I can check out COMMAND and do this myself from the client).
