### PR TITLE
Catch errors thrown by type parsers and emit error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -160,7 +160,7 @@ Client.prototype.connect = function(callback) {
     self.readyForQuery = true;
     self._pulseQueryQueue();
     if(activeQuery) {
-      activeQuery.handleReadyForQuery();
+      activeQuery.handleReadyForQuery(con);
     }
   });
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -55,7 +55,14 @@ Query.prototype.handleRowDescription = function(msg) {
 };
 
 Query.prototype.handleDataRow = function(msg) {
-  var row = this._result.parseRow(msg.fields);
+  var row;
+  try {
+     row = this._result.parseRow(msg.fields);
+  } catch (err) {
+    this._canceledDueToError = err;
+    return;
+  }
+
   this.emit('row', row, this._result);
 
   //if there is a callback collect rows
@@ -81,9 +88,9 @@ Query.prototype.handleEmptyQuery = function(con) {
   }
 };
 
-Query.prototype.handleReadyForQuery = function() {
+Query.prototype.handleReadyForQuery = function(con) {
   if(this._canceledDueToError) {
-    return this.handleError(this._canceledDueToError);
+    return this.handleError(this._canceledDueToError, con);
   }
   if(this.callback) {
     this.callback(null, this._result);

--- a/test/integration/client/query-error-handling-tests.js
+++ b/test/integration/client/query-error-handling-tests.js
@@ -1,5 +1,6 @@
 var helper = require(__dirname + '/test-helper');
 var util = require('util');
+var PgTypes = require('pg-types');
 
 test('error during query execution', function() {
   var client = new Client(helper.args);
@@ -33,6 +34,25 @@ test('error during query execution', function() {
         }));
       }));
     }));
+  }));
+});
+
+test('parseRow error is handled', function() {
+  PgTypes.setTypeParser(23, 'text', function () {
+    throw new Error("Type Parser Error")
+  });
+  var client = new Client(helper.args);
+  client.connect(assert.success(function() {
+    var query1 = client.query('SELECT 1', assert.calls(function(err, result) {
+      PgTypes.setTypeParser(23, 'text', null);
+      assert(err);
+      return client.end();
+    }));
+    // ensure query does not emit an 'end' event since error was thrown
+    query1.on('end', function() {
+      PgTypes.setTypeParser(23, 'text', null);
+      assert.fail('Query with an error should not emit "end" event');
+    });
   }));
 });
 


### PR DESCRIPTION
Errors thrown by type parsers are not currently caught. This catches them and emits an error. 