### PR TITLE
tls socket missing error listener

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -89,6 +89,10 @@ Connection.prototype.connect = function(port, host) {
     });
     self.attachListeners(self.stream);
     self.emit('sslconnect');
+
+    self.stream.on('error', function(error){
+      self.emit('error', error);
+    });
   });
 };
 


### PR DESCRIPTION
This fixes #585

I wasn't able to add a unit test since it's making use of tls and i would need to stub that out.  I usually use proxyquire or sinon to create mock objects for unit testing.
