### PR TITLE
Allow passwords to be provided using a function

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -63,16 +63,27 @@ Client.prototype.connect = function(callback) {
 
   function checkPgPass(cb) {
     return function(msg) {
-      if (null !== self.password) {
+      if (self.password !== undefined && self.password !== null) {
         cb(msg);
-      } else {
-        pgPass(self.connectionParameters, function(pass){
-          if (undefined !== pass) {
-            self.connectionParameters.password = self.password = pass;
-          }
-          cb(msg);
-        });
+        return;
       }
+      self.connectionParameters.getPassword(function (err, pw) {
+        if (err) {
+          self.emit('error', err);
+          return;
+        }
+        self.password = pw;
+        if (null !== self.password) {
+          cb(msg);
+        } else {
+          pgPass(self.connectionParameters, function(pass){
+            if (undefined !== pass) {
+              self.password = pass;
+            }
+            cb(msg);
+          });
+        }
+      });
     };
   }
 

--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -1,5 +1,6 @@
 var url = require('url');
 var dns = require('dns');
+var EventEmitter = require('events').EventEmitter;
 
 var defaults = require(__dirname + '/defaults');
 
@@ -39,12 +40,30 @@ var ConnectionParameters = function(config) {
   this.database = val('database', config);
   this.port = parseInt(val('port', config), 10);
   this.host = val('host', config);
-  this.password = val('password', config);
   this.binary = val('binary', config);
   this.ssl = config.ssl || useSsl();
   this.client_encoding = val("client_encoding", config);
   //a domain socket begins with '/'
   this.isDomainSocket = (!(this.host||'').indexOf('/'));
+
+  if (typeof(config.password) === 'function') {
+    this.pwEmitter = new EventEmitter();
+    var self = this;
+    config.password(this, function (err, pw) {
+      if (!err)
+        self.password = pw;
+      else if (err instanceof Error)
+        self.password = err;
+      else
+        self.password = new Error('Password generator function failed: ' + err);
+
+      var pwEmitter = self.pwEmitter;
+      delete (self.pwEmitter);
+      pwEmitter.emit('done', err);
+    });
+  } else {
+    this.password = val('password', config);
+  }
 
   this.application_name = val('application_name', config, 'PGAPPNAME');
   this.fallback_application_name = val('fallback_application_name', config, false);
@@ -57,7 +76,37 @@ var add = function(params, config, paramName) {
   }
 };
 
+ConnectionParameters.prototype.getPassword = function(cb) {
+  if (this.pwEmitter) {
+    var self = this;
+    this.pwEmitter.on('done', function (err) {
+      cb(err, self.password);
+    });
+    return;
+  }
+  if (this.password instanceof Error) {
+    cb(this.password);
+  } else {
+    cb(null, this.password);
+  }
+};
+
 ConnectionParameters.prototype.getLibpqConnectionString = function(cb) {
+  if (this.pwEmitter) {
+    var self = this;
+    this.pwEmitter.on('done', function (err) {
+      if (err) {
+        cb(err);
+        return;
+      }
+      self.getLibpqConnectionString(cb);
+    });
+    return;
+  }
+  if (this.password instanceof Error) {
+    cb(this.password);
+    return;
+  }
   var params = [];
   add(params, this, 'user');
   add(params, this, 'password');

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -173,6 +173,7 @@ Connection.prototype.cancel = function(processID, secretKey) {
 Connection.prototype.password = function(password) {
   //0x70 = 'p'
   this._send(0x70, this.writer.addCString(password));
+  this.emit('sentPassword');
 };
 
 Connection.prototype._send = function(code, more) {

--- a/test/unit/client/cleartext-password-tests.js
+++ b/test/unit/client/cleartext-password-tests.js
@@ -10,7 +10,12 @@ test('cleartext password authentication', function(){
   var client = createClient();
   client.password = "!";
   client.connection.stream.packets = [];
+  var sent = false;
+  client.connection.on('sentPassword', function() {
+    sent = true;
+  });
   client.connection.emit('authenticationCleartextPassword');
+  assert.ok(sent);
   test('responds with password', function() {
     var packets = client.connection.stream.packets;
     assert.lengthIs(packets, 1);

--- a/test/unit/client/configuration-tests.js
+++ b/test/unit/client/configuration-tests.js
@@ -30,12 +30,37 @@ test('client settings', function() {
     assert.equal(client.password, password);
   });
 
+  test('password function', function() {
+    var user = 'brian';
+    var database = 'pgjstest';
+    var password = function(params, cb) {
+      cb(null, 'boom');
+    };
+    var client = createClient({
+      user: user,
+      database: database,
+      port: 321,
+      password: password
+    });
+
+    assert.equal(client.user, user);
+    assert.equal(client.database, database);
+    assert.equal(client.port, 321);
+    var sent = false;
+    client.connection.on('sentPassword', function() {
+      sent = true;
+    });
+    client.connection.emit('authenticationCleartextPassword');
+    assert.ok(sent);
+    assert.equal(client.password, 'boom');
+  });
+
 });
 
 test('initializing from a config string', function() {
 
   test('uses the correct values from the config string', function() {
-    var client = new Client("postgres://brian:pass@host1:333/databasename")
+    var client = new Client("postgres://brian:pass@host1:333/databasename");
     assert.equal(client.user, 'brian');
     assert.equal(client.password, "pass");
     assert.equal(client.host, "host1");

--- a/test/unit/client/md5-password-tests.js
+++ b/test/unit/client/md5-password-tests.js
@@ -4,8 +4,15 @@ test('md5 authentication', function() {
   var client = createClient();
   client.password = "!";
   var salt = Buffer([1, 2, 3, 4]);
+
+  var sent = false;
+  client.connection.on('sentPassword', function() {
+    sent = true;
+  });
+  client.connection.stream.packets = [];
   client.connection.emit('authenticationMD5Password', {salt: salt});
 
+  assert.ok(sent);
   test('responds', function() {
     assert.lengthIs(client.connection.stream.packets, 1);
     test('should have correct encrypted data', function() {
@@ -17,5 +24,4 @@ test('md5 authentication', function() {
                         .addCString(password).join(true,'p'));
     });
   });
-
 });

--- a/test/unit/client/test-helper.js
+++ b/test/unit/client/test-helper.js
@@ -1,6 +1,6 @@
 var helper = require(__dirname+'/../test-helper');
 var Connection = require(__dirname + '/../../../lib/connection');
-var makeClient = function() {
+var makeClient = function(config) {
   var connection = new Connection({stream: "no"});
   connection.startup = function() {};
   connection.connect = function() {};
@@ -8,7 +8,11 @@ var makeClient = function() {
     this.queries.push(text);
   };
   connection.queries = [];
-  var client = new Client({connection: connection});
+  config = config || {};
+  if (typeof(config) === 'object')
+    config.connection = connection;
+  var client = new Client(config);
+  client.connection = connection;
   client.connect();
   client.connection.emit('connect');
   return client;

--- a/test/unit/connection-parameters/creation-tests.js
+++ b/test/unit/connection-parameters/creation-tests.js
@@ -47,6 +47,27 @@ test('ConnectionParameters initializing from config', function() {
   assert.ok(subject.isDomainSocket === false);
 });
 
+test('ConnectionParameters initializing from config with password function', function() {
+  var config = {
+    user: 'brian',
+    database: 'home',
+    port: 7777,
+    password: function (params, cb) {
+      cb(null, 'pizza');
+    },
+    binary: true,
+    encoding: 'utf8',
+    host: 'yo',
+    ssl: {
+      asdf: 'blah'
+    }
+  };
+  var subject = new ConnectionParameters(config);
+  config.password = 'pizza';
+  compare(subject, config, 'config');
+  assert.ok(subject.isDomainSocket === false);
+});
+
 test('escape spaces if present', function() {
   subject = new ConnectionParameters('postgres://localhost/post gres');
   assert.equal(subject.database, 'post gres');

--- a/test/unit/test-helper.js
+++ b/test/unit/test-helper.js
@@ -17,13 +17,17 @@ p.write = function(packet) {
 
 p.writable = true;
 
-createClient = function() {
+createClient = function(config) {
   var stream = new MemoryStream();
   stream.readyState = "open";
-  var client = new Client({
-    connection: new Connection({stream: stream})
-  });
+  var connection = new Connection({stream: stream});
+  config = config || {};
+  if (typeof(config) === 'object')
+    config.connection = connection;
+  var client = new Client(config);
+  client.connection = connection;
   client.connect();
+  client.connection.emit('connect');
   return client;
 };
 


### PR DESCRIPTION
This patch allows the `password` parameter, when given in a connection settings object, to be a function instead of a string. Example:

```js
var pg = require('pg');
var fs = require('fs');
var connOpts = {
  host: 'somehost',
  database: 'test',
  user: 'test',
  password: getPassword
};
pg.connect(connOpts, function (err, client, done) {
  ...
});

function getPassword(params, cb) {
  fs.readFile('some_pw_file', function(err, data) {
    if (err)
      cb(err);
    else
      cb(null, data.toString());
  });
}
```

This enables applications to provide their own mechanism for reading in (eg from a disk file) or calculating a password at the time of connection rather than in advance before setting up a pool.

Note that this works fine with pools, because `JSON.stringify()` on an object with a function-type member simply skips the function in its output.

I've also added tests for this feature, and amended a few old tests to make sure the code I changed still works.

The reason I personally want this is to be able to use one-time passwords with a postgres server, which have to be different each time you start a new connection (on the postgres side this is implemented by using LDAP auth, and the LDAP server supports the one-time password scheme), but it could also be useful:
 * in a situation where you want to change the password for a user without having to restart your application (it would always read the latest one), or
 * where you're not sure when/if you will use the postgres connection and you want to delay getting the password until you actually need it.

Let me know what you think.