### PR TITLE
register UUID[] type parser same as TEXT[]

### DIFF
--- a/lib/types/textParsers.js
+++ b/lib/types/textParsers.js
@@ -193,6 +193,7 @@ var init = function(register) {
   register(1186, parseInterval);
   register(17, parseByteA);
   register(114, JSON.parse.bind(JSON));
+  register(2951, parseStringArray); //_uuid
 };
 
 module.exports = {


### PR DESCRIPTION
Columns of UUID[](uuid arrays) get returned unparsed. To fix this in application code I had to add:

```
var pg = require('pg');
pg.types.setTypeParser(2951, pg.types.getTypeParser(1014, 'text'));
```

Since the UUID type has been around in postgres since 8.3 with the same oid (2950 for UUID and 2951 for UUID[]). It would be nice to have this parser registered by default.
