### PR TITLE
Don't emit error events parsed out of data stream

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -23,8 +23,13 @@ var pools = {
       log: clientConfig.poolLog || defaults.poolLog,
       create: function(cb) {
         var client = new pools.Client(clientConfig);
+        // Ignore errors on pooled clients until they are connected.
+        client.on('error', Function.prototype);
         client.connect(function(err) {
           if(err) return cb(err, null);
+
+          // Remove the noop error handler after a connection has been established.
+          client.removeListener('error', Function.prototype);
 
           //handle connected client background errors by emitting event
           //via the pg object and then removing errored client from the pool

--- a/test/unit/pool/basic-tests.js
+++ b/test/unit/pool/basic-tests.js
@@ -121,9 +121,10 @@ test('pool with connection error on connection', function() {
         process.nextTick(function() {
           cb(new Error('Could not connect'));
         });
-      }
+      },
+      on: Function.prototype
     };
-  }
+  };
   test('two parameters', function() {
     var p = pools.getOrCreate(poolId++);
     p.connect(assert.calls(function(err, client) {


### PR DESCRIPTION
Messages with the name `error` will also cause the `error` event to be raised on the stream. Thus, emitting the event here again will only cause problems.
Fixed #746 