### PR TITLE
Add test for using intervals as parameter in prepared statements

### DIFF
--- a/test/integration/client/prepared-statement-tests.js
+++ b/test/integration/client/prepared-statement-tests.js
@@ -17,6 +17,32 @@ test("simple, unnamed prepared statement", function(){
   });
 });
 
+test("use interval in prepared statement", function(){
+  var client = helper.client();
+
+  client.query('SELECT interval \'15 days 2 months 3 years 6:12:05\' as interval', assert.success(function(result) {
+      var interval = result.rows[0].interval;
+
+      var query = client.query({
+        text: 'select cast($1 as interval) as interval',
+        values: [interval]
+      });
+
+      assert.emits(query, 'row', function(row) {
+        assert.equal(row.interval.seconds, 5);
+        assert.equal(row.interval.minutes, 12);
+        assert.equal(row.interval.hours, 6);
+        assert.equal(row.interval.days, 15);
+        assert.equal(row.interval.months, 2);
+        assert.equal(row.interval.years, 3);
+      });
+
+      assert.emits(query, 'end', function() {
+        client.end();
+      });
+  }));
+});
+
 test("named prepared statement", function() {
 
   var client = helper.client();


### PR DESCRIPTION
Currently node-postgres returns intervals in the form of ```{days: 12, hours: 2}```. Passing the same object back into a prepared statement causes strange behaviour and is normally not correct.

This just adds a test that will fail. The actual fix is here: https://github.com/brianc/node-pg-types/pull/16
