### PR TITLE
emit event 'ended' on pool drained

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ PG.prototype.end = function() {
       pool.destroyAllNow(function() {
         count--;
         if(count === 0) {
-          self.emit('ended');
+          self.emit('end');
         }
       });
     });

--- a/test/integration/connection-pool/ending-pool-tests.js
+++ b/test/integration/connection-pool/ending-pool-tests.js
@@ -5,7 +5,7 @@ test('disconnects', function() {
   var sink = new helper.Sink(4, function() {
     called = true;
     var eventSink = new helper.Sink(1, function() {});
-    helper.pg.on('ended', function() {
+    helper.pg.on('end', function() {
       eventSink.add();
     });
 


### PR DESCRIPTION
I've noticed that there's no real way that I could see to be notified that all the pools have actually destroyed all their resources successfully. pg.end() ends just orders the pool to drain and destroyAllNow, but doesn't notify anyone when these actions are completed.

This change lets us do this with a new event "ended":

```
    var deferred = Q.defer();
    pg.on('ended', function() {
      deferred.resolve();
    });
    pg.on('error', function(err) {
      deferred.reject(err);
    });
    pg.end();
    return deferred.promise;
```
