### PR TITLE
Update npm to get rid of jshint install error on node v0.8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - 0.8
   - "0.10"
 before_script:
-  - node script/create-test-tables.js pg://postgres@127.0.0.1:5432/postgres
+  - npm i -g npm && node script/create-test-tables.js pg://postgres@127.0.0.1:5432/postgres


### PR DESCRIPTION
Let's hope this works. Kinda annoying this started happening.
