### PR TITLE
Add Close/CloseComplete messages of wire protocol

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -300,6 +300,11 @@ Connection.prototype.end = function() {
   this._send(0x58);
 };
 
+Connection.prototype.close = function(msg, more) {
+  this.writer.addCString(msg.type + (msg.name || ''));
+  this._send(0x43, more);
+};
+
 Connection.prototype.describe = function(msg, more) {
   this.writer.addCString(msg.type + (msg.name || ''));
   this._send(0x44, more);
@@ -363,6 +368,9 @@ Connection.prototype.parseMessage =  function(buffer) {
 
   case 0x32: //2
     return new Message('bindComplete', length);
+
+  case 0x33: //3
+    return new Message('closeComplete', length);
 
   case 0x41: //A
     return this.parseA(buffer, length);


### PR DESCRIPTION
These messages seem to be missing compared to the documentation on http://www.postgresql.org/docs/9.3/static/protocol-message-formats.html

I added them wrt to the issue https://github.com/brianc/node-pg-cursor/issues/6
