### PR TITLE
parse int8[]

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -62,7 +62,13 @@ var defaults = module.exports = {
   parseInputDatesAsUTC: false
 };
 
+var pgTypes = require('pg-types')
+// save default parsers
+var parseBigInteger = pgTypes.getTypeParser(20, 'text')
+var parseBigIntegerArray = pgTypes.getTypeParser(1016, 'text')
+
 //parse int8 so you can get your count values as actual numbers
 module.exports.__defineSetter__("parseInt8", function(val) {
-  require('pg-types').setTypeParser(20, 'text', val ? parseInt : function(val) { return val; });
+  pgTypes.setTypeParser(20, 'text', val ? pgTypes.getTypeParser(23, 'text') : parseBigInteger)
+  pgTypes.setTypeParser(1016, 'text', val ? pgTypes.getTypeParser(1007, 'text') : parseBigIntegerArray)
 });

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -62,13 +62,13 @@ var defaults = module.exports = {
   parseInputDatesAsUTC: false
 };
 
-var pgTypes = require('pg-types')
+var pgTypes = require('pg-types');
 // save default parsers
-var parseBigInteger = pgTypes.getTypeParser(20, 'text')
-var parseBigIntegerArray = pgTypes.getTypeParser(1016, 'text')
+var parseBigInteger = pgTypes.getTypeParser(20, 'text');
+var parseBigIntegerArray = pgTypes.getTypeParser(1016, 'text');
 
 //parse int8 so you can get your count values as actual numbers
 module.exports.__defineSetter__("parseInt8", function(val) {
-  pgTypes.setTypeParser(20, 'text', val ? pgTypes.getTypeParser(23, 'text') : parseBigInteger)
-  pgTypes.setTypeParser(1016, 'text', val ? pgTypes.getTypeParser(1007, 'text') : parseBigIntegerArray)
+  pgTypes.setTypeParser(20, 'text', val ? pgTypes.getTypeParser(23, 'text') : parseBigInteger);
+  pgTypes.setTypeParser(1016, 'text', val ? pgTypes.getTypeParser(1007, 'text') : parseBigIntegerArray);
 });

--- a/test/integration/client/parse-int-8-tests.js
+++ b/test/integration/client/parse-int-8-tests.js
@@ -8,17 +8,16 @@ test('ability to turn on and off parser', function() {
     client.query('CREATE TEMP TABLE asdf(id SERIAL PRIMARY KEY)');
     client.query('SELECT COUNT(*) as "count", \'{1,2,3}\'::bigint[] as array FROM asdf', assert.success(function(res) {
       assert.strictEqual(0, res.rows[0].count);
-      var arr = res.rows[0].array
-      assert.strictEqual(1, arr[0])
-      assert.strictEqual(2, arr[1])
-      assert.strictEqual(3, arr[2])
+      assert.strictEqual(1, res.rows[0].array[0]);
+      assert.strictEqual(2, res.rows[0].array[1]);
+      assert.strictEqual(3, res.rows[0].array[2]);
       pg.defaults.parseInt8 = false;
       client.query('SELECT COUNT(*) as "count", \'{1,2,3}\'::bigint[] as array FROM asdf', assert.success(function(res) {
         done();
         assert.strictEqual('0', res.rows[0].count);
-        assert.strictEqual('1', arr[0])
-        assert.strictEqual('2', arr[1])
-        assert.strictEqual('3', arr[2])
+        assert.strictEqual('1', res.rows[0].array[0]);
+        assert.strictEqual('2', res.rows[0].array[1]);
+        assert.strictEqual('3', res.rows[0].array[2]);
         pg.end();
       }));
     }));

--- a/test/integration/client/parse-int-8-tests.js
+++ b/test/integration/client/parse-int-8-tests.js
@@ -6,11 +6,14 @@ test('ability to turn on and off parser', function() {
   pg.connect(helper.config, assert.success(function(client, done) {
     pg.defaults.parseInt8 = true;
     client.query('CREATE TEMP TABLE asdf(id SERIAL PRIMARY KEY)');
-    client.query('SELECT COUNT(*) as "count" FROM asdf', assert.success(function(res) {
+    client.query('SELECT COUNT(*) as "count", \'{1,2,3}\'::bigint[] as array FROM asdf', assert.success(function(res) {
+      assert.strictEqual(0, res.rows[0].count);
+      assert.strictEqual([1, 2, 3], res.rows[0].array);
       pg.defaults.parseInt8 = false;
-      client.query('SELECT COUNT(*) as "count" FROM asdf', assert.success(function(res) {
+      client.query('SELECT COUNT(*) as "count", \'{1,2,3}\'::bigint[] as array FROM asdf', assert.success(function(res) {
         done();
         assert.strictEqual("0", res.rows[0].count);
+        assert.strictEqual(['1', '2', '3'], res.rows[0].array);
         pg.end();
       }));
     }));

--- a/test/integration/client/parse-int-8-tests.js
+++ b/test/integration/client/parse-int-8-tests.js
@@ -8,12 +8,12 @@ test('ability to turn on and off parser', function() {
     client.query('CREATE TEMP TABLE asdf(id SERIAL PRIMARY KEY)');
     client.query('SELECT COUNT(*) as "count", \'{1,2,3}\'::bigint[] as array FROM asdf', assert.success(function(res) {
       assert.strictEqual(0, res.rows[0].count);
-      assert.strictEqual([1, 2, 3], res.rows[0].array);
+      assert.deepStrictEqual([1, 2, 3], res.rows[0].array);
       pg.defaults.parseInt8 = false;
       client.query('SELECT COUNT(*) as "count", \'{1,2,3}\'::bigint[] as array FROM asdf', assert.success(function(res) {
         done();
         assert.strictEqual("0", res.rows[0].count);
-        assert.strictEqual(['1', '2', '3'], res.rows[0].array);
+        assert.deepStrictEqual(['1', '2', '3'], res.rows[0].array);
         pg.end();
       }));
     }));

--- a/test/integration/client/parse-int-8-tests.js
+++ b/test/integration/client/parse-int-8-tests.js
@@ -8,12 +8,17 @@ test('ability to turn on and off parser', function() {
     client.query('CREATE TEMP TABLE asdf(id SERIAL PRIMARY KEY)');
     client.query('SELECT COUNT(*) as "count", \'{1,2,3}\'::bigint[] as array FROM asdf', assert.success(function(res) {
       assert.strictEqual(0, res.rows[0].count);
-      assert.deepStrictEqual([1, 2, 3], res.rows[0].array);
+      var arr = res.rows[0].array
+      assert.strictEqual(1, arr[0])
+      assert.strictEqual(2, arr[1])
+      assert.strictEqual(3, arr[2])
       pg.defaults.parseInt8 = false;
       client.query('SELECT COUNT(*) as "count", \'{1,2,3}\'::bigint[] as array FROM asdf', assert.success(function(res) {
         done();
-        assert.strictEqual("0", res.rows[0].count);
-        assert.deepStrictEqual(['1', '2', '3'], res.rows[0].array);
+        assert.strictEqual('0', res.rows[0].count);
+        assert.strictEqual('1', arr[0])
+        assert.strictEqual('2', arr[1])
+        assert.strictEqual('3', arr[2])
         pg.end();
       }));
     }));


### PR DESCRIPTION
Parsing int8 and int8 arrays when

``` javascript
require('pg').defaults.parseInt8 = true
```

Fix for #614 
