### PR TITLE
Use the correct environment variable for defaults on Windows

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,10 +3,10 @@ var defaults = module.exports = {
   host: 'localhost',
 
   //database user's name
-  user: process.env.USER,
+  user: process.platform === 'win32' ? process.env.USERNAME : process.env.USER,
 
   //name of database to connect
-  database: process.env.USER,
+  database: process.platform === 'win32' ? process.env.USERNAME : process.env.USER,
 
   //database user's password
   password: null,


### PR DESCRIPTION
Windows uses the USERNAME environment variable instead of the USER environment variable for the current user so the default for pg doesn't work on windows.
This tiny patch gets this right.
I've opted for process.platform instead of os.platform() as I didn't want to introduce a require('os') into defaults.js but if using one or the other is more than a matter of taste (which I don't think) yout migth want to use os.platform() instead.
Didn't test anything but Windows but I don't expect any problems with this two-liner.

Regards,
Brar
