### PR TITLE
Fix memory leak with domains

### DIFF
--- a/lib/native/query.js
+++ b/lib/native/query.js
@@ -19,6 +19,9 @@ var NativeQuery = function(config, values, callback) {
   this.text = c.text;
   this.values = c.values;
   this.callback = c.callback;
+  if(process.domain && c.callback) {
+    this.callback = process.domain.bind(c.callback);
+  }
   this.singleRowMode = false;
 
   if(!this.callback) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -64,23 +64,9 @@ var pools = {
       pool.acquire(function(err, client) {
         if(domain) {
           cb = domain.bind(cb);
-          domain.add(client);
-          //native clients do not have a connection object
-          if(client.connection) {
-            domain.add(client.connection);
-            domain.add(client.connection.stream);
-          }
         }
         if(err)  return cb(err, null, function() {/*NOOP*/});
         cb(null, client, function(err) {
-          if(domain) {
-            //native clients do not have a connection object
-            if(client.connection) {
-              domain.remove(client.connection.stream);
-              domain.remove(client.connection);
-            }
-            domain.remove(client);
-          }
           if(err) {
             pool.destroy(client);
           } else {

--- a/lib/query.js
+++ b/lib/query.js
@@ -20,6 +20,9 @@ var Query = function(config, values, callback) {
   //use unique portal name each time
   this.portal = config.portal || "";
   this.callback = config.callback;
+  if(process.domain && config.callback) {
+    this.callback = process.domain.bind(config.callback);
+  }
   this._fieldNames = [];
   this._fieldConverters = [];
   this._result = new Result(config.rowMode);


### PR DESCRIPTION
This fixes an issue where memory was slowly leaked if you were using domains with node-postgres.  I don't understand the underlying reason with the memory leak - everything I did looked like it lined up with the node.js documentation on domains.  None the less I confirmed (and was bitten in production by) a memory leak here and this code resolves it while maintaining functionality for the majority of the use cases. 

With this release I am going to unpublish the buggy releases.
