### PR TITLE
potential improvement for error stacktraces

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -28,6 +28,9 @@ var Query = function(config, values, callback) {
   this._result = new Result(config.rowMode);
   this.isPreparedStatement = false;
   this._canceledDueToError = false;
+
+  this.originalStack = new Error().stack;
+
   EventEmitter.call(this);
 };
 
@@ -86,6 +89,13 @@ Query.prototype.handleReadyForQuery = function() {
 
 Query.prototype.handleError = function(err, connection) {
   //need to sync after error during a prepared statement
+
+  var originalStack = this.originalStack.split('\n');
+  originalStack.shift();
+  originalStack = originalStack.join('\n');
+
+  err.stack += '\n' + originalStack;
+
   if(this.isPreparedStatement) {
     connection.sync();
   }


### PR DESCRIPTION
Example:

for the following code

```javascript
var pg = require('pg.js')

var client = new pg.Client()

client.connect(function (error) {
  if (error) throw error

  client.query('SELECT NQOW() AS "theTime"', function (error, result) {
    if (error) throw error
    console.log(result.rows[0].theTime)
    process.exit(0)
  })
})
```

the original stack trace is the following

```javascript
error: function nqow() does not exist
    at Connection.parseE (/Users/lalit/sandbox/pg-better-errors/node_modules/pg.js/lib/connection.js:534:11)
    at Connection.parseMessage (/Users/lalit/sandbox/pg-better-errors/node_modules/pg.js/lib/connection.js:361:17)
    at Socket.<anonymous> (/Users/lalit/sandbox/pg-better-errors/node_modules/pg.js/lib/connection.js:105:22)
    at Socket.emit (events.js:95:17)
    at Socket.<anonymous> (_stream_readable.js:764:14)
    at Socket.emit (events.js:92:17)
    at emitReadable_ (_stream_readable.js:426:10)
    at emitReadable (_stream_readable.js:422:5)
    at readableAddChunk (_stream_readable.js:165:9)
    at Socket.Readable.push (_stream_readable.js:127:10)
```

After modification the stack trace is like so:

```javascript
error: function nqow() does not exist
    at Connection.parseE (/Users/lalit/sandbox/pg-better-errors/node_modules/pg.js/lib/connection.js:534:11)
    at Connection.parseMessage (/Users/lalit/sandbox/pg-better-errors/node_modules/pg.js/lib/connection.js:361:17)
    at Socket.<anonymous> (/Users/lalit/sandbox/pg-better-errors/node_modules/pg.js/lib/connection.js:105:22)
    at Socket.emit (events.js:95:17)
    at Socket.<anonymous> (_stream_readable.js:764:14)
    at Socket.emit (events.js:92:17)
    at emitReadable_ (_stream_readable.js:426:10)
    at emitReadable (_stream_readable.js:422:5)
    at readableAddChunk (_stream_readable.js:165:9)
    at Socket.Readable.push (_stream_readable.js:127:10)
    at new Query (/Users/lalit/sandbox/pg-better-errors/node_modules/pg.js/lib/query.js:32:24)
    at Client.query (/Users/lalit/sandbox/pg-better-errors/node_modules/pg.js/lib/client.js:333:6)
    at /Users/lalit/sandbox/pg-better-errors/index.js:8:10
    at null.<anonymous> (/Users/lalit/sandbox/pg-better-errors/node_modules/pg.js/lib/client.js:154:7)
    at g (events.js:180:16)
    at emit (events.js:117:20)
    at Socket.<anonymous> (/Users/lalit/sandbox/pg-better-errors/node_modules/pg.js/lib/connection.js:109:12)
    at Socket.emit (events.js:95:17)
    at Socket.<anonymous> (_stream_readable.js:764:14)
    at Socket.emit (events.js:92:17)
```

Notice the line (which tells you where the query was executed)

```javascript
    at /Users/lalit/sandbox/pg-better-errors/index.js:8:10
```

There are probably better ways to handle this I'm not too familiar with the error capturing/prepareStackTrace stuff.