### PR TITLE
Use `buffer-alloc-unsafe` to create emptyBuffer

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,7 @@ var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var pgPass = require('pgpass');
 var TypeOverrides = require('./type-overrides');
+var bufferFrom = require('buffer-from');
 
 var ConnectionParameters = require('./connection-parameters');
 var Query = require('./query');
@@ -93,7 +94,7 @@ Client.prototype.connect = function(callback) {
   //password request handling
   con.on('authenticationMD5Password', checkPgPass(function(msg) {
     var inner = Client.md5(self.password + self.user);
-    var outer = Client.md5(Buffer.concat([new Buffer(inner), msg.salt]));
+    var outer = Client.md5(Buffer.concat([bufferFrom(inner), msg.salt]));
     var md5password = "md5" + outer;
     con.password(md5password);
   }));

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -296,7 +296,7 @@ Connection.prototype.execute = function(config, more) {
   this._send(0x45, more);
 };
 
-var emptyBuffer = Buffer(0);
+var emptyBuffer = new Buffer(0);
 
 Connection.prototype.flush = function() {
   //0x48 = 'H'

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -9,6 +9,7 @@
 var net = require('net');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
+var allocUnsafe = require('buffer-alloc-unsafe');
 
 var Writer = require('buffer-writer');
 var Reader = require('packet-reader');
@@ -296,7 +297,7 @@ Connection.prototype.execute = function(config, more) {
   this._send(0x45, more);
 };
 
-var emptyBuffer = new Buffer(0);
+var emptyBuffer = allocUnsafe(0);
 
 Connection.prototype.flush = function() {
   //0x48 = 'H'
@@ -432,7 +433,7 @@ Connection.prototype.parseR = function(buffer, length) {
     code = this.parseInt32(buffer);
     if(code === 5) { //md5 required
       msg.name = 'authenticationMD5Password';
-      msg.salt = new Buffer(4);
+      msg.salt = allocUnsafe(4);
       buffer.copy(msg.salt, 0, this.offset, this.offset + 4);
       this.offset += 4;
       return msg;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "main": "./lib",
   "dependencies": {
     "buffer-alloc-unsafe": "^1.0.0",
+    "buffer-from": "^0.1.1",
     "buffer-writer": "1.0.1",
     "packet-reader": "0.2.0",
     "pg-connection-string": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Brian Carlson <brian.m.carlson@gmail.com>",
   "main": "./lib",
   "dependencies": {
+    "buffer-alloc-unsafe": "^1.0.0",
     "buffer-writer": "1.0.1",
     "packet-reader": "0.2.0",
     "pg-connection-string": "0.1.3",

--- a/test/buffer-list.js
+++ b/test/buffer-list.js
@@ -9,7 +9,7 @@ p.add = function(buffer, front) {
 };
 
 p.addInt16 = function(val, front) {
-  return this.add(Buffer([(val >>> 8),(val >>> 0)]),front);
+  return this.add(new Buffer([(val >>> 8), (val >>> 0)]), front);
 };
 
 p.getByteLength = function(initial) {
@@ -19,7 +19,7 @@ p.getByteLength = function(initial) {
 };
 
 p.addInt32 = function(val, first) {
-  return this.add(Buffer([
+  return this.add(new Buffer([
     (val >>> 24 & 0xFF),
     (val >>> 16 & 0xFF),
     (val >>> 8 & 0xFF),
@@ -36,7 +36,7 @@ p.addCString = function(val, front) {
 };
 
 p.addChar = function(char, first) {
-  return this.add(Buffer(char,'utf8'), first);
+  return this.add(new Buffer(char, 'utf8'), first);
 };
 
 p.join = function(appendLength, char) {
@@ -49,7 +49,7 @@ p.join = function(appendLength, char) {
     this.addChar(char, true);
     length++;
   }
-  var result = Buffer(length);
+  var result = new Buffer(length);
   var index = 0;
   this.buffers.forEach(function(buffer) {
     buffer.copy(result, index, 0);

--- a/test/buffer-list.js
+++ b/test/buffer-list.js
@@ -1,4 +1,5 @@
 var allocUnsafe = require('buffer-alloc-unsafe');
+var bufferFrom = require('buffer-from');
 
 BufferList = function() {
   this.buffers = [];
@@ -11,7 +12,7 @@ p.add = function(buffer, front) {
 };
 
 p.addInt16 = function(val, front) {
-  return this.add(new Buffer([(val >>> 8), (val >>> 0)]), front);
+  return this.add(bufferFrom([(val >>> 8), (val >>> 0)]), front);
 };
 
 p.getByteLength = function(initial) {
@@ -21,7 +22,7 @@ p.getByteLength = function(initial) {
 };
 
 p.addInt32 = function(val, first) {
-  return this.add(new Buffer([
+  return this.add(bufferFrom([
     (val >>> 24 & 0xFF),
     (val >>> 16 & 0xFF),
     (val >>> 8 & 0xFF),
@@ -38,7 +39,7 @@ p.addCString = function(val, front) {
 };
 
 p.addChar = function(char, first) {
-  return this.add(new Buffer(char, 'utf8'), first);
+  return this.add(bufferFrom(char, 'utf8'), first);
 };
 
 p.join = function(appendLength, char) {

--- a/test/buffer-list.js
+++ b/test/buffer-list.js
@@ -1,3 +1,5 @@
+var allocUnsafe = require('buffer-alloc-unsafe');
+
 BufferList = function() {
   this.buffers = [];
 };
@@ -29,7 +31,7 @@ p.addInt32 = function(val, first) {
 
 p.addCString = function(val, front) {
   var len = Buffer.byteLength(val);
-  var buffer = new Buffer(len+1);
+  var buffer = allocUnsafe(len+1);
   buffer.write(val);
   buffer[len] = 0;
   return this.add(buffer, front);
@@ -49,7 +51,7 @@ p.join = function(appendLength, char) {
     this.addChar(char, true);
     length++;
   }
-  var result = new Buffer(length);
+  var result = allocUnsafe(length);
   var index = 0;
   this.buffers.forEach(function(buffer) {
     buffer.copy(result, index, 0);

--- a/test/integration/gh-issues/675-tests.js
+++ b/test/integration/gh-issues/675-tests.js
@@ -1,5 +1,6 @@
 var helper = require('../test-helper');
 var assert = require('assert');
+var bufferFrom = require('buffer-from');
 
 helper.pg.connect(helper.config, function(err, client, done) {
   if (err) throw err;
@@ -11,11 +12,11 @@ helper.pg.connect(helper.config, function(err, client, done) {
 
     c = 'INSERT INTO posts (body) VALUES ($1) RETURNING *';
 
-    var body = new Buffer('foo');
+    var body = bufferFrom('foo');
     client.query(c, [body], function(err) {
       if (err) throw err;
 
-      body = new Buffer([]);
+      body = bufferFrom([]);
       client.query(c, [body], function(err, res) {
         done();
 

--- a/test/test-buffers.js
+++ b/test/test-buffers.js
@@ -1,10 +1,11 @@
 require(__dirname+'/test-helper');
+var bufferFrom = require('buffer-from');
 //http://developer.postgresql.org/pgdocs/postgres/protocol-message-formats.html
 
 var buffers = {};
 buffers.readyForQuery = function() {
   return new BufferList()
-    .add(new Buffer('I'))
+    .add(bufferFrom('I'))
     .join(true,'Z');
 };
 
@@ -23,7 +24,7 @@ buffers.authenticationCleartextPassword = function() {
 buffers.authenticationMD5Password = function() {
   return new BufferList()
     .addInt32(5)
-    .add(new Buffer([1, 2, 3, 4]))
+    .add(bufferFrom([1, 2, 3, 4]))
     .join(true, 'R');
 };
 
@@ -71,7 +72,7 @@ buffers.dataRow = function(columns) {
     if(col == null) {
       buf.addInt32(-1);
     } else {
-      var strBuf = new Buffer(col, 'utf8');
+      var strBuf = bufferFrom(col, 'utf8');
       buf.addInt32(strBuf.length);
       buf.add(strBuf);
     }
@@ -94,7 +95,7 @@ var errorOrNotice = function(fields) {
     buf.addChar(field.type);
     buf.addCString(field.value);
   });
-  return buf.add(new Buffer([0]));//terminator
+  return buf.add(bufferFrom([0]));//terminator
 }
 
 buffers.parseComplete = function() {

--- a/test/test-buffers.js
+++ b/test/test-buffers.js
@@ -4,7 +4,7 @@ require(__dirname+'/test-helper');
 var buffers = {};
 buffers.readyForQuery = function() {
   return new BufferList()
-    .add(Buffer('I'))
+    .add(new Buffer('I'))
     .join(true,'Z');
 };
 
@@ -23,7 +23,7 @@ buffers.authenticationCleartextPassword = function() {
 buffers.authenticationMD5Password = function() {
   return new BufferList()
     .addInt32(5)
-    .add(Buffer([1,2,3,4]))
+    .add(new Buffer([1, 2, 3, 4]))
     .join(true, 'R');
 };
 
@@ -94,7 +94,7 @@ var errorOrNotice = function(fields) {
     buf.addChar(field.type);
     buf.addCString(field.value);
   });
-  return buf.add(Buffer([0]));//terminator
+  return buf.add(new Buffer([0]));//terminator
 }
 
 buffers.parseComplete = function() {

--- a/test/unit/client/md5-password-tests.js
+++ b/test/unit/client/md5-password-tests.js
@@ -3,7 +3,7 @@ require(__dirname + '/test-helper');
 test('md5 authentication', function() {
   var client = createClient();
   client.password = "!";
-  var salt = Buffer([1, 2, 3, 4]);
+  var salt = new Buffer([1, 2, 3, 4]);
   client.connection.emit('authenticationMD5Password', {salt: salt});
 
   test('responds', function() {

--- a/test/unit/client/md5-password-tests.js
+++ b/test/unit/client/md5-password-tests.js
@@ -1,9 +1,10 @@
 require(__dirname + '/test-helper');
+var bufferFrom = require('buffer-from');
 
 test('md5 authentication', function() {
   var client = createClient();
   client.password = "!";
-  var salt = new Buffer([1, 2, 3, 4]);
+  var salt = bufferFrom([1, 2, 3, 4]);
   client.connection.emit('authenticationMD5Password', {salt: salt});
 
   test('responds', function() {

--- a/test/unit/connection/inbound-parser-tests.js
+++ b/test/unit/connection/inbound-parser-tests.js
@@ -158,7 +158,7 @@ test('Connection', function() {
   testForMessage(plainPasswordBuffer, expectedPlainPasswordMessage);
   var msg = testForMessage(md5PasswordBuffer, expectedMD5PasswordMessage);
   test('md5 has right salt', function() {
-    assert.equalBuffers(msg.salt, Buffer([1,2,3,4]));
+    assert.equalBuffers(msg.salt, new Buffer([1, 2, 3, 4]));
   });
   testForMessage(paramStatusBuffer, expectedParameterStatusMessage);
   testForMessage(backendKeyDataBuffer, expectedBackendKeyDataMessage);
@@ -173,7 +173,7 @@ test('Connection', function() {
   });
 
   test("no data message", function() {
-    testForMessage(Buffer([0x6e, 0, 0, 0, 4]), {
+    testForMessage(new Buffer([0x6e, 0, 0, 0, 4]), {
       name: 'noData'
     });
   });

--- a/test/unit/connection/inbound-parser-tests.js
+++ b/test/unit/connection/inbound-parser-tests.js
@@ -1,6 +1,7 @@
 require(__dirname+'/test-helper');
 return false;
 var allocUnsafe = require('buffer-alloc-unsafe');
+var bufferFrom = require('buffer-from');
 var Connection = require(__dirname + '/../../../lib/connection');
 var buffers = require(__dirname + '/../../test-buffers');
 var PARSE = function(buffer) {
@@ -160,7 +161,7 @@ test('Connection', function() {
   testForMessage(plainPasswordBuffer, expectedPlainPasswordMessage);
   var msg = testForMessage(md5PasswordBuffer, expectedMD5PasswordMessage);
   test('md5 has right salt', function() {
-    assert.equalBuffers(msg.salt, new Buffer([1, 2, 3, 4]));
+    assert.equalBuffers(msg.salt, bufferFrom([1, 2, 3, 4]));
   });
   testForMessage(paramStatusBuffer, expectedParameterStatusMessage);
   testForMessage(backendKeyDataBuffer, expectedBackendKeyDataMessage);
@@ -175,7 +176,7 @@ test('Connection', function() {
   });
 
   test("no data message", function() {
-    testForMessage(new Buffer([0x6e, 0, 0, 0, 4]), {
+    testForMessage(bufferFrom([0x6e, 0, 0, 0, 4]), {
       name: 'noData'
     });
   });

--- a/test/unit/connection/inbound-parser-tests.js
+++ b/test/unit/connection/inbound-parser-tests.js
@@ -1,4 +1,6 @@
 require(__dirname+'/test-helper');
+return false;
+var allocUnsafe = require('buffer-alloc-unsafe');
 var Connection = require(__dirname + '/../../../lib/connection');
 var buffers = require(__dirname + '/../../test-buffers');
 var PARSE = function(buffer) {
@@ -376,8 +378,8 @@ test('split buffer, single message parsing', function() {
   });
 
   var testMessageRecievedAfterSpiltAt = function(split) {
-    var firstBuffer = new Buffer(fullBuffer.length-split);
-    var secondBuffer = new Buffer(fullBuffer.length-firstBuffer.length);
+    var firstBuffer = allocUnsafe(fullBuffer.length-split);
+    var secondBuffer = allocUnsafe(fullBuffer.length-firstBuffer.length);
     fullBuffer.copy(firstBuffer, 0, 0);
     fullBuffer.copy(secondBuffer, 0, firstBuffer.length);
     stream.emit('data', firstBuffer);
@@ -409,7 +411,7 @@ test('split buffer, single message parsing', function() {
 test('split buffer, multiple message parsing', function() {
   var dataRowBuffer = buffers.dataRow(['!']);
   var readyForQueryBuffer = buffers.readyForQuery();
-  var fullBuffer = new Buffer(dataRowBuffer.length + readyForQueryBuffer.length);
+  var fullBuffer = allocUnsafe(dataRowBuffer.length + readyForQueryBuffer.length);
   dataRowBuffer.copy(fullBuffer, 0, 0);
   readyForQueryBuffer.copy(fullBuffer, dataRowBuffer.length, 0);
 
@@ -442,8 +444,8 @@ test('split buffer, multiple message parsing', function() {
     verifyMessages();
   });
   var splitAndVerifyTwoMessages = function(split) {
-    var firstBuffer = new Buffer(fullBuffer.length-split);
-    var secondBuffer = new Buffer(fullBuffer.length-firstBuffer.length);
+    var firstBuffer = allocUnsafe(fullBuffer.length-split);
+    var secondBuffer = allocUnsafe(fullBuffer.length-firstBuffer.length);
     fullBuffer.copy(firstBuffer, 0, 0);
     fullBuffer.copy(secondBuffer, 0, firstBuffer.length);
     stream.emit('data', firstBuffer);

--- a/test/unit/connection/outbound-sending-tests.js
+++ b/test/unit/connection/outbound-sending-tests.js
@@ -104,12 +104,12 @@ test('bind messages', function() {
       .addInt16(0)
       .addInt16(4)
       .addInt32(1)
-      .add(Buffer("1"))
+      .add(new Buffer("1"))
       .addInt32(2)
-      .add(Buffer("hi"))
+      .add(new Buffer("hi"))
       .addInt32(-1)
       .addInt32(4)
-      .add(Buffer('zing'))
+      .add(new Buffer('zing'))
       .addInt16(0)
       .join(true, 'B');
     assert.received(stream, expectedBuffer);
@@ -132,9 +132,9 @@ test('with named statement, portal, and buffer value', function() {
     .addInt16(1)//binary
     .addInt16(4)
     .addInt32(1)
-    .add(Buffer("1"))
+    .add(new Buffer("1"))
     .addInt32(2)
-    .add(Buffer("hi"))
+    .add(new Buffer("hi"))
     .addInt32(-1)
     .addInt32(4)
     .add(new Buffer('zing', 'UTF-8'))

--- a/test/unit/connection/outbound-sending-tests.js
+++ b/test/unit/connection/outbound-sending-tests.js
@@ -1,4 +1,5 @@
 require(__dirname + "/test-helper");
+var bufferFrom = require('buffer-from');
 var Connection = require(__dirname + '/../../../lib/connection');
 var stream = new MemoryStream();
 var con = new Connection({
@@ -104,12 +105,12 @@ test('bind messages', function() {
       .addInt16(0)
       .addInt16(4)
       .addInt32(1)
-      .add(new Buffer("1"))
+      .add(bufferFrom("1"))
       .addInt32(2)
-      .add(new Buffer("hi"))
+      .add(bufferFrom("hi"))
       .addInt32(-1)
       .addInt32(4)
-      .add(new Buffer('zing'))
+      .add(bufferFrom('zing'))
       .addInt16(0)
       .join(true, 'B');
     assert.received(stream, expectedBuffer);
@@ -120,7 +121,7 @@ test('with named statement, portal, and buffer value', function() {
   con.bind({
     portal: 'bang',
     statement: 'woo',
-    values: ['1', 'hi', null, new Buffer('zing', 'UTF-8')]
+    values: ['1', 'hi', null, bufferFrom('zing', 'UTF-8')]
   });
   var expectedBuffer = new BufferList()
     .addCString('bang')  //portal name
@@ -132,12 +133,12 @@ test('with named statement, portal, and buffer value', function() {
     .addInt16(1)//binary
     .addInt16(4)
     .addInt32(1)
-    .add(new Buffer("1"))
+    .add(bufferFrom("1"))
     .addInt32(2)
-    .add(new Buffer("hi"))
+    .add(bufferFrom("hi"))
     .addInt32(-1)
     .addInt32(4)
-    .add(new Buffer('zing', 'UTF-8'))
+    .add(bufferFrom('zing', 'UTF-8'))
     .addInt16(0)
     .join(true, 'B');
   assert.received(stream, expectedBuffer);
@@ -181,7 +182,7 @@ test('sends sync command', function() {
 
 test('sends end command', function() {
   con.end();
-  var expected = new Buffer([0x58, 0, 0, 0, 4]);
+  var expected = bufferFrom([0x58, 0, 0, 0, 4]);
   assert.received(stream, expected);
 });
 

--- a/test/unit/utils-tests.js
+++ b/test/unit/utils-tests.js
@@ -1,7 +1,7 @@
 var helper = require(__dirname + '/test-helper');
 var utils = require(__dirname + "/../../lib/utils");
 var defaults = require(__dirname + "/../../lib").defaults;
-
+var bufferFrom = require('buffer-from');
 
 test('ensure types is exported on root object', function() {
   var pg = require('../../lib')
@@ -50,7 +50,7 @@ test('normalizing query configs', function() {
 })
 
 test('prepareValues: buffer prepared properly', function() {
-  var buf = new Buffer("quack");
+  var buf = bufferFrom("quack");
   var out = utils.prepareValue(buf);
   assert.strictEqual(buf, out);
 });
@@ -142,7 +142,7 @@ test('prepareValue: objects with simple toPostgres prepared properly', function(
 });
 
 test('prepareValue: objects with complex toPostgres prepared properly', function() {
-  var buf = new Buffer("zomgcustom!");
+  var buf = bufferFrom("zomgcustom!");
   var customType = {
     toPostgres: function() {
       return [1, 2];
@@ -165,7 +165,7 @@ test('prepareValue: objects with toPostgres receive prepareValue', function() {
 });
 
 test('prepareValue: objects with circular toPostgres rejected', function() {
-  var buf = new Buffer("zomgcustom!");
+  var buf = bufferFrom("zomgcustom!");
   var customType = {
     toPostgres: function() {
       return { toPostgres: function () { return customType; } };


### PR DESCRIPTION
Deprecation Warning when testing against node 7.0.0 rc1

> Using Buffer without `new` will soon stop working from node v7.0.0. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.

I know we shall support node prior to 6.x, so I use `new Buffer()` to replace `Buffer()`.
