### PR TITLE
remove pause/resumeDrain functions from native code as discussed in issue #515

### DIFF
--- a/lib/native/index.js
+++ b/lib/native/index.js
@@ -118,12 +118,7 @@ Connection.prototype._pulseQueryQueue = function(initialConnection) {
   var query = this._queryQueue.shift();
   if(!query) {
     if(!initialConnection) {
-      //TODO remove all the pause-drain stuff for v1.0
-      if(this._drainPaused) {
-        this._drainPaused++;
-      } else {
-        this.emit('drain');
-      }
+      this.emit('drain');
     }
     return;
   }
@@ -143,19 +138,6 @@ Connection.prototype._pulseQueryQueue = function(initialConnection) {
     //call native function
     this._sendQuery(query.text, query.singleRowMode);
   }
-};
-
-//TODO remove all the pause-drain stuff for v1.0
-Connection.prototype.pauseDrain = function() {
-  this._drainPaused = 1;
-};
-
-//TODO remove all the pause-drain stuff for v1.0
-Connection.prototype.resumeDrain = function() {
-  if(this._drainPaused > 1) {
-    this.emit('drain');
-  }
-  this._drainPaused = 0;
 };
 
 Connection.prototype.sendCopyFail = function(msg) {


### PR DESCRIPTION
As discussed in the ticket and stated in the code we should remove these functions.
