### PR TITLE
enable instrumentation of Client used in pool

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -6,6 +6,7 @@ var genericPool = require('generic-pool');
 
 module.exports = function(Client) {
   var pools = {
+    Client: Client,
     //dictionary of all key:pool pairs
     all: {},
     //reference to the client constructor - can override in tests or for require('pg').native
@@ -23,7 +24,7 @@ module.exports = function(Client) {
         reapIntervalMillis: clientConfig.reapIntervalMillis || defaults.reapIntervalMillis,
         log: clientConfig.poolLog || defaults.poolLog,
         create: function(cb) {
-          var client = new Client(clientConfig);
+          var client = new pools.Client(clientConfig);
           // Ignore errors on pooled clients until they are connected.
           client.on('error', Function.prototype);
           client.connect(function(err) {


### PR DESCRIPTION
This commit broke the newrelic instrumentation since the Client constructor used in pool is now hidden and cannot be instrumented.
https://github.com/brianc/node-postgres/commit/a8bd44a6ec89b941bcfcd2ef7f386eca34a2fdb4

This is a quick fix to unblock any users using pg native and pooling with newrelic.  I am open to working on a better way to instrument as a follow up, if this is not optimal.