### PR TITLE
handle 'stringable' objects in query() method, besides strings and query objects

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -110,6 +110,12 @@ function dateToStringUTC(date) {
 
 function normalizeQueryConfig (config, values, callback) {
   //can take in strings or config objects
+  
+  if( 0 !== config.toString().indexOf('[object ') ){
+    // if toString is overridden then call it
+    config = config.toString();
+  }
+  
   config = (typeof(config) == 'string') ? { text: config } : config;
   if(values) {
     if(typeof values === 'function') {


### PR DESCRIPTION
handle 'stringable' objects in query() method, besides strings and query objects
(automatic to string conversion, then handling as a string)

I would like to add for convenience an automatic toString() conversion of a parameter that could be a string.
The is another use case of having a parameter with a config object and in that case the config object is handled as usual.
So we have a sum total of 3 use case handled: strings, stringable objects and config objects.
The rationale of this patch is having the toString conversion in one place inside the query method call instead of having to call many times toString (at every query method call).
So **this patch would allow to reduce replication** of "toString" code (when calling query method).
