### PR TITLE
pgpass: Upgrade to 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pg-connection-string": "0.1.3",
     "pg-pool": "1.*",
     "pg-types": "1.*",
-    "pgpass": "0.0.6",
+    "pgpass": "1.x",
     "semver": "4.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
pgpass is using semver versioning now, thus a dependency on
version 1.x should be safe.