### PR TITLE
Remove unused parameter 'name' from DataRowMessage.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -478,7 +478,7 @@ Connection.prototype.parseField = function(buffer) {
 };
 
 var DATA_ROW = 'dataRow';
-var DataRowMessage = function(name, length, fieldCount) {
+var DataRowMessage = function(length, fieldCount) {
   this.name = DATA_ROW;
   this.length = length;
   this.fieldCount = fieldCount;


### PR DESCRIPTION
This hasn't been a problem (at least not yet) because the length and fieldCount properties aren't used anywhere. Nevertheless, I reckoned this is the intended form of DataRowMessage since there is an invocation of "new DataRowMessage(length, fieldCount)" down the line.
