### PR TITLE
Add reference to XeCycle/pg-template-tag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ node-postgres is by design pretty light on abstractions.  These are some handy m
 - [vitaly-t/pg-promise](https://github.com/vitaly-t/pg-promise) - Use node-postgres via [Promises/A+](https://promisesaplus.com/).
 - [pg-then](https://github.com/coderhaoxin/pg-then) A tiny wrapper of `pg` for promise api.
 - [acarl/pg-restify](https://github.com/acarl/pg-restify) - Creates a generic REST API for a postgres database using restify.
+- [XeCycle/pg-template-tag](https://github.com/XeCycle/pg-template-tag) - Write queries with ES6 tagged template literals, a "poor man's query builder".
 
 ## License
 


### PR DESCRIPTION
Dead simple and super flexible query builder.  No idea about its performance, however I have been using it without trouble for quite some time (long before publishing to GitHub).