### PR TITLE
Fix hanging client on empty prepared statement

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -113,6 +113,11 @@ Client.prototype.connect = function(callback) {
       self.activeQuery.handlePortalSuspended(con);
     });
 
+    //deletagate emptyQuery to active query
+    con.on('emptyQuery', function(msg) {
+      self.activeQuery.handleEmptyQuery(con);
+    });
+
     //delegate commandComplete to active query
     con.on('commandComplete', function(msg) {
       self.activeQuery.handleCommandComplete(msg, con);

--- a/lib/query.js
+++ b/lib/query.js
@@ -72,6 +72,15 @@ Query.prototype.handleCommandComplete = function(msg, con) {
   }
 };
 
+//if a named prepared statement is created with empty query text
+//the backend will send an emptyQuery message but *not* a command complete message
+//execution on the connection will hang until the backend receives a sync message
+Query.prototype.handleEmptyQuery = function(con) {
+  if (this.isPreparedStatement) {
+    con.sync();
+  }
+};
+
 Query.prototype.handleReadyForQuery = function() {
   if(this._canceledDueToError) {
     return this.handleError(this._canceledDueToError);

--- a/test/integration/gh-issues/882-tests.js
+++ b/test/integration/gh-issues/882-tests.js
@@ -1,0 +1,8 @@
+//client should not hang on an empty query
+var helper = require('../test-helper');
+var client = helper.client();
+client.query({ name: 'foo1', text: null});
+client.query({ name: 'foo2', text: '   ' });
+client.query({ name: 'foo3', text: '' }, function(err, res) {
+  client.end();
+});


### PR DESCRIPTION
The backend sends an `emptyQuery` message but no `commandComplete` or `errorResponse` message.  The connected client needs to send a `sync` message after receiving an `emptyQuery` message _on a prepared statement_.  Otherwise execution halts as both the backend and frontend are waiting for expected responses from one another.

fixes #822