### PR TITLE
Catch connection reset or terminated by administrator command

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -165,7 +165,16 @@ Connection.prototype._send = function(code, more) {
   if(more === true) {
     this.writer.addHeader(code);
   } else {
-    return this.stream.write(this.writer.flush(code));
+    try {
+      return this.stream.write(this.writer.flush(code));
+    } catch (error) {
+      // catch connection reset or terminated by administrator command
+      if(error.code == 'ECONNRESET' || error.code == 'ECONNABORTED') {
+        return false;
+      } else {
+        throw error;
+      }
+    }
   }
 };
 


### PR DESCRIPTION
This prevents a fatal error when postgres is restarted or crashes during a query.  The underlying error emits an 'error' event, but node would still crash when trying to end the connection.  This way, you can handle the error in your app and exit gracefully.
