### PR TITLE
Use connection configuration consistently in tests

### DIFF
--- a/test/integration/gh-issues/130-tests.js
+++ b/test/integration/gh-issues/130-tests.js
@@ -6,7 +6,11 @@ helper.pg.defaults.poolIdleTimeout = 1000;
 helper.pg.connect(helper.config, function(err,client) {
   client.query("SELECT pg_backend_pid()", function(err, result) {
     var pid = result.rows[0].pg_backend_pid;
-    exec('psql -c "select pg_terminate_backend('+pid+')" template1', assert.calls(function (error, stdout, stderr) {
+    var psql = 'psql';
+    if (helper.args.host) psql = psql+' -h '+helper.args.host;
+    if (helper.args.port) psql = psql+' -p '+helper.args.port;
+    if (helper.args.user) psql = psql+' -U '+helper.args.user;
+    exec(psql+' -c "select pg_terminate_backend('+pid+')" template1', assert.calls(function (error, stdout, stderr) {
         assert.isNull(error);
     }));
   });

--- a/test/integration/gh-issues/675-tests.js
+++ b/test/integration/gh-issues/675-tests.js
@@ -1,7 +1,7 @@
 var helper = require('../test-helper');
 var assert = require('assert');
 
-helper.pg.connect(function(err, client, done) {
+helper.pg.connect(helper.config, function(err, client, done) {
   if (err) throw err;
 
   var c = 'CREATE TEMP TABLE posts (body TEXT)';

--- a/test/integration/gh-issues/699-tests.js
+++ b/test/integration/gh-issues/699-tests.js
@@ -4,7 +4,7 @@ var copyFrom = require('pg-copy-streams').from;
 
 if(helper.args.native) return;
 
-helper.pg.connect(function (err, client, done) {
+helper.pg.connect(helper.config, function (err, client, done) {
   if (err) throw err;
 
   var c = 'CREATE TEMP TABLE employee (id integer, fname varchar(400), lname varchar(400))';


### PR DESCRIPTION
This fixes a few tests that ignore the provided connection parameters and try and connect to the default instance instead.