### PR TITLE
client.end: add .onDone option

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -327,8 +327,14 @@ Client.prototype.query = function(config, values, callback) {
   return query;
 };
 
-Client.prototype.end = function() {
-  this.connection.end();
+Client.prototype.end = function(config) {
+  if (config && config.onDone && this.activeQuery) {
+    this.once('drain', function() {
+      this.end();
+    });
+  } else {
+    this.connection.end();
+  }
 };
 
 Client.md5 = function(string) {


### PR DESCRIPTION
I was hitting a code path where I needed to check the "private" property `.activeQuery` in order to properly end the client. This patch adds a `.onDone` option to `client#end()` that only ends when it's not busy.

Context: I was using `client.on('drain', () => client.end())` before, but the problem with that is if you have that as the last line of a program that isn't supposed to run forever, like a server, and if the there's nothing in the client's queue, there will never be a `drain` event fired.

I didn't add tests or docs as I wasn't sure whether you're ok with this api and approach.
