### PR TITLE
Add details about differences between js and native bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,17 @@ var Pool = pg.Pool // good! a pool bound to the native client
 var Client = pg.Client // good! this client uses libpq bindings
 ```
 
-node-postgres abstracts over the pg-native module to provide exactly the same interface as the pure JavaScript version. Care has been taken to keep the number of api differences between the two modules to a minimum; however, it is recommended you use either the pure JavaScript or native bindings in both development and production and don't mix & match them in the same process - it can get confusing!
+#### API differences
+
+node-postgres abstracts over the pg-native module to provide the same interface as the pure JavaScript version. Care has been taken to keep the number of api differences between the two modules to a minimum.  
+However, currently some differences remain, especially :
+* the error object in pg-native is different : notably, the information about the postgres error code is not present in field `code` but in the field `sqlState` , and the name of a few other fields is different (see https://github.com/brianc/node-postgres/issues/938, https://github.com/brianc/node-postgres/issues/972).
+So for example, if you rely on error.code in your application, your will have to adapt your code to work with native bindings.
+* the notification object has a few less properties  (see https://github.com/brianc/node-postgres/issues/1045)
+* column objects have less properties (see https://github.com/brianc/node-postgres/issues/988)
+* the modules https://github.com/brianc/node-pg-copy-streams and https://github.com/brianc/node-pg-query-stream do not work with native bindings (you will have to require 'pg' to use them).
+
+Thus, it is recommended you use either the pure JavaScript or native bindings in both development and production and don't mix & match them in the same process - it can get confusing!
 
 ## Features
 


### PR DESCRIPTION
For a new comer, native bindings seems to be a drop in replacement, but there's some sligthly differences between the two API, especially regarding the error object .
Theses differences have raised several questions and issues.
Thus, providing some details about these actual differences should avoid some difficulties for the user who wants to use the native bindings.

I'm not a native english speaker :disappointed: so feel free to reformulate the text of the PR, I won't be upset :wink: .