### PR TITLE
Proper error message with undefined where options

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,6 +48,9 @@ var prepareValue = function(val, seen) {
   if(typeof val === 'object') {
     return prepareObject(val, seen);
   }
+  if (typeof val === 'undefined') {
+    throw new Error('SQL queries with undefined where clause option');
+  }
   return val.toString();
 };
 


### PR DESCRIPTION
When user provides a knex select statement with an undefined options in where clause it is not properly handled an give an ambiguous error message telling `Unhandled rejection TypeError: Cannot read property 'toString' of undefined.` This PR will helpful to users at it will tell them the exact problem.