### PR TITLE
new Buffer(str) is deprecated, use Buffer.from(str) instead

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -84,7 +84,7 @@ Client.prototype.connect = function(callback) {
   //password request handling
   con.on('authenticationMD5Password', checkPgPass(function(msg) {
     var inner = Client.md5(self.password + self.user);
-    var outer = Client.md5(Buffer.concat([new Buffer(inner), msg.salt]));
+    var outer = Client.md5(Buffer.concat([Buffer.from(inner), msg.salt]));
     var md5password = "md5" + outer;
     con.password(md5password);
   }));


### PR DESCRIPTION
https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html#buffer_new_buffer_str_encoding says new Buffer(str) is deprecated and Buffer.from(str) should be used instead. Sorry I missed that in my first pull request.