### PR TITLE
use NAN for Node 0.8->0.11+ compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,13 +2,16 @@
   'targets': [
     {
       'target_name': 'binding',
+      'sources': ['src/binding.cc'],
+      'include_dirs': [
+        '<!@(pg_config --includedir)',
+        '<!(node -e \'require("nan")\')'
+      ],
       'conditions' : [
         ['OS=="win"', {
           'conditions' : [
             ['"<!@(cmd /C where /Q pg_config || echo n)"!="n"',
               {
-                'sources': ['src/binding.cc'],
-                'include_dirs': ['<!@(pg_config --includedir)'],
                 'libraries' : ['libpq.lib'],
                 'msvs_settings': {
                   'VCLinkerTool' : {
@@ -24,8 +27,6 @@
           'conditions' : [
             ['"y"!="n"', # ToDo: add pg_config existance condition that works on linux
               {
-                'sources': ['src/binding.cc'],
-                'include_dirs': ['<!@(pg_config --includedir)'],
                 'libraries' : ['-lpq -L<!@(pg_config --libdir)']
               }
             ]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "main": "./lib",
   "dependencies": {
     "generic-pool": "2.0.3",
-    "buffer-writer": "1.0.0"
+    "buffer-writer": "1.0.0",
+    "nan": "~0.6.0"
   },
   "devDependencies": {
     "jshint": "1.1.0",

--- a/test/integration/connection-pool/ending-pool-tests.js
+++ b/test/integration/connection-pool/ending-pool-tests.js
@@ -11,11 +11,11 @@ test('disconnects', function() {
     helper.pg.connect(config, function(err, client, done) {
       assert.isNull(err);
       client.query("SELECT * FROM NOW()", function(err, result) {
-        process.nextTick(function() {
+        setTimeout(function() {
           assert.equal(called, false, "Should not have disconnected yet")
           sink.add();
           done();
-        })
+        }, 0)
       })
     })
   })


### PR DESCRIPTION
Node 0.11 and onwards uses the new V8 which has huge breaking API changes. NAN is designed to make it easy to support V8 and Node across versions 0.8 to 0.11 and onwards without the need for branching macros. NAN is keeping up-to-date as newer versions of Node 0.11 are released and new breaking changes come upstream from V8.

This PR adds NAN support for compiling against the latest Node 0.11; tests all pass. Would be good to get this in npm before the impending 0.12 release.

Let me know if you have any questions.
