### PR TITLE
Accept connection parameters in Pool constructor

### DIFF
--- a/lib/pool-factory.js
+++ b/lib/pool-factory.js
@@ -1,11 +1,13 @@
 var Client = require('./client');
+var ConnectionParameters = require('./connection-parameters');
 var util = require('util');
 var Pool = require('pg-pool');
 
 module.exports = function(Client) {
 
   var BoundPool = function(options) {
-    var config = { Client: Client };
+    var config = new ConnectionParameters(options);
+    config.Client = Client;
     for (var key in options) {
       config[key] = options[key];
     }

--- a/lib/pool-factory.js
+++ b/lib/pool-factory.js
@@ -8,9 +8,6 @@ module.exports = function(Client) {
   var BoundPool = function(options) {
     var config = new ConnectionParameters(options);
     config.Client = Client;
-    for (var key in options) {
-      config[key] = options[key];
-    }
     Pool.call(this, config);
   };
 


### PR DESCRIPTION
It seems that `Pool` doesn't accept connection parameters like `connect` does, this fixes that.
