### PR TITLE
_result.rows was empty

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -63,9 +63,9 @@ Query.prototype.handleDataRow = function(msg) {
   this.emit('row', row, this._result);
 
   //if there is a callback collect rows
-  if(this.callback) {
+  // if(this.callback) {
     this._result.addRow(row);
-  }
+  // }
 };
 
 Query.prototype.handleCommandComplete = function(msg) {


### PR DESCRIPTION
var pg=require('pg');
var db=new pg.Client("postgres://postgres:1234@localhost/postgres");
db.connect(function(){
  var sql="select 'bar' as foo where $1=$1;";
  var values=[1];
  db.query(sql,values).on("end",function(result){
    console.log(result);
  });
});
//>>{command:'SELECT',rowCount:1,oid:NaN,rows:[],,,}
