### PR TITLE
added .npmignore in order to not publish tests to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+node_modules/
+*.swp
+*.log
+.lock-wscript
+build/
+*~
+test/
+script/


### PR DESCRIPTION
Added an .npmignore so that pg doesn't publish the test code to npm, thereby shrinking the dependency size for anyone using it.