### PR TITLE
fix global variable leaks for ROW_DESCRIPTION, FORMAT_TEXT, FORMAT_BINARY, DATA_ROW

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -460,7 +460,7 @@ Connection.prototype.parseZ = function(buffer, length) {
   return msg;
 };
 
-ROW_DESCRIPTION = 'rowDescription';
+var ROW_DESCRIPTION = 'rowDescription';
 Connection.prototype.parseT = function(buffer, length) {
   var msg = new Message(ROW_DESCRIPTION, length);
   msg.fieldCount = this.parseInt16(buffer);
@@ -482,8 +482,8 @@ var Field = function() {
   this.format = null;
 };
 
-FORMAT_TEXT = 'text';
-FORMAT_BINARY = 'binary';
+var FORMAT_TEXT = 'text';
+var FORMAT_BINARY = 'binary';
 Connection.prototype.parseField = function(buffer) {
   var field = new Field();
   field.name = this.parseCString(buffer);
@@ -502,7 +502,7 @@ Connection.prototype.parseField = function(buffer) {
   return field;
 };
 
-DATA_ROW = 'dataRow';
+var DATA_ROW = 'dataRow';
 var DataRowMessage = function(name, length, fieldCount) {
   this.name = DATA_ROW;
   this.length = length;


### PR DESCRIPTION
Newer code is leaking these variables into the global namespace: ROW_DESCRIPTION, FORMAT_TEXT, FORMAT_BINARY, DATA_ROW

This simply qualifies them appropriately. 
