### PR TITLE
Bring native API in line with pure js version. Fixes #743 

### DIFF
--- a/lib/native/result.js
+++ b/lib/native/result.js
@@ -19,3 +19,10 @@ NativeResult.prototype.addCommandComplete = function(pq) {
     });
   }
 };
+
+NativeResult.prototype.addRow = function(row) {
+  // This is empty to ensure pg code doesn't break when switching to pg-native
+  // pg-native loads all rows into the final result object by default.
+  // This is because libpg loads all rows into memory before passing the result
+  // to pg-native.
+};

--- a/test/integration/client/simple-query-tests.js
+++ b/test/integration/client/simple-query-tests.js
@@ -36,6 +36,27 @@ test("simple query interface", function() {
   });
 });
 
+test("simple query interface using addRow", function() {
+
+  var client = helper.client();
+
+  var query = client.query("select name from person order by name");
+
+  client.on('drain', client.end.bind(client));
+
+  query.on('row', function(row, result) {
+    assert.ok(result);
+    result.addRow(row);
+  });
+
+  query.on('end', function(result) {
+    assert.lengthIs(result.rows, 26, "result returned wrong number of rows");
+    assert.lengthIs(result.rows, result.rowCount);
+    assert.equal(result.rows[0].name, "Aaron");
+    assert.equal(result.rows[25].name, "Zanzabar");
+  });
+});
+
 test("multiple simple queries", function() {
   var client = helper.client();
   client.query({ text: "create temp table bang(id serial, name varchar(5));insert into bang(name) VALUES('boom');"})


### PR DESCRIPTION
>  node-postgres abstracts over the pg-native module to provide exactly the same interface as the pure JavaScript version. **No other code changes are required.** If you find yourself having to change code other than the require statement when switching from require('pg') to require('pg').native please report an issue.

In issue #743 the code breaks using `pg-native` where the `Result.addRow` method is used. 

This method is missing from the native bindings because libpq loads all rows into memory before handing it to pg-native. The native bindings already simulate emitting row events, but does not replicate the addRow function.

I've added a test in `test/integration/client/simple-query-tests.js` using `Result.addRow`. 

And an empty function stub in `lib/native/result.js` which doesn't have to do anything since `pg-native` accumulates rows by default.
