### PR TITLE
bump pg-connection-string to support relative urls for database name

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pgpass": "0.0.3",
     "nan": "~1.3.0",
     "packet-reader": "0.2.0",
-    "pg-connection-string": "0.1.1",
+    "pg-connection-string": "0.1.2",
     "pg-types": "1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pulls in the change from https://github.com/iceddev/pg-connection-string/pull/1 that adds support for relative URLs as database name with default host
