### PR TITLE
Add SQL_ASCII support and fix client_encoding inconsistency

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -24,11 +24,11 @@ var Client = function(config) {
 
   this.connection = c.connection || new Connection({
     stream: c.stream,
-    ssl: this.connectionParameters.ssl
+    ssl: this.connectionParameters.ssl,
+    server_encoding: c.server_encoding
   });
   this.queryQueue = [];
   this.binary = c.binary || defaults.binary;
-  this.encoding = 'utf8';
   this.processID = null;
   this.secretKey = null;
   this.ssl = this.connectionParameters.ssl || false;
@@ -192,9 +192,9 @@ Client.prototype.getStartupConf = function() {
   var params = this.connectionParameters;
 
   var data = {
-    user     : params.user ,
-    database : params.database
-    // client_encoding : "'".concat(params.client_encoding).concat("'")
+    user            : params.user,
+    database        : params.database,
+    client_encoding : params.client_encoding
   };
 
   var appName = params.application_name || params.fallback_application_name;

--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -41,7 +41,6 @@ var parse = function(str) {
   if(result.protocol == 'socket:') {
     config.host = decodeURI(result.pathname);
     config.database = result.query.db;
-    config.client_encoding = result.query.encoding;
     return config;
   }
   config.host = result.hostname;
@@ -81,7 +80,10 @@ var ConnectionParameters = function(config) {
   this.password = val('password', config);
   this.binary = val('binary', config);
   this.ssl = config.ssl || useSsl();
-  this.client_encoding = val("client_encoding", config);
+
+  // do not make this configurable without adding a string decoder to Connection
+  this.client_encoding = 'UTF8';
+
   //a domain socket begins with '/'
   this.isDomainSocket = (!(this.host||'').indexOf('/'));
 
@@ -103,6 +105,7 @@ ConnectionParameters.prototype.getLibpqConnectionString = function(cb) {
   add(params, this, 'port');
   add(params, this, 'application_name');
   add(params, this, 'fallback_application_name');
+  add(params, this, 'client_encoding');
 
   if(this.database) {
     params.push("dbname='" + this.database + "'");
@@ -112,9 +115,6 @@ ConnectionParameters.prototype.getLibpqConnectionString = function(cb) {
   }
   if(this.isDomainSocket) {
     return cb(null, params.join(' '));
-  }
-  if(this.client_encoding) {
-    params.push("client_encoding='" + this.client_encoding + "'");
   }
   dns.lookup(this.host, function(err, address) {
     if(err) return cb(err, null);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -16,7 +16,7 @@ var Connection = function(config) {
   this.lastOffset = 0;
   this.buffer = null;
   this.offset = null;
-  this.encoding = 'utf8';
+  this.updateEncoding(config.server_encoding);
   this.parsedStatements = {};
   this.writer = new Writer();
   this.ssl = config.ssl || false;
@@ -100,6 +100,11 @@ Connection.prototype.attachListeners = function(stream) {
   }.bind(this));
 };
 
+Connection.prototype.updateEncoding = function(encoding) {
+  this.server_encoding = encoding;
+  this.encoding = (encoding === 'SQL_ASCII') ? 'binary' : 'utf8';
+};
+
 Connection.prototype.requestSsl = function(config) {
   this.checkSslResponse = true;
 
@@ -126,8 +131,6 @@ Connection.prototype.startup = function(config) {
     var val = config[key];
     writer.addCString(key).addCString(val);
   });
-
-  writer.addCString('client_encoding').addCString("'utf-8'");
 
   var bodyBuffer = writer.addCString('').flush();
   //this message is sent without a code
@@ -452,6 +455,11 @@ Connection.prototype.parseS = function(buffer, length) {
   var msg = new Message('parameterStatus', length);
   msg.parameterName = this.parseCString(buffer);
   msg.parameterValue = this.parseCString(buffer);
+
+  if(msg.parameterName === 'server_encoding') {
+    this.updateEncoding(msg.parameterValue);
+  }
+
   return msg;
 };
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -36,8 +36,6 @@ var defaults = module.exports = {
   //pool log function / boolean
   poolLog: false,
 
-  client_encoding: "",
-
   ssl: false,
 
   application_name : undefined,

--- a/test/unit/connection-parameters/creation-tests.js
+++ b/test/unit/connection-parameters/creation-tests.js
@@ -72,19 +72,17 @@ test('initializing with unix domain socket and a specific database, the simple w
 });
 
 test('initializing with unix domain socket, the health way', function() {
-  var subject = new ConnectionParameters('socket:/some path/?db=my[db]&encoding=utf8');
+  var subject = new ConnectionParameters('socket:/some path/?db=my[db]');
   assert.ok(subject.isDomainSocket);
   assert.equal(subject.host, '/some path/');
   assert.equal(subject.database, 'my[db]', 'must to be escaped and unescaped trough "my%5Bdb%5D"');
-  assert.equal(subject.client_encoding, 'utf8');
 });
 
 test('initializing with unix domain socket, the escaped health way', function() {
-  var subject = new ConnectionParameters('socket:/some%20path/?db=my%2Bdb&encoding=utf8');
+  var subject = new ConnectionParameters('socket:/some%20path/?db=my%2Bdb');
   assert.ok(subject.isDomainSocket);
   assert.equal(subject.host, '/some path/');
   assert.equal(subject.database, 'my+db');
-  assert.equal(subject.client_encoding, 'utf8');
 });
 
 test('libpq connection string building', function() {
@@ -157,18 +155,6 @@ test('libpq connection string building', function() {
       checkForPart(parts, "host=/tmp/");
     }));
   });
-
-  test("encoding can be specified by config", function() {
-    var config = {
-      client_encoding: "utf-8"
-    }
-    var subject = new ConnectionParameters(config);
-    subject.getLibpqConnectionString(assert.calls(function(err, constring) {
-      assert.isNull(err);
-      var parts = constring.split(" ");
-      checkForPart(parts, "client_encoding='utf-8'");
-    }));
-  })
 
   test('password contains  < and/or >  characters', function () {
     return false;

--- a/test/unit/connection/outbound-sending-tests.js
+++ b/test/unit/connection/outbound-sending-tests.js
@@ -14,7 +14,8 @@ assert.received = function(stream, buffer) {
 test("sends startup message", function() {
   con.startup({
     user: 'brian',
-    database: 'bang'
+    database: 'bang',
+    client_encoding: 'UTF8'
   });
   assert.received(stream, new BufferList()
                   .addInt16(3)
@@ -24,7 +25,7 @@ test("sends startup message", function() {
                   .addCString('database')
                   .addCString('bang')
                   .addCString('client_encoding')
-                  .addCString("'utf-8'")
+                  .addCString('UTF8')
                   .addCString('').join(true))
 });
 


### PR DESCRIPTION
Hello,

I'm working with a 3rd-party database that (unfortunately) uses the SQL_ASCII character set.
node-postgres presented problems decoding strings and after some research I think I came up with an acceptable solution. Note that I'm in no way a Pg expert, so please point out any problems!

SQL_ASCII is not supported because Connection (both native and javascript) always decodes strings as UTF-8. This isn't a problem with other encodings because PostgreSQL automatically converts strings in compatible charsets to the requested client_encoding, but it can result in invalid code points for SQL_ASCII strings as they are sent without conversion.

On top of that, the handling of client_encoding should be reviewed. The javascript version always use UTF-8 whereas the native bindings accept a configurable parameter. But without a proper decoding algorithm, there's no reason to accept different client_encodings (you just end up with an invalid UTF-8 string -- bug introduced in #370).

I see three possible solutions:
- Accept a configurable client_encoding and implement a decoder for [every Pg charset](http://www.postgresql.org/docs/9.3/static/multibyte.html).
  - I can't see any upsides. Receive strings in a specific encoding just to decode them in javascript? Pg can convert them for us, probably faster.
- Accept a configurable client_encoding and leave strings as-is (ie. Buffer) if they are not UTF-8.
  - Still easy to use in most cases (UTF-8).
  - The user can request the original encoding if desired (to write to disk/network, decode manually for some reason, etc).
- Make client_connection fixed and let Pg convert strings for us (related issue: #498)
  - Easiest of them all: just have to deal with the SQL_ASCII exception.
  - The user can still encode them to different encodings if needed.

What do you think? I'm personally leaning torwards the second option. It'd work exactly the same as now, unless the user explicitly asks for the raw strings.

In this pull request I went with the third option, mainly because I'm not familiar with Node's C++ API and the native bindings seemed trickier to mess with.

For this, I centralized the client_encoding setting location to solve the native/javascript disparity, and added a check for the server_enconding runtime variable that's sent during the startup phase. If it is SQL_ASCII, I disable the UTF-8 decoding. Otherwise, leave it as before.

It still works the same, unless the user or server sets server_encoding to SQL_ASCII.

Sorry for the verbosity; being one of my first open-source contributions certainly didn't help that!
