### PR TITLE
Fix SSL configuration error and add tests. #848

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -47,7 +47,7 @@ var ConnectionParameters = function(config) {
   this.host = val('host', config);
   this.password = val('password', config);
   this.binary = val('binary', config);
-  this.ssl = config.ssl || useSsl();
+  this.ssl = typeof config.ssl === 'boolean' ? config.ssl : useSsl();
   this.client_encoding = val("client_encoding", config);
   //a domain socket begins with '/'
   this.isDomainSocket = (!(this.host||'').indexOf('/'));

--- a/test/unit/client/configuration-tests.js
+++ b/test/unit/client/configuration-tests.js
@@ -11,6 +11,7 @@ test('client settings', function() {
     assert.equal(client.user, pguser);
     assert.equal(client.database, pgdatabase);
     assert.equal(client.port, pgport);
+    assert.equal(client.ssl, false);
   });
 
   test('custom', function() {
@@ -21,13 +22,37 @@ test('client settings', function() {
       user: user,
       database: database,
       port: 321,
-      password: password
+      password: password,
+      ssl: true
     });
 
     assert.equal(client.user, user);
     assert.equal(client.database, database);
     assert.equal(client.port, 321);
     assert.equal(client.password, password);
+    assert.equal(client.ssl, true);
+  });
+
+  test('custom ssl default on', function() {
+    var old = process.env.PGSSLMODE;
+    process.env.PGSSLMODE = "prefer";
+
+    var client = new Client();
+    process.env.PGSSLMODE = old;
+
+    assert.equal(client.ssl, true);
+  });
+
+  test('custom ssl force off', function() {
+    var old = process.env.PGSSLMODE;
+    process.env.PGSSLMODE = "prefer";
+
+    var client = new Client({
+      ssl: false
+    });
+    process.env.PGSSLMODE = old;
+
+    assert.equal(client.ssl, false);
   });
 
 });


### PR DESCRIPTION
Fixes a small configuration bug. When the user explicitly passes `false`, it is still overridden by the environment. This fixes that error.