### PR TITLE
Support TCP keepalives similarly to libpq

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -25,7 +25,8 @@ var Client = function(config) {
 
   this.connection = c.connection || new Connection({
     stream: c.stream,
-    ssl: this.connectionParameters.ssl
+    ssl: this.connectionParameters.ssl,
+    keepalives: this.connectionParameters.keepalives
   });
   this.queryQueue = [];
   this.binary = c.binary || defaults.binary;

--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -48,6 +48,9 @@ var ConnectionParameters = function(config) {
 
   this.application_name = val('application_name', config, 'PGAPPNAME');
   this.fallback_application_name = val('fallback_application_name', config, false);
+
+  this.keepalives = 'keepalives' in config ? config.keepalives : val('keepalives', config);
+  this.keepalives = this.keepalives === true || this.keepalives === 1 || this.keepalives === 'true' || this.keepalives === '1';
 };
 
 var add = function(params, config, paramName) {
@@ -76,6 +79,9 @@ ConnectionParameters.prototype.getLibpqConnectionString = function(cb) {
   }
   if(this.client_encoding) {
     params.push("client_encoding='" + this.client_encoding + "'");
+  }
+  if(this.keepalives) {
+    params.push("keepalives=1");
   }
   dns.lookup(this.host, function(err, address) {
     if(err) return cb(err, null);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -11,8 +11,9 @@ var Connection = function(config) {
   EventEmitter.call(this);
   config = config || {};
   this.stream = config.stream || new net.Stream();
-  if (typeof this.stream.setKeepAlive === 'function')
+  if (typeof this.stream.setKeepAlive === 'function') {
     this.stream.setKeepAlive(config.keepalives);
+  }
   this.lastBuffer = false;
   this.lastOffset = 0;
   this.buffer = null;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -11,6 +11,8 @@ var Connection = function(config) {
   EventEmitter.call(this);
   config = config || {};
   this.stream = config.stream || new net.Stream();
+  if (typeof this.stream.setKeepAlive === 'function')
+    this.stream.setKeepAlive(config.keepalives);
   this.lastBuffer = false;
   this.lastOffset = 0;
   this.buffer = null;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -41,7 +41,9 @@ var defaults = module.exports = {
   ssl: false,
 
   application_name : undefined,
-  fallback_application_name: undefined
+  fallback_application_name: undefined,
+
+  keepalives: true
 };
 
 //parse int8 so you can get your count values as actual numbers

--- a/test/unit/client/configuration-tests.js
+++ b/test/unit/client/configuration-tests.js
@@ -11,6 +11,7 @@ test('client settings', function() {
     assert.equal(client.user, pguser);
     assert.equal(client.database, pgdatabase);
     assert.equal(client.port, pgport);
+    assert.equal(client.keepalives, true);
   });
 
   test('custom', function() {

--- a/test/unit/connection-parameters/creation-tests.js
+++ b/test/unit/connection-parameters/creation-tests.js
@@ -98,7 +98,8 @@ test('libpq connection string building', function() {
       password: 'xyz',
       port: 888,
       host: 'localhost',
-      database: 'bam'
+      database: 'bam',
+      keepalives: true
     }
     var subject = new ConnectionParameters(config);
     subject.getLibpqConnectionString(assert.calls(function(err, constring) {
@@ -109,6 +110,7 @@ test('libpq connection string building', function() {
       checkForPart(parts, "port='888'");
       checkForPart(parts, "hostaddr=127.0.0.1");
       checkForPart(parts, "dbname='bam'");
+      checkForPart(parts, "keepalives=1");
     }));
   });
 


### PR DESCRIPTION
This depends on https://github.com/iceddev/pg-connection-string/pull/7 (which is why the tests don't pass yet) and would fix #909. Tested in production in my project. This is a more fleshed-out solution than #918.

I'd appreciate a comment from a maintainer here in support of the `pg-connection-string` PR, so that it gets merged there, after which the tests here can be re-run and the PR merged.