### PR TITLE
when define a model without primary key, it will add automatically

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,9 +73,12 @@ if(typeof process.env.NODE_PG_FORCE_NATIVE != 'undefined') {
   module.exports = new PG(Client);
 
   //lazy require native module...the native module may not have installed
-  module.exports.__defineGetter__("native", function() {
-    delete module.exports.native;
-    module.exports.native = new PG(require('./native'));
-    return module.exports.native;
+  Object.defineProperty(module.exports, 'native', {
+    get: function () {
+      delete module.exports._native;
+      module.exports._native = new PG(require('./native'));
+      return module.exports._native;
+    },
+    enumerable: false
   });
 }

--- a/test/unit/client/native-property-tests.js
+++ b/test/unit/client/native-property-tests.js
@@ -1,0 +1,7 @@
+var helper = require(__dirname + "/test-helper");
+var client = require(__dirname + "/../../../lib");
+
+test('native property is non-enumerable', function() {
+    assert.equal(Object.keys(client).indexOf('native'), -1);
+});
+


### PR DESCRIPTION
``` js
var Sys = sequelize.define('name_sysid', {
    system_id:Sequelize.BIGINT,
        // primaryKey: true

    system_name: Sequelize.STRING(100),
    system_type: Sequelize.BIGINT,
}, {
        timestamps: false,
        freezeTableName: true
    });


Sys.findAll()
   .then(function (sys) {
       for (let i in sys) {
           console.log(`${i.type}: ${i.name}`);
       }
   }).catch(function (err) {
       // error
       console.log(err);
   });
```
# 

error information

> ```
> Executing (default): SELECT "id", "system_id", "system_name", "system_type" FROM "name_sysid" AS "name_sysid";
> { SequelizeDatabaseError: column "id" does not exist
> .....}
> ```
