### PR TITLE
Require statements break Browserify compatibility

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4,10 +4,10 @@ var util = require('util');
 var pgPass = require('pgpass');
 var TypeOverrides = require('./type-overrides');
 
-var ConnectionParameters = require(__dirname + '/connection-parameters');
-var Query = require(__dirname + '/query');
-var defaults = require(__dirname + '/defaults');
-var Connection = require(__dirname + '/connection');
+var ConnectionParameters = require('./connection-parameters');
+var Query = require('./query');
+var defaults = require('./defaults');
+var Connection = require('./connection');
 
 var Client = function(config) {
   EventEmitter.call(this);

--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -1,7 +1,7 @@
 var url = require('url');
 var dns = require('dns');
 
-var defaults = require(__dirname + '/defaults');
+var defaults = require('./defaults');
 
 var val = function(key, config, envVar) {
   if (envVar === undefined) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,9 @@
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
-var Client = require(__dirname+'/client');
-var defaults =  require(__dirname + '/defaults');
-var pool = require(__dirname + '/pool');
-var Connection = require(__dirname + '/connection');
+var Client = require('./client');
+var defaults =  require('./defaults');
+var pool = require('./pool');
+var Connection = require('./connection');
 
 var PG = function(clientConstructor) {
   EventEmitter.call(this);

--- a/lib/native/index.js
+++ b/lib/native/index.js
@@ -5,7 +5,7 @@ var pkg = require('../../package.json');
 var assert = require('assert');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
-var ConnectionParameters = require(__dirname + '/../connection-parameters');
+var ConnectionParameters = require('../connection-parameters');
 
 var msg = 'Version >= ' + pkg.minNativeVersion + ' of pg-native required.';
 assert(semver.gte(Native.version, pkg.minNativeVersion), msg);

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,13 +1,13 @@
 var EventEmitter = require('events').EventEmitter;
 
-var defaults = require(__dirname + '/defaults');
+var defaults = require('./defaults');
 var genericPool = require('generic-pool');
 
 var pools = {
   //dictionary of all key:pool pairs
   all: {},
   //reference to the client constructor - can override in tests or for require('pg').native
-  Client: require(__dirname + '/client'),
+  Client: require('./client'),
   getOrCreate: function(clientConfig) {
     clientConfig = clientConfig || {};
     var name = JSON.stringify(clientConfig);

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,8 +1,8 @@
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
-var Result = require(__dirname + '/result');
-var utils = require(__dirname + '/utils');
+var Result = require('./result');
+var utils = require('./utils');
 
 var Query = function(config, values, callback) {
   // use of "new" optional


### PR DESCRIPTION
Using __dirname in require statements breaks compatibility with Browserify.

I've also submitted a related PR for pg-types (https://github.com/brianc/node-pg-types/pull/43).