### PR TITLE
Upgrading tests to PostgreSQL 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-sudo: false
+sudo: required
+dist: trusty
 before_script:
   - node script/create-test-tables.js pg://postgres@127.0.0.1:5432/postgres
 env:
@@ -16,16 +17,16 @@ matrix:
   include:
     - node_js: "0.10"
       addons:
-        postgresql: "9.4"
+        postgresql: "9.5"
     - node_js: "0.12"
       addons:
-        postgresql: "9.4"
+        postgresql: "9.5"
     - node_js: "4"
       addons:
-        postgresql: "9.4"
+        postgresql: "9.5"
     - node_js: "5"
       addons:
-        postgresql: "9.4"
+        postgresql: "9.5"
     - node_js: "6"
       addons:
         postgresql: "9.1"
@@ -38,3 +39,6 @@ matrix:
     - node_js: "6"
       addons:
         postgresql: "9.4"
+    - node_js: "6"
+      addons:
+        postgresql: "9.5"        


### PR DESCRIPTION
Setting PostgreSQL 9.5 as the main version to test against.

NOTE: The following settings are currently required for PostgreSQL 9.5 to work:
```
sudo: required
dist: trusty
```

For details and the long painful history of adding PostgreSQL 9.5 support see https://github.com/travis-ci/travis-ci/issues/4264

---

@brianc now you can start extending your tests for JSONP, including: :wink:

* support for large JSON/JSONP objects
*  type conversions for JSONP data