### PR TITLE
Remove unused variables

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -1,6 +1,5 @@
 var url = require('url');
 var dns = require('dns');
-var path = require('path');
 
 var defaults = require(__dirname + '/defaults');
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,9 +1,7 @@
 var net = require('net');
-var crypto = require('crypto');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
-var utils = require(__dirname + '/utils');
 var Writer = require('buffer-writer');
 var Reader = require('packet-reader');
 
@@ -110,7 +108,7 @@ Connection.prototype.attachListeners = function(stream) {
   });
 };
 
-Connection.prototype.requestSsl = function(config) {
+Connection.prototype.requestSsl = function() {
   this.checkSslResponse = true;
 
   var bodyBuffer = this.writer
@@ -266,7 +264,7 @@ Connection.prototype.execute = function(config, more) {
   config = config || {};
   config.portal = config.portal || '';
   config.rows = config.rows || '';
-  var buffer = this.writer
+  this.writer
     .addCString(config.portal)
     .addInt32(config.rows);
 

--- a/lib/copystream.js
+++ b/lib/copystream.js
@@ -80,7 +80,7 @@ CopyFromStream.prototype.write = function (string, encoding) {
   return this._handleChunk.apply(this, arguments);
 };
 
-CopyFromStream.prototype.end = function (string, encondig) {
+CopyFromStream.prototype.end = function (string, encoding) {
   if(this._error || this._finished) {
     return false;
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -99,7 +99,6 @@ Query.prototype.handleError = function(err, connection) {
 };
 
 Query.prototype.submit = function(connection) {
-  var self = this;
   if(this.requiresPreparation()) {
     this.prepare(connection);
   } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,3 @@
-var url = require('url');
-var defaults = require(__dirname + "/defaults");
 
 // convert a JS array to a postgres array literal
 // uses comma separator so won't work for types like box that use


### PR DESCRIPTION
Saw there were a few unused `require`'s when looking at utils.js and decided to do a quick pass and take out anything obviously unused (not unused arguments, except [where they're incorrect](https://github.com/tgriesser/node-postgres/compare/brianc:master...tgriesser:unused-vars?expand=1#diff-259dec4414a400a6e895f16ff1d0ca3bR111)).
