### PR TITLE
don't return clients that have errored to the connection pool

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -84,6 +84,8 @@ module.exports = function(Client) {
           cb(null, client, function(err) {
             if(err) {
               pool.destroy(client);
+            } else if (client._destroying) {
+              return;
             } else {
               pool.release(client);
             }


### PR DESCRIPTION
The test for this one mostly speaks for itself.

We're using some constructs to make sure connections are always returned to the pool. Unfortunately after a client has errored, we still call `done()`. This was returning bad connections to the pool, that would error when we tried to use them. We've fixed our code to call `done(err)` if a connection has errored, but it's complicated and is uglying up our code ;). I believe the library should behave intelligently for this case.