### PR TITLE
Fix prepare value map to postgres

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -103,6 +103,10 @@ function normalizeQueryConfig (config, values, callback) {
 }
 
 module.exports = {
-  prepareValue: prepareValue,
+  prepareValue: function prepareValueWrapper (value) {
+    //this ensures that extra arguments do not get passed into prepareValue
+    //by accident, eg: from calling values.map(utils.prepareValue)
+    return prepareValue(value);
+  },
   normalizeQueryConfig: normalizeQueryConfig
 };

--- a/test/unit/utils-tests.js
+++ b/test/unit/utils-tests.js
@@ -171,3 +171,14 @@ test('prepareValue: objects with circular toPostgres rejected', function() {
   }
   throw new Error("Expected prepareValue to throw exception");
 });
+
+test('prepareValue: can safely be used to map an array of values including those with toPostgres functions', function() {
+  var customType = {
+    toPostgres: function() {
+      return "zomgcustom!";
+    }
+  };
+  var values = [1, "test", customType]
+  var out = values.map(utils.prepareValue)
+  assert.deepEqual(out, [1, "test", "zomgcustom!"])
+})


### PR DESCRIPTION
There was an issue where if a complex value (a value having a toPostgres function defined) was passed to prepareValue from a map operation, the index of the value would be passed as an additional parameter and prevent the internal seen variable from being correctly initialized.

Rather than try and identify all usages of this and fix the individual map operations, I thought it would be better to prevent the seen variable from being accidentally tampered with.

An example of current usage that causes problems: https://github.com/brianc/node-pg-cursor/blob/master/index.js#L6