### PR TITLE
switch to pg-connection-string module for parsing

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -18,47 +18,7 @@ var val = function(key, config, envVar) {
 };
 
 //parses a connection string
-var parse = function(str) {
-  var config;
-  //unix socket
-  if(str.charAt(0) === '/') {
-    config = str.split(' ');
-    return { host: config[0], database: config[1] };
-  }
-  // url parse expects spaces encoded as %20
-  if(/ |%[^a-f0-9]|%[a-f0-9][^a-f0-9]/i.test(str)) {
-    str = encodeURI(str).replace(/\%25(\d\d)/g, "%$1");
-  }
-  var result = url.parse(str, true);
-  config = {};
-
-  if (result.query.application_name) {
-    config.application_name = result.query.application_name;
-  }
-  if (result.query.fallback_application_name) {
-    config.fallback_application_name = result.query.fallback_application_name;
-  }
-
-  config.port = result.port;
-  if(result.protocol == 'socket:') {
-    config.host = decodeURI(result.pathname);
-    config.database = result.query.db;
-    config.client_encoding = result.query.encoding;
-    return config;
-  }
-  config.host = result.hostname;
-  config.database = result.pathname ? decodeURI(result.pathname.slice(1)) : null;
-  var auth = (result.auth || ':').split(':');
-  config.user = auth[0];
-  config.password = auth[1];
-
-  var ssl = result.query.ssl;
-  if (ssl === 'true' || ssl === '1') {
-    config.ssl = true;
-  }
-
-  return config;
-};
+var parse = require('pg-connection-string').parse;
 
 var useSsl = function() {
   switch(process.env.PGSSLMODE) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "pgpass": "0.0.3",
     "nan": "~0.6.0",
     "packet-reader": "0.2.0",
+    "pg-connection-string": "0.1.1",
     "pg-types": "1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I needed to use the parse method in another module so I pulled it out into its own module.  I also used tests from node-postgres that related to connection strings.
