### PR TITLE
Fix of pool leaking

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -25,7 +25,8 @@ var Client = function(config) {
 
   this.connection = c.connection || new Connection({
     stream: c.stream,
-    ssl: this.connectionParameters.ssl
+    ssl: this.connectionParameters.ssl,
+    heartbeat: this.connectionParameters.heartbeatInterval
   });
   this.queryQueue = [];
   this.binary = c.binary || defaults.binary;

--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -48,6 +48,8 @@ var ConnectionParameters = function(config) {
 
   this.application_name = val('application_name', config, 'PGAPPNAME');
   this.fallback_application_name = val('fallback_application_name', config, false);
+
+  this.heartbeatInterval = parseInt(val('heartbeat_interval', config), 10);
 };
 
 var add = function(params, config, paramName) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -58,7 +58,7 @@ Connection.prototype.connect = function(port, host) {
             clearInterval(self._heartbeatObject);
             self.emit('error', err);
           }
-        })
+        });
       }, self._heartbeatInterval);
     }
   });

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -26,6 +26,9 @@ var Connection = function(config) {
     headerSize: 1,
     lengthPadding: -4
   });
+  this._heartbeatEnable = !!config.heartbeat;
+  this._heartbeatInterval = Number(config.heartbeat);
+  this._heartbeatObject = null;
   var self = this;
   this.on('newListener', function(eventName) {
     if(eventName == 'message') {
@@ -48,6 +51,16 @@ Connection.prototype.connect = function(port, host) {
 
   this.stream.on('connect', function() {
     self.emit('connect');
+    if (self._heartbeatEnable) {
+      self._heartbeatObject = setInterval(function() {
+        self.stream.write('', function (err) {
+          if (err) {
+            clearInterval(self._heartbeatObject);
+            self.emit('error', err);
+          }
+        })
+      }, self._heartbeatInterval);
+    }
   });
 
   this.stream.on('error', function(error) {
@@ -56,6 +69,7 @@ Connection.prototype.connect = function(port, host) {
     if(self._ending && error.code == 'ECONNRESET') {
       return;
     }
+    clearInterval(self._heartbeatObject);
     self.emit('error', error);
   });
 
@@ -63,6 +77,7 @@ Connection.prototype.connect = function(port, host) {
     // NOTE: node-0.10 emits both 'end' and 'close'
     //       for streams closed by the peer, while
     //       node-0.8 only emits 'close'
+    clearInterval(self._heartbeatObject);
     self.emit('end');
   });
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -41,7 +41,11 @@ var defaults = module.exports = {
   ssl: false,
 
   application_name : undefined,
-  fallback_application_name: undefined
+  fallback_application_name: undefined,
+
+  //heartbeat interval to check, that socket is alive. if 0 - heartbeat is disabled (for backward capability).
+  //else - timeout in ms.
+  heartbeat_interval: 0
 };
 
 //parse int8 so you can get your count values as actual numbers


### PR DESCRIPTION
There is some bug with connection pool. 
To reproduce it - you need connect to postgresql, start request and kill db process by `kill -9`. Client will not be free on any time. 

To stop this, we can add heartbeat to net.Socket on pg.Client. To force backward capability heartbeat on default is 0. If heartbeat is 0, no heartbeat will be used. 

I have tested it on my db, seems, that it works fine.

P.S. sorry for my English.