### PR TITLE
Add badges for npm version and number of dl on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://secure.travis-ci.org/brianc/node-postgres.svg?branch=master)](http://travis-ci.org/brianc/node-postgres)
 [![Dependency Status](https://david-dm.org/brianc/node-postgres.svg)](https://david-dm.org/brianc/node-postgres)
+<span class="badge-npmversion"><a href="https://npmjs.org/package/pg" title="View this project on NPM"><img src="https://img.shields.io/npm/v/pg.svg" alt="NPM version" /></a></span>
+<span class="badge-npmdownloads"><a href="https://npmjs.org/package/pg" title="View this project on NPM"><img src="https://img.shields.io/npm/dm/pg.svg" alt="NPM downloads" /></a></span>
 
 Non-blocking PostgreSQL client for node.js.  Pure JavaScript and optional native libpq bindings.
 


### PR DESCRIPTION
Adding those two badges in the Readme for the following reasons  : 
- having a badge for npm version allow to see at a glance the current version
- the badge for dl/month allow to see immediatly that this module is very used in the ecosystem, which is an useful information when you are a newcomer to node and databases drivers.