### PR TITLE
Use the standard postgres:// URL prefix for consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-connectionString=pg://
+connectionString=postgres://
 
 params := $(connectionString)
 
@@ -13,15 +13,15 @@ all:
 	npm install
 
 help:
-	@echo "make prepare-test-db [connectionString=pg://<your connection string>]"
-	@echo "make test-all [connectionString=pg://<your connection string>]"
+	@echo "make prepare-test-db [connectionString=postgres://<your connection string>]"
+	@echo "make test-all [connectionString=postgres://<your connection string>]"
 
 test: test-unit 
 
 test-all: jshint test-unit test-integration test-native test-binary
 
 test-travis: test-all upgrade-pg
-	@make test-all connectionString=pg://postgres@localhost:5433/postgres
+	@make test-all connectionString=postgres://postgres@localhost:5433/postgres
 
 upgrade-pg:
 	@chmod 755 script/travis-pg-9.2-install.sh

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var pg = require('pg');
 //or native libpq bindings
 //var pg = require('pg').native
 
-var conString = "tcp://postgres:1234@localhost/postgres";
+var conString = "postgres://postgres:1234@localhost/postgres";
 
 var client = new pg.Client(conString);
 client.connect(function(err) {
@@ -44,7 +44,7 @@ Typically you will access the PostgreSQL server through a pool of clients.  node
 
 ```javascript
 var pg = require('pg');
-var conString = "tcp://postgres:1234@localhost/postgres";
+var conString = "postgres://postgres:1234@localhost/postgres";
 
 pg.connect(conString, function(err, client, done) {
   if(err) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "semver": "~1.1.4"
   },
   "scripts": {
-    "test": "make test-travis connectionString=pg://postgres@localhost:5432/postgres",
+    "test": "make test-travis connectionString=postgres://postgres@localhost:5432/postgres",
     "install": "node-gyp rebuild || (exit 0)"
   },
   "engines": {

--- a/script/travis-pg-9.2-install.sh
+++ b/script/travis-pg-9.2-install.sh
@@ -17,4 +17,4 @@ sudo echo "host    all         all         0.0.0.0 255.255.255.255 trust" >> /et
 sudo /etc/init.d/postgresql restart
 # for some reason both postgres 9.1 and 9.2 are started
 # 9.2 is running on port 5433
-node script/create-test-tables.js pg://postgres@localhost:5433/postgres
+node script/create-test-tables.js postgres://postgres@localhost:5433/postgres

--- a/test/integration/client/error-handling-tests.js
+++ b/test/integration/client/error-handling-tests.js
@@ -163,7 +163,7 @@ test('multiple connection errors (gh#31)', function() {
   });
 
   test('with callback method', function() {
-    var badConString = "tcp://aslkdfj:oi14081@"+helper.args.host+":"+helper.args.port+"/"+helper.args.database;
+    var badConString = "postgres://aslkdfj:oi14081@"+helper.args.host+":"+helper.args.port+"/"+helper.args.database;
     return false;
   });
 });

--- a/test/unit/client/configuration-tests.js
+++ b/test/unit/client/configuration-tests.js
@@ -31,7 +31,7 @@ test('client settings', function() {
 test('initializing from a config string', function() {
 
   test('uses the correct values from the config string', function() {
-    var client = new Client("pg://brian:pass@host1:333/databasename")
+    var client = new Client("postgres://brian:pass@host1:333/databasename")
     assert.equal(client.user, 'brian')
     assert.equal(client.password, "pass")
     assert.equal(client.host, "host1")
@@ -40,7 +40,7 @@ test('initializing from a config string', function() {
   })
 
   test('uses the correct values from the config string with space in password', function() {
-    var client = new Client("pg://brian:pass word@host1:333/databasename")
+    var client = new Client("postgres://brian:pass word@host1:333/databasename")
     assert.equal(client.user, 'brian')
     assert.equal(client.password, "pass word")
     assert.equal(client.host, "host1")
@@ -49,7 +49,7 @@ test('initializing from a config string', function() {
   })
 
   test('when not including all values the defaults are used', function() {
-    var client = new Client("pg://host1")
+    var client = new Client("postgres://host1")
     assert.equal(client.user, process.env['PGUSER'] || process.env.USER)
     assert.equal(client.password, process.env['PGPASSWORD'] || null)
     assert.equal(client.host, "host1")

--- a/test/unit/connection-parameters/creation-tests.js
+++ b/test/unit/connection-parameters/creation-tests.js
@@ -11,7 +11,7 @@ for(var key in process.env) {
 test('ConnectionParameters construction', function() {
   assert.ok(new ConnectionParameters(), 'with null config');
   assert.ok(new ConnectionParameters({user: 'asdf'}), 'with config object');
-  assert.ok(new ConnectionParameters('pg://localhost/postgres'), 'with connection string');
+  assert.ok(new ConnectionParameters('postgres://localhost/postgres'), 'with connection string');
 });
 
 var compare = function(actual, expected, type) {
@@ -145,13 +145,13 @@ test('libpq connection string building', function() {
       host: 'localhost',
       database: 'postgres'
     }
-    var connectionString = 'pg://' + sourceConfig.user + ':' + sourceConfig.password + '@' + sourceConfig.host + ':' + sourceConfig.port + '/' + sourceConfig.database;
+    var connectionString = 'postgres://' + sourceConfig.user + ':' + sourceConfig.password + '@' + sourceConfig.host + ':' + sourceConfig.port + '/' + sourceConfig.database;
     var subject = new ConnectionParameters(connectionString);
     assert.equal(subject.password, sourceConfig.password);
   });
 
   test('password contains weird characters', function() {
-    var strang = 'pg://my first name:is&%awesome!@localhost:9000';
+    var strang = 'postgres://my first name:is&%awesome!@localhost:9000';
     var subject = new ConnectionParameters(strang);
     assert.equal(subject.user, 'my first name');
     assert.equal(subject.password, 'is&%awesome!');

--- a/test/unit/pool/basic-tests.js
+++ b/test/unit/pool/basic-tests.js
@@ -54,7 +54,7 @@ test('pool creates pool on miss', function() {
   var p2 = pools.getOrCreate();
   assert.equal(p, p2);
   assert.equal(Object.keys(pools.all).length, 1);
-  var p3 = pools.getOrCreate("pg://postgres:password@localhost:5432/postgres");
+  var p3 = pools.getOrCreate("postgres://postgres:password@localhost:5432/postgres");
   assert.notEqual(p, p3);
   assert.equal(Object.keys(pools.all).length, 2);
 });


### PR DESCRIPTION
Fixes #286.

Passes `make test-all`.
