### PR TITLE
bump up timeout for tests against AWS from 5s to 15s

### DIFF
--- a/test/integration/client/heroku-pgpass-tests.js
+++ b/test/integration/client/heroku-pgpass-tests.js
@@ -35,5 +35,5 @@ test('uses password file when PGPASSFILE env variable is set', function() {
       done();
       pg.end();
     }))
-  }, 15000));
+  }));
 });

--- a/test/integration/client/heroku-ssl-tests.js
+++ b/test/integration/client/heroku-ssl-tests.js
@@ -24,5 +24,5 @@ test('connection with config ssl = true', function() {
       done();
       pg.end();
     }))
-  }, 15000));
+  }));
 });

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -133,9 +133,13 @@ assert.lengthIs = function(actual, expectedLength) {
 
 var expect = function(callback, timeout) {
   var executed = false;
-  timeout = timeout || 5000;
+  timeout = timeout || parseInt(process.env.TEST_TIMEOUT) || 5000;
   var id = setTimeout(function() {
-    assert.ok(executed, "Expected execution of function to be fired within " + timeout + ' milliseconds');
+    assert.ok(executed,
+      "Expected execution of function to be fired within " + timeout
+      + " milliseconds " +
+      + " (hint: export TEST_TIMEOUT=<timeout in milliseconds>"
+      + " to change timeout globally)");
   }, timeout)
 
   if(callback.length < 3) {


### PR DESCRIPTION
More often than not, connection to the AWS test server will timeout for locations with poor Internet connectivity (China..).
