### PR TITLE
Fix result.rowCount being a string instead of a number via native bindings.

### DIFF
--- a/lib/native/result.js
+++ b/lib/native/result.js
@@ -7,7 +7,7 @@ var NativeResult = module.exports = function(pq) {
 
 NativeResult.prototype.addCommandComplete = function(pq) {
   this.command = pq.cmdStatus().split(' ')[0];
-  this.rowCount = pq.cmdTuples();
+  this.rowCount = parseInt(pq.cmdTuples(), 10);
   var nfields = pq.nfields();
   if(nfields < 1) return;
 
@@ -19,4 +19,3 @@ NativeResult.prototype.addCommandComplete = function(pq) {
     });
   }
 };
-

--- a/test/native/callback-api-tests.js
+++ b/test/native/callback-api-tests.js
@@ -8,6 +8,7 @@ test('fires callback with results', function() {
   client.query('SELECT 1 as num', assert.calls(function(err, result) {
     assert.isNull(err);
     assert.equal(result.rows[0].num, 1);
+    assert.equal(result.rowCount, 1);
     client.query('SELECT * FROM person WHERE name = $1', ['Brian'], assert.calls(function(err, result) {
       assert.isNull(err);
       assert.equal(result.rows[0].name, 'Brian');

--- a/test/native/callback-api-tests.js
+++ b/test/native/callback-api-tests.js
@@ -8,7 +8,7 @@ test('fires callback with results', function() {
   client.query('SELECT 1 as num', assert.calls(function(err, result) {
     assert.isNull(err);
     assert.equal(result.rows[0].num, 1);
-    assert.equal(result.rowCount, 1);
+    assert.strictEqual(result.rowCount, 1);
     client.query('SELECT * FROM person WHERE name = $1', ['Brian'], assert.calls(function(err, result) {
       assert.isNull(err);
       assert.equal(result.rows[0].name, 'Brian');


### PR DESCRIPTION
Btw, once you drop support for node 0.8 you can drop the `parseInt` radix, as it should default to 10.