### PR TITLE
use latest generic-pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "main": "./lib",
   "dependencies": {
     "buffer-writer": "1.0.1",
-    "generic-pool": "2.1.1",
+    "generic-pool": "2.4.2",
     "packet-reader": "0.2.0",
     "pg-connection-string": "0.1.3",
     "pg-types": "1.*",


### PR DESCRIPTION
generic-pool has had a few bug fixes since 2.1.1 and it'd be good to get those in