### PR TITLE
Fix 2 bugs in connection-parameters, and use environment vars consistently.

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -7,7 +7,7 @@ var val = function(key, config, envVar) {
   if (envVar === undefined) {
     envVar = process.env[ 'PG' + key.toUpperCase() ];
   } else if (envVar === false) {
-    // do nothing ... use false
+    envVar = '';
   } else {
     envVar = process.env[ envVar ];
   }
@@ -75,19 +75,20 @@ var useSsl = function() {
 
 var ConnectionParameters = function(config) {
   config = typeof config == 'string' ? parse(config) : (config || {});
-  this.user = val('user', config);
-  this.database = val('database', config);
-  this.port = parseInt(val('port', config), 10);
-  this.host = val('host', config);
-  this.password = val('password', config);
-  this.binary = val('binary', config);
-  this.ssl = config.ssl || useSsl();
-  this.client_encoding = val("client_encoding", config);
+  this.user     =           val('user',             config, 'PGUSER'          );
+  this.database =           val('database',         config, 'PGDATABASE'      );
+  this.port     = parseInt( val('port',             config, 'PGPORT'          ), 10);
+  this.host     =           val('host',             config, 'PGHOST'          );
+  this.password =           val('password',         config, 'PGPASSWORD'      );
+  this.binary   =           val('binary',           config, false             );
+  this.client_encoding  =   val("client_encoding",  config, 'PGCLIENTENCODING');
+  this.application_name =   val('application_name', config, 'PGAPPNAME'       );
+  this.fallback_application_name = val('fallback_application_name', config, false);
+
+  this.ssl      = config.ssl || useSsl();
   //a domain socket begins with '/'
   this.isDomainSocket = (!(this.host||'').indexOf('/'));
 
-  this.application_name = val('application_name', config, 'PGAPPNAME');
-  this.fallback_application_name = val('fallback_application_name', config, false);
 };
 
 var add = function(params, config, paramName) {


### PR DESCRIPTION
Bug 1: There's no such environment variable PGBINARY honored by
Postgres, but the code accidently honored such a variable, if present,
even though there's no support for binary format, yet.

Bug 2: Code, again by accident, honored PGCLIENT_ENCODING environment
variable, whereas there's no such variable honored by Postgres' libpq.
Corrected it to use PGCLIENTENCODING instead.

Since the above two mistakes were purely because of the way var()
function is coded to assume the env variable name to be equivalent of
'PG'+passed_in_key, it's easy to see how easy it is to make such
mistakes in future. So I consistently specify the env variable name,
even though the above mentioned derivation works just fine for most
keys.

Also, it seems odd to return a boolean false from val() function, so I
changed the code to return an empty string instead. Would it have been
better to return null or undefined?