### PR TITLE
Add sehrope/node-pg-db to Extras in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ node-postgres is by design pretty light on abstractions.  These are some handy m
 - [CSNW/sql-bricks](https://github.com/CSNW/sql-bricks) - Transparent, Schemaless SQL Generation
 - [datalanche/node-pg-format](https://github.com/datalanche/node-pg-format) - Safely and easily create dynamic SQL queries with this Node implementation of [PostgreSQL format()](http://www.postgresql.org/docs/9.3/static/functions-string.html#FUNCTIONS-STRING-FORMAT).
 - [iceddev/pg-transact](https://github.com/iceddev/pg-transact) - A nicer API on node-postgres transactions
+- [sehrope/node-pg-db](https://github.com/sehrope/node-pg-db) - Simpler interface, named parameter support, transaction management and event hooks.
 
 ## License
 


### PR DESCRIPTION
[`pg-db`](https://github.com/sehrope/node-pg-db) is a module I put together that adds a bunch of things atop node-postgres:
- Simple interface (ex: `db.query(sql, [params], function(err, rows))` or `db.queryOne(sql, [params], function(err, row))`)
- Named parameter support (ex: `... WHERE foo = :foo` instead of `... WHERE foo = $1`)
- Transactions (more info below)
- Event hooks (ex: log all SQL that's executed or execute non-transactional hook on commit/rollback)

Transactions are implemented using domains. Database interactions automatically take part in an ongoing transaction so there's no need to manually pass a `Client` object around. Here's an example: https://github.com/sehrope/node-pg-db-examples/blob/master/src/tx.coffee
