### PR TITLE
Set database on socket string connection

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -12,16 +12,24 @@ var val = function(key, config) {
 var url = require('url');
 //parses a connection string
 var parse = function(str) {
+  var config;
   //unix socket
   if(str.charAt(0) === '/') {
-    return { host: str };
+    config = str.split(' ');
+    return { host: config[0], database: config[1] };
   }
   // url parse expects spaces encoded as %20
-  str = encodeURI(str);
+  if(/ |%[^a-f0-9]|%[a-f0-9][^a-f0-9]/i.test(str)) str = encodeURI(str);
   var result = url.parse(str, true);
-  var config = {};
+  config = {};
+  if(result.protocol == 'socket:') {
+    config.host = decodeURI(result.pathname);
+    config.database = result.query.db;
+    config.client_encoding = result.query.encoding;
+    return config;
+  }
   config.host = result.hostname;
-  config.database = result.pathname ? result.pathname.slice(1) : null;
+  config.database = result.pathname ? decodeURI(result.pathname.slice(1)) : null;
   var auth = (result.auth || ':').split(':');
   config.user = auth[0];
   config.password = auth[1];


### PR DESCRIPTION
Allows to connect to a specific database trough this ways:

```
pg.connect('/some/path database', callback);
pg.connect('socket:/some/path?db=database', callback)
pg.connect('socket:/some/path?db=database&encoding=utf8', callback)
```

Closes [issue 484](https://github.com/brianc/node-postgres/issues/484)
