### PR TITLE
added the option to connect without specifying a database (noDatabase option)

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -12,7 +12,9 @@ var val = function(key, config, envVar) {
     envVar = process.env[ envVar ];
   }
 
-  return config[key] ||
+  // let the user connect without selecting a database
+  if (key === 'database' && config.noDatabase) return '';
+  else return config[key] ||
     envVar ||
     defaults[key];
 };


### PR DESCRIPTION
Added the `noDatabase` option to the connection configuration object. It makes it possible to connect to a postgres server without specifying which database to use. This doesn't change the existing API and should not introduce any issues with backward compatibility.

I am working on a db migration tool for an orm and it would be very useful for the automated setup and testing of databases to be able to create a database without the need to use an existing one.

usage:

````
var client = new pg.Client({
      user: 'someUser'
    , password: 'somePassword'
    , host: 'localhost'
    , noDatabase: true
});
````

See also #437 
