### PR TITLE
bump pg-connection-string to support colons in password

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "generic-pool": "2.1.1",
     "nan": "1.3.0",
     "packet-reader": "0.2.0",
-    "pg-connection-string": "0.1.2",
+    "pg-connection-string": "0.1.3",
     "pg-types": "1.4.0",
     "pgpass": "0.0.3"
   },


### PR DESCRIPTION
We just landed support for colons in the password (e.g. `username:pass:word`) in https://github.com/iceddev/pg-connection-string/commit/fbdd033d6c90cf5f9c2f6f258bc77a2184345f20 and released as 0.1.3.
