### PR TITLE
pg.native – return null if pg-native is missing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,16 @@ if(typeof process.env.NODE_PG_FORCE_NATIVE != 'undefined') {
   //lazy require native module...the native module may not have installed
   module.exports.__defineGetter__("native", function() {
     delete module.exports.native;
-    module.exports.native = new PG(require('./native'));
-    return module.exports.native;
+    var native = null;
+    try {
+      native = new PG(require('./native'));
+    } catch (err) {
+      if (err.code !== 'MODULE_NOT_FOUND') {
+        throw err;
+      }
+      console.error(err.message);
+    }
+    module.exports.native = native;
+    return native;
   });
 }

--- a/test/native/missing-native.js
+++ b/test/native/missing-native.js
@@ -3,6 +3,4 @@
 
 var assert = require('assert');
 
-assert.throws(function() {
-  require('../../lib').native;
-});
+assert.equal(require('../../lib').native, null);


### PR DESCRIPTION
`require('pg').native` will be `null` and report error once to `stdout` when `pg-native` is missing.

Fixes #838