### PR TITLE
Pass in connection string as property

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -35,7 +35,7 @@ var useSsl = function() {
 
 var ConnectionParameters = function(config) {
   config = typeof config == 'string' ? parse(config) :
-           typeof config.connection == 'string' ? parse(config.connection) :
+           typeof config == 'object' && typeof config.connection == 'string' ? parse(config.connection) :
            (config || {});
   this.user = val('user', config);
   this.database = val('database', config);

--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -34,7 +34,9 @@ var useSsl = function() {
 };
 
 var ConnectionParameters = function(config) {
-  config = typeof config == 'string' ? parse(config) : (config || {});
+  config = typeof config == 'string' ? parse(config) :
+           typeof config.connection == 'string' ? parse(config.connection) :
+           (config || {});
   this.user = val('user', config);
   this.database = val('database', config);
   this.port = parseInt(val('port', config), 10);

--- a/test/unit/client/configuration-tests.js
+++ b/test/unit/client/configuration-tests.js
@@ -42,6 +42,15 @@ test('initializing from a config string', function() {
     assert.equal(client.port, 333);
     assert.equal(client.database, "databasename");
   });
+  
+  test('uses the string in the `connection` property', function() {
+    var client = new Client({ connection: "postgres://brian:pass@host1:333/databasename" })
+    assert.equal(client.user, 'brian');
+    assert.equal(client.password, "pass");
+    assert.equal(client.host, "host1");
+    assert.equal(client.port, 333);
+    assert.equal(client.database, "databasename");
+  });
 
   test('uses the correct values from the config string with space in password', function() {
     var client = new Client("postgres://brian:pass word@host1:333/databasename")


### PR DESCRIPTION
Whereas, I would like to be able to configure some specific `pg` properties, yet at the same time also be able to use a connection string. Therefore I propose support for the following client configuration:
```js
{
  connection: 'postgres://brian:pass@host1:333/databasename',
  poolSize: 10
}
```

The connection string would override other properties (`user`, `port`, etc).