### PR TITLE
Remove legacy .once events shim

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,17 +1,5 @@
 var url = require('url');
 var defaults = require(__dirname + "/defaults");
-var events = require('events');
-
-//compatibility for old nodes
-if(typeof events.EventEmitter.prototype.once !== 'function') {
-  events.EventEmitter.prototype.once = function (type, listener) {
-    var self = this;
-    self.on(type, function g () {
-      self.removeListener(type, g);
-      listener.apply(this, arguments);
-    });
-  };
-}
 
 // convert a JS array to a postgres array literal
 // uses comma separator so won't work for types like box that use


### PR DESCRIPTION
As I was taking a look through the new utils.js, I noticed that the shim for once was still around. As the dependency is now >= 0.8, I assume this can be safely removed?
