### PR TITLE
Adding returnToHead in clientConfig param

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -33,6 +33,9 @@ var defaults = module.exports = {
   //frequency to check for idle clients within the client pool
   reapIntervalMillis: 1000,
 
+  //if true the most recently released resources will be the first to be allocated
+  returnToHead: false,
+
   //pool log function / boolean
   poolLog: false,
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -22,6 +22,7 @@ module.exports = function(Client) {
         max: clientConfig.poolSize || defaults.poolSize,
         idleTimeoutMillis: clientConfig.poolIdleTimeout || defaults.poolIdleTimeout,
         reapIntervalMillis: clientConfig.reapIntervalMillis || defaults.reapIntervalMillis,
+        returnToHead: clientConfig.returnToHead || defaults.returnToHead,
         log: clientConfig.poolLog || defaults.poolLog,
         create: function(cb) {
           var client = new pools.Client(clientConfig);


### PR DESCRIPTION
Making returnToHead param for creating a Pool() configurable https://github.com/coopernurse/node-pool
Right now it defaults to false and there is no way to override it.