### PR TITLE
improve SHELL portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /bin/sh
 
 connectionString=postgres://
 


### PR DESCRIPTION
bash isn't a standard shell outside a Linux world, but sh is (per POSIX, see link below). should be no-op due to no bashisms in the script.

http://pubs.opengroup.org/onlinepubs/009695399/utilities/sh.html
