### PR TITLE
Add ability to opt-in to int8 parsing

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,4 +1,4 @@
-module.exports = {
+var defaults = module.exports = {
   // database host defaults to localhost
   host: 'localhost',
 
@@ -38,3 +38,8 @@ module.exports = {
 
   client_encoding: ""
 };
+
+//parse int8 so you can get your count values as actual numbers
+module.exports.__defineSetter__("parseInt8", function(val) {
+  require('./types').setTypeParser(20, 'text', val ? parseInt : function(val) { return val; });
+});

--- a/test/integration/client/parse-int-8-tests.js
+++ b/test/integration/client/parse-int-8-tests.js
@@ -1,0 +1,18 @@
+
+var helper = require(__dirname + '/../test-helper');
+var pg = helper.pg;
+test('ability to turn on and off parser', function() {
+  if(helper.args.binary) return false;
+  pg.connect(helper.config, assert.success(function(client, done) {
+    pg.defaults.parseInt8 = true;
+    client.query('CREATE TEMP TABLE asdf(id SERIAL PRIMARY KEY)');
+    client.query('SELECT COUNT(*) as "count" FROM asdf', assert.success(function(res) {
+      pg.defaults.parseInt8 = false;
+      client.query('SELECT COUNT(*) as "count" FROM asdf', assert.success(function(res) {
+        done();
+        assert.strictEqual("0", res.rows[0].count);
+        pg.end();
+      }));
+    }));
+  }));
+});


### PR DESCRIPTION
Switching the result of all COUNT operations to a string is
a pretty nasty breaking change, and the majority of us aren't
going to be hitting numbers larger than Number.MAX_VALUE

I bumped the major version number, but this makes the upgrade easier.  I know in my apps I don't ever use 64bit numbers but I do COUNT(*) all over the place.

fixes https://github.com/brianc/node-postgres/issues/378

to opt in just do

``` js
require('pg').defaults.parseInt8 = true
```

Basically this is a handy shortcut  for this:

``` js

require('pg').types.setTypeParser(20, 'text', parseInt)

```
