### PR TITLE
Requiring native bindings polutes 'global'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ PG.prototype.connect = function(config, callback) {
     callback = config;
     config = null;
   }
-  var pool = this.pools.getOrCreate(config, this.Client);
+  var pool = this.pools.getOrCreate(config);
   pool.connect(callback);
   if(!pool.listeners('error').length) {
     //propagate errors up to pg object

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,9 @@ var Connection = require('./connection');
 var PG = function(clientConstructor) {
   EventEmitter.call(this);
   this.defaults = defaults;
-  this.Client = pool.Client = clientConstructor;
+  this.Client = clientConstructor;
   this.Query = this.Client.Query;
-  this.pools = pool;
+  this.pools = pool(clientConstructor);
   this.Connection = Connection;
   this.types = require('pg-types');
 };
@@ -45,7 +45,7 @@ PG.prototype.connect = function(config, callback) {
     callback = config;
     config = null;
   }
-  var pool = this.pools.getOrCreate(config);
+  var pool = this.pools.getOrCreate(config, this.Client);
   pool.connect(callback);
   if(!pool.listeners('error').length) {
     //propagate errors up to pg object

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -3,93 +3,95 @@ var EventEmitter = require('events').EventEmitter;
 var defaults = require('./defaults');
 var genericPool = require('generic-pool');
 
-var pools = {
-  //dictionary of all key:pool pairs
-  all: {},
-  //reference to the client constructor - can override in tests or for require('pg').native
-  Client: require('./client'),
-  getOrCreate: function(clientConfig) {
-    clientConfig = clientConfig || {};
-    var name = JSON.stringify(clientConfig);
-    var pool = pools.all[name];
-    if(pool) {
+
+module.exports = function(Client) {
+  var pools = {
+    //dictionary of all key:pool pairs
+    all: {},
+    //reference to the client constructor - can override in tests or for require('pg').native
+    getOrCreate: function(clientConfig) {
+      clientConfig = clientConfig || {};
+      var name = JSON.stringify(clientConfig);
+      var pool = pools.all[name];
+      if(pool) {
+        return pool;
+      }
+      pool = genericPool.Pool({
+        name: name,
+        max: clientConfig.poolSize || defaults.poolSize,
+        idleTimeoutMillis: clientConfig.poolIdleTimeout || defaults.poolIdleTimeout,
+        reapIntervalMillis: clientConfig.reapIntervalMillis || defaults.reapIntervalMillis,
+        log: clientConfig.poolLog || defaults.poolLog,
+        create: function(cb) {
+          var client = new Client(clientConfig);
+          // Ignore errors on pooled clients until they are connected.
+          client.on('error', Function.prototype);
+          client.connect(function(err) {
+            if(err) return cb(err, null);
+
+            // Remove the noop error handler after a connection has been established.
+            client.removeListener('error', Function.prototype);
+
+            //handle connected client background errors by emitting event
+            //via the pg object and then removing errored client from the pool
+            client.on('error', function(e) {
+              pool.emit('error', e, client);
+
+              // If the client is already being destroyed, the error
+              // occurred during stream ending. Do not attempt to destroy
+              // the client again.
+              if (!client._destroying) {
+                pool.destroy(client);
+              }
+            });
+
+            // Remove connection from pool on disconnect
+            client.on('end', function(e) {
+              // Do not enter infinite loop between pool.destroy
+              // and client 'end' event...
+              if ( ! client._destroying ) {
+                pool.destroy(client);
+              }
+            });
+            client.poolCount = 0;
+            return cb(null, client);
+          });
+        },
+        destroy: function(client) {
+          client._destroying = true;
+          client.poolCount = undefined;
+          client.end();
+        }
+      });
+      pools.all[name] = pool;
+      //mixin EventEmitter to pool
+      EventEmitter.call(pool);
+      for(var key in EventEmitter.prototype) {
+        if(EventEmitter.prototype.hasOwnProperty(key)) {
+          pool[key] = EventEmitter.prototype[key];
+        }
+      }
+      //monkey-patch with connect method
+      pool.connect = function(cb) {
+        var domain = process.domain;
+        pool.acquire(function(err, client) {
+          if(domain) {
+            cb = domain.bind(cb);
+          }
+          if(err)  return cb(err, null, function() {/*NOOP*/});
+          client.poolCount++;
+          cb(null, client, function(err) {
+            if(err) {
+              pool.destroy(client);
+            } else {
+              pool.release(client);
+            }
+          });
+        });
+      };
       return pool;
     }
-    pool = genericPool.Pool({
-      name: name,
-      max: clientConfig.poolSize || defaults.poolSize,
-      idleTimeoutMillis: clientConfig.poolIdleTimeout || defaults.poolIdleTimeout,
-      reapIntervalMillis: clientConfig.reapIntervalMillis || defaults.reapIntervalMillis,
-      log: clientConfig.poolLog || defaults.poolLog,
-      create: function(cb) {
-        var client = new pools.Client(clientConfig);
-        // Ignore errors on pooled clients until they are connected.
-        client.on('error', Function.prototype);
-        client.connect(function(err) {
-          if(err) return cb(err, null);
+  };
 
-          // Remove the noop error handler after a connection has been established.
-          client.removeListener('error', Function.prototype);
-
-          //handle connected client background errors by emitting event
-          //via the pg object and then removing errored client from the pool
-          client.on('error', function(e) {
-            pool.emit('error', e, client);
-
-            // If the client is already being destroyed, the error
-            // occurred during stream ending. Do not attempt to destroy
-            // the client again.
-            if (!client._destroying) {
-              pool.destroy(client);
-            }
-          });
-
-          // Remove connection from pool on disconnect
-          client.on('end', function(e) {
-            // Do not enter infinite loop between pool.destroy
-            // and client 'end' event...
-            if ( ! client._destroying ) {
-              pool.destroy(client);
-            }
-          });
-          client.poolCount = 0;
-          return cb(null, client);
-        });
-      },
-      destroy: function(client) {
-        client._destroying = true;
-        client.poolCount = undefined;
-        client.end();
-      }
-    });
-    pools.all[name] = pool;
-    //mixin EventEmitter to pool
-    EventEmitter.call(pool);
-    for(var key in EventEmitter.prototype) {
-      if(EventEmitter.prototype.hasOwnProperty(key)) {
-        pool[key] = EventEmitter.prototype[key];
-      }
-    }
-    //monkey-patch with connect method
-    pool.connect = function(cb) {
-      var domain = process.domain;
-      pool.acquire(function(err, client) {
-        if(domain) {
-          cb = domain.bind(cb);
-        }
-        if(err)  return cb(err, null, function() {/*NOOP*/});
-        client.poolCount++;
-        cb(null, client, function(err) {
-          if(err) {
-            pool.destroy(client);
-          } else {
-            pool.release(client);
-          }
-        });
-      });
-    };
-    return pool;
-  }
-};
-
-module.exports = pools;
+  return pools;
+}

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -94,4 +94,4 @@ module.exports = function(Client) {
   };
 
   return pools;
-}
+};

--- a/test/integration/gh-issues/981-tests.js
+++ b/test/integration/gh-issues/981-tests.js
@@ -1,0 +1,20 @@
+var assert = require('assert')
+var pg = require('../../../lib')
+var native = require('../../../lib').native
+
+var JsClient = require('../../../lib/client')
+var NativeClient = require('../../../lib/native')
+
+assert(pg.Client === JsClient);
+assert(native.Client === NativeClient);
+
+pg.connect(function(err, client, done) {
+  assert(client instanceof JsClient);
+  client.end();
+
+  native.connect(function(err, client, done) {
+    assert(client instanceof NativeClient);
+    client.end();
+  });
+});
+

--- a/test/integration/gh-issues/981-tests.js
+++ b/test/integration/gh-issues/981-tests.js
@@ -1,3 +1,10 @@
+var helper = require(__dirname + '/../test-helper');
+
+//native bindings are only installed for native tests
+if(!helper.args.native) {
+  return;
+}
+
 var assert = require('assert')
 var pg = require('../../../lib')
 var native = require('../../../lib').native

--- a/test/unit/pool/timeout-tests.js
+++ b/test/unit/pool/timeout-tests.js
@@ -3,7 +3,7 @@ var EventEmitter = require('events').EventEmitter;
 
 var libDir = __dirname + '/../../../lib';
 var defaults = require(libDir + '/defaults');
-var pools = require(libDir + '/pool');
+var poolsFactory = require(libDir + '/pool');
 var poolId = 0;
 
 require(__dirname + '/../../test-helper');
@@ -25,8 +25,9 @@ FakeClient.prototype.end = function() {
 defaults.poolIdleTimeout = 10;
 defaults.reapIntervalMillis = 10;
 
+var pools = poolsFactory(FakeClient)
+
 test('client times out from idle', function() {
-  pools.Client = FakeClient;
   var p = pools.getOrCreate(poolId++);
   p.connect(function(err, client, done) {
     done();


### PR DESCRIPTION
There was some nasty global-ish variable reference updating happening when the native module 'initializes' after its require with `require('pg').native`

This fixes the issue by making sure both `require('pg')` and `require('pg').native` each initialize their own context in isolation and no weird global-ish references are used & subsequently stomped on.