### PR TITLE
Question: support arrays for JSON columns

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,6 +35,9 @@ var prepareValue = function(val, seen) {
     return dateToString(val);
   }
   if(Array.isArray(val)) {
+    if (val.hasOwnProperty('isJSON') && !val.propertyIsEnumerable('isJSON')) {
+      return JSON.stringify(val);
+    }
     return arrayString(val);
   }
   if(val === null || typeof val === 'undefined') {


### PR DESCRIPTION
Currently when a JSON array is inserted into a JSON column it is transformed into a String array suitable for an Array column.

A workaround consists of serialising the JSON array into a string before we insert its value into the database.
Reviewing the 'toPostgresql' function supported for object serialisation it looked like maybe we could do something here as well.

This PR defines an none enumerable property 'isJSON' to serialise the array as a String suitable for a JSON array.
Let me know if that is a good way to proceed.

We could also add a configuration parameter to the client that would assume that all arrays are targeting JSON columns.