### PR TITLE
Make sure 'end' is emitted even if no connection has ever happened

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,18 +21,22 @@ PG.prototype.end = function() {
   var self = this;
   var keys = Object.keys(self.pools.all);
   var count = keys.length;
-  keys.forEach(function(key) {
-    var pool = self.pools.all[key];
-    delete self.pools.all[key];
-    pool.drain(function() {
-      pool.destroyAllNow(function() {
-        count--;
-        if(count === 0) {
-          self.emit('end');
-        }
+  if(count === 0) {
+    self.emit('end');
+  } else {
+    keys.forEach(function(key) {
+      var pool = self.pools.all[key];
+      delete self.pools.all[key];
+      pool.drain(function() {
+        pool.destroyAllNow(function() {
+          count--;
+          if(count === 0) {
+            self.emit('end');
+          }
+        });
       });
     });
-  });
+  }
 };
 
 

--- a/test/integration/connection-pool/ending-empty-pool-tests.js
+++ b/test/integration/connection-pool/ending-empty-pool-tests.js
@@ -1,0 +1,15 @@
+var helper = require(__dirname + '/test-helper')
+
+var called = false;
+test('disconnects', function() {
+  called = true;
+  var eventSink = new helper.Sink(1, function() {});
+  helper.pg.on('end', function() {
+    eventSink.add();
+  });
+
+  //this should exit the process
+  helper.pg.end();
+})
+
+


### PR DESCRIPTION
`pg.end()` didn't emit an `end` event when no pool has been created yet.
