### PR TITLE
Fix of pool leaking by TCP-keepalive

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -48,6 +48,7 @@ Connection.prototype.connect = function(port, host) {
 
   this.stream.on('connect', function() {
     self.emit('connect');
+    self.stream.setKeepAlive(true);
   });
 
   this.stream.on('error', function(error) {

--- a/test/unit/connection/startup-tests.js
+++ b/test/unit/connection/startup-tests.js
@@ -43,6 +43,18 @@ test('using closed stream', function() {
     assert.ok(hit);
 
   });
+
+  test('after stream emits connected event init TCP-keepalive', function() {
+
+    var res = false;
+
+    con.setKeepAlive = function(bit) {
+      res = bit;
+    };
+
+    assert.ok(stream.emit('connect'));
+    assert.equal(res, true);
+  });
 });
 
 test('using opened stream', function() {

--- a/test/unit/connection/startup-tests.js
+++ b/test/unit/connection/startup-tests.js
@@ -48,7 +48,7 @@ test('using closed stream', function() {
 
     var res = false;
 
-    con.setKeepAlive = function(bit) {
+    stream.setKeepAlive = function(bit) {
       res = bit;
     };
 

--- a/test/unit/test-helper.js
+++ b/test/unit/test-helper.js
@@ -15,6 +15,8 @@ p.write = function(packet) {
   this.packets.push(packet);
 };
 
+p.setKeepAlive = function(){};
+
 p.writable = true;
 
 createClient = function() {


### PR DESCRIPTION
There is some bug with connection pool.
To reproduce it - you need connect to postgresql, start request and kill db process by kill -9. Client will not be free on any time.

To fix this, we can add heartbeat to client connection (https://github.com/brianc/node-postgres/pull/913) or add TCP-keepalive.

I have tested it. On TCP-socket close it return error to `client#query` callback function. I think, that it is the best resolve of this problem.

P.S. Please, if you will merge one of my PR - close another one.