### PR TITLE
Updated Test Environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.11"
+  - "0.12"
+  - "iojs"
 before_script:
   - node script/create-test-tables.js pg://postgres@127.0.0.1:5432/postgres
 env:


### PR DESCRIPTION
* Replaced NodeJS 0.11 with 0.12, because people only care about 0.10 and 0.12 today;
* Added test support for the most recent stable version of IO.js