### PR TITLE
Added missing argument to handleError method call.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -175,7 +175,7 @@ Client.prototype.connect = function(callback) {
   con.once('end', function() {
     if(self.activeQuery) {
       var disconnectError = new Error('Stream unexpectedly ended during query execution');
-      self.activeQuery.handleError(disconnectError);
+      self.activeQuery.handleError(disconnectError, con);
       self.activeQuery = null;
     }
     self.emit('end');


### PR DESCRIPTION
Before the change, it would crash with a very unhelpful error message:

```
[project path]/node_modules/pg/lib/query.js:92
    connection.sync();
               ^
TypeError: Cannot call method 'sync' of undefined
    at Query.handleError ([project path]/node_modules/pg/lib/query.js:92:16)
    at Client.connect ([project path]/node_modules/pg/lib/client.js:178:24)
    at g (events.js:185:14)
    at EventEmitter.emit (events.js:85:17)
    at Socket.<anonymous> ([project path]/node_modules/pg/lib/connection.js:60:10)
    at Socket.EventEmitter.emit (events.js:85:17)
    at TCP.onread (net.js:424:51)
```

After the change, it reports a much more helpful

```
error running query [Error: Stream unexpectedly ended during query execution]
```
