### PR TITLE
escapeLiteral handles more types of input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,6 @@ test-missing-native:
 	@echo "***Testing optional native install***"
 	@rm -rf node_modules/pg-native
 	@node test/native/missing-native.js
-	@npm install pg-native@1.4.0
-	@node test/native/missing-native.js
 	@rm -rf node_modules/pg-native
 
 node_modules/pg-native/index.js:

--- a/lib/client.js
+++ b/lib/client.js
@@ -277,11 +277,11 @@ Client.prototype.escapeLiteral = function(value) {
     The unit tests cover this behavior.
     */
     return value == true ? 'TRUE' : 'FALSE'; // jshint ignore:line
-  } else if (value instanceof Date){
+  } else if (value instanceof Date) {
     return utils.dateToString(value);
   } else if (value.constructor === Array) {
     return utils.arrayString(value);
-  } else if(typeof value === 'string' || value instanceof String){
+  } else if(typeof value === 'string' || value instanceof String) {
     // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
     var hasBackslash = false;
     var escaped = '\'';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "PostgreSQL client - pure javascript & libpq with the same API",
   "keywords": [
     "postgres",

--- a/test/unit/client/escape-tests.js
+++ b/test/unit/client/escape-tests.js
@@ -81,7 +81,7 @@ testLit('escapeLiteral: true Boolean object',
 testLit('escapeLiteral: false Boolean object',
         new Boolean(false), "FALSE");
 
-test('escapeLiteral: Date', function(){
+test('escapeLiteral: Date', function() {
   testDateHelper.setTimezoneOffset(420);
 
   var d = new Date(2015, 9, 27); // note: Javascript month range is 0 - 11  


### PR DESCRIPTION
I added functionality to escape more kinds of values instead of only just strings similar to the way other SQL libraries do it:
https://www.npmjs.com/package/mysql#escaping-query-values

I left the existing code for handling strings in place and now also handle null, undefined, numbers, booleans, and arrays. The only strange thing might be that if the value being escaped is not one of those types, I just pass it back.