### PR TITLE
Support for defaults.connectionString

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -34,7 +34,13 @@ var useSsl = function() {
 };
 
 var ConnectionParameters = function(config) {
+  //if a string is passed, it is a raw connection string so we parse it into a config
   config = typeof config == 'string' ? parse(config) : (config || {});
+  //if the config has a connectionString defined, parse IT into the config we use
+  //this will override other default values with what is stored in connectionString
+  if(config.connectionString) {
+    config = parse(config.connectionString);
+  }
   this.user = val('user', config);
   this.database = val('database', config);
   this.port = parseInt(val('port', config), 10);

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -11,6 +11,11 @@ var defaults = module.exports = {
   //database user's password
   password: null,
 
+  // a Postgres connection string to be used instead of setting individual connection items
+  // NOTE:  Setting this value will cause it to override any other value (such as database or user) defined
+  // in the defaults object.
+  connectionString : undefined,
+
   //database port
   port: 5432,
 

--- a/test/unit/connection-parameters/creation-tests.js
+++ b/test/unit/connection-parameters/creation-tests.js
@@ -29,6 +29,25 @@ test('ConnectionParameters initializing from defaults', function() {
   assert.ok(subject.isDomainSocket === false);
 });
 
+test('ConnectionParameters initializing from defaults with connectionString set', function() {
+  var config = {
+    user     : 'brians-are-the-best',
+    database : 'scoobysnacks',
+    port     : 7777,
+    password : 'mypassword',
+    host     : 'foo.bar.net',
+    binary   : defaults.binary
+  };
+
+  var original_value = defaults.connectionString;
+  // Just changing this here doesn't actually work because it's no longer in scope when viewed inside of
+  // of ConnectionParameters() so we have to pass in the defaults explicitly to test it
+  defaults.connectionString = 'postgres://brians-are-the-best:mypassword@foo.bar.net:7777/scoobysnacks';
+  var subject = new ConnectionParameters(defaults);
+  defaults.connectionString = original_value;
+  compare(subject, config, 'defaults-connectionString');
+});
+
 test('ConnectionParameters initializing from config', function() {
   var config = {
     user: 'brian',


### PR DESCRIPTION
An attempt to resolve #384 

If a connectionString is provided in defaults it ignores anything else set by the defaults file and acts like the user passed in the connection String to the constructor.   I had considered parsing it and overlaying it on top of the 'defaults' file but felt this is probably 'more correct.'  If you disagree I will fix.  