### PR TITLE
query: remove dead type-parsing code path

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -46,10 +46,6 @@ Query.prototype.requiresPreparation = function() {
 };
 
 
-var noParse = function(val) {
-  return val;
-};
-
 //associates row metadata from the supplied
 //message with this query object
 //metadata used when parsing row results


### PR DESCRIPTION
Type parsing was factored out into the pg-types package. Remove vestigal
`noParse` function.

All tests continue to pass on my machine.
