### PR TITLE
Support ending single pool

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,27 +17,37 @@ var PG = function(clientConstructor) {
 
 util.inherits(PG, EventEmitter);
 
-PG.prototype.end = function() {
+PG.prototype.end = function(config) {
   var self = this;
-  var keys = Object.keys(self.pools.all);
-  var count = keys.length;
-  if(count === 0) {
-    self.emit('end');
+  var pool;
+  if (config) {
+    pool = self.pools.get(config);
+    if (pool) pool.end();
   } else {
-    keys.forEach(function(key) {
-      var pool = self.pools.all[key];
-      delete self.pools.all[key];
-      pool.drain(function() {
-        pool.destroyAllNow(function() {
-          count--;
-          if(count === 0) {
-            self.emit('end');
-          }
-        });
-      });
+    forEachOf(self.pools.all, function (pool, name, callback) {
+      pool.end(callback);
+    }, function () {
+      self.emit('end');
     });
   }
 };
+
+function forEachOf(object, iterator, callback) {
+  var keys = Object.keys(object);
+  var count = keys.length;
+  if (count === 0) {
+    callback();
+  } else {
+    keys.forEach(function (key) {
+      iterator(object[key], key, function () {
+        count--;
+        if (count === 0) {
+          callback();
+        }
+      });
+    });
+  }
+}
 
 
 PG.prototype.connect = function(config, callback) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -8,6 +8,10 @@ var pools = {
   all: {},
   //reference to the client constructor - can override in tests or for require('pg').native
   Client: require(__dirname + '/client'),
+  get: function(clientConfig) {
+    var name = JSON.stringify(clientConfig || {});
+    return pools.all[name];
+  },
   getOrCreate: function(clientConfig) {
     clientConfig = clientConfig || {};
     var name = JSON.stringify(clientConfig);
@@ -81,6 +85,12 @@ var pools = {
             pool.release(client);
           }
         });
+      });
+    };
+    pool.end = function(cb) {
+      delete pools.all[name];
+      pool.drain(function() {
+        pool.destroyAllNow(cb);
       });
     };
     return pool;


### PR DESCRIPTION
Done with `pg.end(connString)`.

This is a draft pull request. Tell me what you think about API and/or code. Also it looks like to test this I'll need to add some sink magic to `ending-pool-tests.js`, I don't however have more than 1 config.