### PR TITLE
Fix byte representation of CancelRequest message

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -159,7 +159,7 @@ Connection.prototype.cancel = function(processID, secretKey) {
     .addInt16(5678)
     .addInt32(processID)
     .addInt32(secretKey)
-    .addCString('').flush();
+    .flush();
 
   var length = bodyBuffer.length + 4;
 


### PR DESCRIPTION
I noticed that query cancellation was not working when connecting through pgbouncer,
even though it worked fine when directly connected. This is because we're appending an
extra null byte, and pgbouncer is strict about the packet length.
(per http://www.postgresql.org/docs/9.1/static/protocol-message-formats.html)

This removes the extraneous byte, which fixes cancellation against pgbouncer.