### PR TITLE
feat(757) support returning an array of results

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -10,6 +10,7 @@ var Query = function(config, values, callback) {
 
   config = utils.normalizeQueryConfig(config, values, callback);
 
+  this.multiResult = config.multiResult;
   this.text = config.text;
   this.values = config.values;
   this.rows = config.rows;
@@ -23,7 +24,10 @@ var Query = function(config, values, callback) {
   if(process.domain && config.callback) {
     this.callback = process.domain.bind(config.callback);
   }
-  this._result = new Result(config.rowMode, config.types);
+  this.rowMode = config.rowMode;
+  // the active result in muti result mode
+  this._result = new Result(this.rowMode);
+  this._resultsArray = [];
   this.isPreparedStatement = false;
   this._canceledDueToError = false;
   EventEmitter.call(this);
@@ -70,6 +74,11 @@ Query.prototype.handleCommandComplete = function(msg, con) {
   if(this.isPreparedStatement) {
     con.sync();
   }
+  // new result for next query
+  if(this.multiResult) {
+    this._resultsArray.push(this._result);
+    this._result = new Result(this.rowMode);
+  }
 };
 
 Query.prototype.handleReadyForQuery = function() {
@@ -77,7 +86,7 @@ Query.prototype.handleReadyForQuery = function() {
     return this.handleError(this._canceledDueToError);
   }
   if(this.callback) {
-    this.callback(null, this._result);
+    this.callback(null, this.multiResult ? this._resultsArray : this._result);
   }
   this.emit('end', this._result);
 };

--- a/test/integration/client/api-tests.js
+++ b/test/integration/client/api-tests.js
@@ -165,3 +165,26 @@ test('null and undefined are both inserted as NULL', function() {
     }))
   }))
 })
+
+test('can configure multiResult option', function() {
+  pg.connect(helper.config, assert.calls(function(err, client, done) {
+    assert.isNull(err);
+    test('result is not an array by default', function() {
+      client.query({ text: 'select \'hi\' as val; select \'bye\' as val;' }, assert.calls(function(err, result) {
+        assert.isNull(err);
+        assert.equal(result instanceof Array, false);
+        done();
+      }))
+    })
+    test('result is an array when asked', function() {
+      client.query({ text: 'select \'hi\' as val; select \'bye\' as val;', multiResult: true }, assert.calls(function(err, results) {
+        assert.isNull(err);
+        assert.equal(results instanceof Array, true);
+        assert.equal(results.length, 2);
+        assert.equal(results[0].rows[0].val, 'hi');
+        assert.equal(results[1].rows[0].val, 'bye');
+        done();
+      }))
+    })
+  }))
+})


### PR DESCRIPTION
Attempt at implementing #757.

Support for returning multiple results (array) if the query has more than one. You have to tell the query that you expect an array returned using an option. E.g.
client.query({text: query, rowMode: 'array', multiResult: true}, (err, results) => {
  // results is an Array of Result
});

I know this has no tests, could you point me in the right direction on creating tests for the project? Also this might be the completely wrong way to achieve this, let me know your thoughts, I'm no Postgres-anything expert.

Cheers