### PR TITLE
Connection Parameters optimization

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -12,7 +12,7 @@ var Connection = require(__dirname + '/connection');
 var Client = function(config) {
   EventEmitter.call(this);
 
-  this.connectionParameters = new ConnectionParameters(config);
+  this.connectionParameters = (config instanceof ConnectionParameters) ? config: new ConnectionParameters(config);
   this.user = this.connectionParameters.user;
   this.database = this.connectionParameters.database;
   this.port = this.connectionParameters.port;


### PR DESCRIPTION
For an app that executes millions of requests through a connection pool it is absolutely unnecessary to parse the connection every single time. If the client provides its own instance of `ConnectionParameters`, it should be used instead of parsing everything all over again, on each request.