### PR TITLE
Use svg version of travis build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #node-postgres
 
-[![Build Status](https://secure.travis-ci.org/brianc/node-postgres.png?branch=master)](http://travis-ci.org/brianc/node-postgres)
+[![Build Status](https://secure.travis-ci.org/brianc/node-postgres.svg?branch=master)](http://travis-ci.org/brianc/node-postgres)
 
 PostgreSQL client for node.js.  Pure JavaScript and optional native libpq bindings.
 


### PR DESCRIPTION
Hey!

Just a minor PR here. I noticed you are using the png version of the travis build status badge. They actually also offer a svg version which is nicer looking, especially on retina screens.

So if you want, this PR changes the badge to the svg version instead of png.

Thanks for making this available and have a great day!