### PR TITLE
Client.end conflicting API and examples

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -336,8 +336,11 @@ Client.prototype.query = function(config, values, callback) {
   return query;
 };
 
-Client.prototype.end = function() {
+Client.prototype.end = function(cb) {
   this.connection.end();
+  if (cb) {
+    this.connection.once('end', cb);
+  }
 };
 
 Client.md5 = function(string) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -122,6 +122,9 @@ Connection.prototype.attachListeners = function(stream) {
       packet = self._reader.read();
     }
   });
+  stream.on('end', function() {
+    self.emit('end');
+  });
 };
 
 Connection.prototype.requestSsl = function() {

--- a/test/integration/client/end-callback-tests.js
+++ b/test/integration/client/end-callback-tests.js
@@ -1,0 +1,6 @@
+var helper = require('./test-helper')
+
+var client = helper.client(assert.success(function() {
+  client.end(assert.success(function() {
+  }))
+}))

--- a/test/integration/test-helper.js
+++ b/test/integration/test-helper.js
@@ -7,9 +7,9 @@ if(helper.args.native) {
 }
 
 //creates a client from cli parameters
-helper.client = function() {
+helper.client = function(cb) {
   var client = new Client(helper.config);
-  client.connect();
+  client.connect(cb);
   return client;
 };
 


### PR DESCRIPTION
The first simple example shows: https://github.com/brianc/node-postgres/blame/master/README.md#L40
1) client.end() should be called after client.connect()
2) client.end() takes a callback

Client.end() documentation https://github.com/brianc/node-postgres/wiki/Client#method-end
states:
1) "Clients created via the pg#connect method will be automatically disconnected or placed back into the connection pool and should not have their #end method called."
2) "end() : null" i.e. end() does not take callback parameter

I don't understand where "pg#connect" method refers to. I can't find one. But in the simple example client.connect is used, so does this mean end() should not be called?

I stumbled on this when I took the simple example and wanted to move calling end() to server shutdown hook, but passing a callback to the end() did not work.
