### PR TITLE
Add warning on long query names

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -199,6 +199,11 @@ Connection.prototype.parse = function(query, more) {
 
   //normalize missing query names to allow for null
   query.name = query.name || '';
+  if (query.name.length > 63) {
+    console.error('Warning! Postgres only supports 63 characters for query names.');
+    console.error('You supplied', query.name, '(', query.name.length, ')');
+    console.error('This can cause conflicts and silent errors executing queries');
+  }
   //normalize null type array
   query.types = query.types || [];
   var len = query.types.length;

--- a/lib/native/query.js
+++ b/lib/native/query.js
@@ -85,6 +85,11 @@ NativeQuery.prototype.submit = function(client) {
 
   //named query
   if(this.name) {
+    if (this.name.length > 63) {
+      console.error('Warning! Postgres only supports 63 characters for query names.');
+      console.error('You supplied', this.name, '(', this.name.length, ')');
+      console.error('This can cause conflicts and silent errors executing queries');
+    }
     var values = (this.values||[]).map(utils.prepareValue);
 
     //check if the client has already executed this named query

--- a/test/integration/gh-issues/787-tests.js
+++ b/test/integration/gh-issues/787-tests.js
@@ -1,0 +1,11 @@
+var helper = require(__dirname + '/../test-helper');
+
+helper.pg.connect(helper.config, function(err,client) {
+  var q = {
+    name: 'This is a super long query name just so I can test that an error message is properly spit out to console.error without throwing an exception or anything',
+    text: 'SELECT NOW()'
+  };
+  client.query(q, function() {
+    client.end();
+  });
+});


### PR DESCRIPTION
Postgres has a 63 character limit on query names.  To avoid potential footgunning of users we'll log to their stderr if they use a longer query name.

For reference: https://github.com/brianc/node-postgres/pull/772