### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "changelog": "npm i github-changes && ./node_modules/.bin/github-changes -o brianc -r node-postgres -d pulls -a -v",
     "test": "make test-all connectionString=postgres://postgres@localhost:5432/postgres"
   },
+  "license": "MIT",
   "engines": {
     "node": ">= 0.8.0"
   }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/