### PR TITLE
Test that an active query is cancelled

### DIFF
--- a/test/integration/client/cancel-query-tests.js
+++ b/test/integration/client/cancel-query-tests.js
@@ -1,5 +1,20 @@
 var helper = require(__dirname+"/test-helper");
 
+test("cancellation of an active query", function() {
+  var client = helper.client();
+
+  var qry = "select pg_sleep(4)";
+  var query1 = client.query(qry);
+  client.cancel(client, query1);
+  var otherClient = helper.client();
+  activeQueries = "SELECT * FROM pg_stat_activity WHERE query LIKE '%pg_sleep(4)%' AND query NOT LIKE '%pg_stat_activity%'";
+  otherClient.query(activeQueries, assert.calls(function(err, result) {
+    assert.equal(result.rows.length, 0);
+    otherClient.end();
+    client.end();
+  }));
+});
+
 //before running this test make sure you run the script create-test-tables
 test("cancellation of a query", function() {
 
@@ -13,11 +28,11 @@ test("cancellation of a query", function() {
 
   var query1 = client.query(qry);
   query1.on('row', function(row) {
-    throw new Error('Should not emit a row')
+    throw new Error('Should not emit a row');
   });
   var query2 = client.query(qry);
   query2.on('row', function(row) {
-    throw new Error('Should not emit a row')
+    throw new Error('Should not emit a row');
   });
   var query3 = client.query(qry);
   query3.on('row', function(row) {
@@ -25,7 +40,7 @@ test("cancellation of a query", function() {
   });
   var query4 = client.query(qry);
   query4.on('row', function(row) {
-    throw new Error('Should not emit a row')
+    throw new Error('Should not emit a row');
   });
 
   helper.pg.cancel(helper.config, client, query1);

--- a/test/integration/test-helper.js
+++ b/test/integration/test-helper.js
@@ -24,4 +24,3 @@ helper.versionGTE = function(client, versionString, callback) {
 
 //export parent helper stuffs
 module.exports = helper;
-

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -248,5 +248,3 @@ module.exports = {
   setTimezoneOffset: setTimezoneOffset,
   resetTimezoneOffset: resetTimezoneOffset
 };
-
-


### PR DESCRIPTION
Test first makes a query to the active Postgres database, then issues a cancel
request, and verifies that the query was indeed canceled.

It looks like the test currently in that file only tests that the query is spliced from the queue.