### PR TITLE
Remove NAN as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "buffer-writer": "1.0.0",
     "generic-pool": "2.1.1",
-    "nan": "1.3.0",
     "packet-reader": "0.2.0",
     "pg-connection-string": "0.1.3",
     "pg-types": "1.6.0",


### PR DESCRIPTION
NAN is no longer required directly because
[pg-native](https://github.com/brianc/node-pg-native.git) requires it.
