### PR TITLE
Switch from ^ to ~ for bindings dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Brian Carlson <brian.m.carlson@gmail.com>",
   "main": "./lib",
   "dependencies": {
-    "bindings": "^1.2.1",
+    "bindings": "~1.2.1",
     "buffer-writer": "1.0.0",
     "generic-pool": "2.1.1",
     "nan": "~1.3.0",


### PR DESCRIPTION
The ^ symbol is not supported in the version of npm shipped with node 0.8.
