### PR TITLE
Add lazy mode for row parsing

### DIFF
--- a/lib/native/index.js
+++ b/lib/native/index.js
@@ -112,6 +112,7 @@ Client.prototype.query = function(config, values, callback) {
     query.name = config.name;
     query.callback = config.callback;
     query._arrayMode = config.rowMode == 'array';
+    query._lazyMode = config.rowMode == 'lazy';
   }
 
   //support query({...}, function() {}) style calls

--- a/lib/native/query.js
+++ b/lib/native/query.js
@@ -12,6 +12,7 @@ var NativeQuery = module.exports = function(native) {
   this.callback = null;
   this.state = 'new';
   this._arrayMode = false;
+  this._lazyMode = false;
 
   //if the 'row' event is listened for
   //then emit them as they come in
@@ -47,9 +48,11 @@ NativeQuery.prototype.submit = function(client) {
   this.state = 'running';
   var self = this;
   client.native.arrayMode = this._arrayMode;
+  client.native.lazyMode = this._lazyMode;
 
   var after = function(err, rows) {
     client.native.arrayMode = false;
+    client.native.lazyMode = false;
     setImmediate(function() {
       self.emit('_done');
     });

--- a/lib/result.js
+++ b/lib/result.js
@@ -12,6 +12,7 @@ var Result = function(rowMode) {
   this._parsers = [];
   this.RowCtor = null;
   this.rowAsArray = rowMode == "array";
+  this.lazyParsingRow = rowMode == "lazy";
   if(this.rowAsArray) {
     this.parseRow = this._parseRowAsArray;
   }
@@ -84,18 +85,37 @@ Result.prototype.addFields = function(fieldDescriptions) {
     this.fields = [];
     this._parsers = [];
   }
-  var ctorBody = "";
   for(var i = 0; i < fieldDescriptions.length; i++) {
     var desc = fieldDescriptions[i];
     this.fields.push(desc);
     var parser = this._getTypeParser(desc.dataTypeID, desc.format || 'text');
     this._parsers.push(parser);
-    //this is some craziness to compile the row result parsing
-    //results in ~60% speedup on large query result sets
-    ctorBody += inlineParser(desc.name, i);
   }
   if(!this.rowAsArray) {
-    this.RowCtor = Function("parsers", "rowData", ctorBody);
+    if (this.lazyParsingRow) {
+      ctorBody = "\nthis._parsers = parsers;";
+      var rowPrototypeFunctions = [];
+      for(i = 0; i < fieldDescriptions.length; i++) {
+        var fieldName = fieldDescriptions[i].name.replace("'", "\\'");
+        ctorBody += "\nthis['" + fieldName + "'] = rowData[" + i + "]";
+        rowPrototypeFunctions.push({
+          name: fieldName,
+          body: "return this['" + fieldName + "'] == null ? null : this._parsers[" + i + "](this['" + fieldName + "']);"
+        });
+      }
+      this.RowCtor = Function("parsers", "rowData", ctorBody);
+      for(i = 0; i < rowPrototypeFunctions.length; i++) {
+        this.RowCtor.prototype["parse_" + rowPrototypeFunctions[i].name] = Function(rowPrototypeFunctions[i].body);
+      }
+    } else {
+      ctorBody = "";
+      for(i = 0; i < fieldDescriptions.length; i++) {
+        //this is some craziness to compile the row result parsing
+        //results in ~60% speedup on large query result sets
+        ctorBody += inlineParser(fieldDescriptions[i].name, i);
+      }
+      this.RowCtor = Function("parsers", "rowData", ctorBody);
+    }
   }
 };
 

--- a/test/integration/client/results-lazy-tests.js
+++ b/test/integration/client/results-lazy-tests.js
@@ -1,0 +1,42 @@
+var util = require('util');
+var helper = require('./test-helper');
+
+var Client = helper.Client;
+
+var conInfo = helper.config;
+
+test('returns results as lazy parsing object', function() {
+  var client = new Client(conInfo);
+  var checkRow = function(row) {
+    if (helper.config.binary) {
+      assert.strictEqual(Object.getPrototypeOf(row['value1']), Buffer.prototype);
+      assert.strictEqual(Object.getPrototypeOf(row['value2']), Buffer.prototype);
+      assert.strictEqual(Object.getPrototypeOf(row['value3']), Buffer.prototype);
+      assert.strictEqual(row['value4'], null);
+    } else {
+      assert.strictEqual(typeof row['value1'], 'string');
+      assert.strictEqual(row['value2'], '1');
+      assert.strictEqual(row['value3'], 'hai');
+      assert.strictEqual(row['value4'], null);
+    }
+    assert.equal(row.parse_value1().getFullYear(), new Date().getFullYear());
+    assert.strictEqual(row.parse_value2(), 1);
+    assert.strictEqual(row.parse_value3(), 'hai');
+    assert.strictEqual(row.parse_value4(), null);
+  }
+  client.connect(assert.success(function() {
+    var config = {
+      text: 'SELECT NOW() as value1, 1::int as value2, $1::text as value3, null as value4',
+      values: ['hai'],
+      rowMode: 'lazy'
+    };
+    var query = client.query(config, assert.success(function(result) {
+      assert.equal(result.rows.length, 1);
+      checkRow(result.rows[0]);
+      client.end();
+    }));
+    assert.emits(query, 'row', function(row) {
+      checkRow(row);
+    });
+  }));
+});


### PR DESCRIPTION
In lazy mode, raw values will be used and parsing function need to be called explicitly.
For example:
```javascript
function processRow(row) {
  return {
    name: row.obj_name, //Raw value
    createdTime: row.parse_obj_created_time() //Return the parsed value
  }
}
```
This would be useful when we want to access raw value from database, and also when we only want to access a subset of values. For example, suppose we have the following query result


obj_id | obj_name | obj_created_time | property_name 
-------- | ------------- | ----------------------- | ---------------
 1        | Object 1   |  2015-01-01         | Prop A
 1        | Object 1   |  2015-01-01         | Prop B
 1        | Object 1   |  2015-01-01         | Prop C

Ideally, we only need `obj_name` and `obj_created_time` of the first row and we don't need the parsing of `obj_created_time` to be run for more than once.

This PR will need a new version of pg-native (https://github.com/brianc/node-pg-native/pull/26)