### PR TITLE
node-postgres blocks with faulty SQL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,13 +68,13 @@ PG.prototype.connect = function(config, callback) {
 
   this._pools[poolName] = this._pools[poolName] || new this.Pool(config);
   var pool = this._pools[poolName];
-  pool.connect(callback);
   if(!pool.listeners('error').length) {
     //propagate errors up to pg object
     pool.on('error', function(e) {
       this.emit('error', e, e.client);
     }.bind(this));
   }
+  return pool.connect(callback);
 };
 
 // cancel the query running on the given client

--- a/lib/native/query.js
+++ b/lib/native/query.js
@@ -34,8 +34,8 @@ var NativeQuery = module.exports = function(native) {
 
 util.inherits(NativeQuery, EventEmitter);
 
-NativeQuery.prototype.then = function(callback) {
-  return this.promise().then(callback);
+NativeQuery.prototype.then = function(onSuccess, onFailure) {
+  return this.promise().then(onSuccess, onFailure);
 };
 
 NativeQuery.prototype.catch = function(callback) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -40,8 +40,8 @@ var Query = function(config, values, callback) {
 
 util.inherits(Query, EventEmitter);
 
-Query.prototype.then = function(callback) {
-  return this.promise().then(callback);
+Query.prototype.then = function(onSuccess, onFailure) {
+  return this.promise().then(onSuccess, onFailure);
 };
 
 Query.prototype.catch = function(callback) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "async": "0.9.0",
+    "co": "4.6.0",
     "jshint": "2.5.2",
     "lodash": "4.13.1",
     "pg-copy-streams": "0.3.0",

--- a/test/integration/connection-pool/yield-support-body.js
+++ b/test/integration/connection-pool/yield-support-body.js
@@ -1,0 +1,28 @@
+var helper = require('./test-helper')
+var co = require('co')
+
+var tid = setTimeout(function() {
+  throw new Error('Tests did not complete in tme')
+}, 1000)
+
+co(function * () {
+  var client = yield helper.pg.connect()
+  var res = yield client.query('SELECT $1::text as name', ['foo'])
+  assert.equal(res.rows[0].name, 'foo')
+
+  var threw = false
+  try {
+    yield client.query('SELECT LKDSJDSLKFJ')
+  } catch(e) {
+    threw = true
+  }
+  assert(threw)
+  client.release()
+  helper.pg.end()
+  clearTimeout(tid)
+})
+.catch(function(e) {
+  setImmediate(function() {
+    throw e
+  })
+})

--- a/test/integration/connection-pool/yield-support-tests.js
+++ b/test/integration/connection-pool/yield-support-tests.js
@@ -1,0 +1,5 @@
+var semver = require('semver')
+if (semver.lt(process.version, '1.0.0')) {
+  return console.log('yield is not supported in node <= v0.12')
+}
+require('./yield-support-body')


### PR DESCRIPTION
I'm using ES6 with async/await and node-postgres with connection pooling.

Let there is a table with a column which has UNIQUE constraint and a primary key column, the following code block blocks on `client.query`:

````
export async function someFunction () {
    const client = Postgres.connect()

    try {
        //  First insertion
        const result = await client.query('INSERT INTO table (column) VALUES ($1::text) RETURNING *', ['test'])

        //  Second insertion, which will fail
        const secondResult = await client.query('INSERT INTO table (column) VALUES ($1::text) RETURNING *', ['test'])

        console.log(secondResult.rows)    //  never called
    } catch (err) {
        console.error(err)
    } finally {
        client.release()
    }
}
````

However, I'm expecting to see this in somewhere:

     ERROR:  duplicate key value violates unique constraint "table_column_key"
     DETAIL:  Key (column)=(test) already exists.

Am I doing something wrong?