### PR TITLE
fix nodejs 7 DeprecationWarning: calling new Buffer(0)

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -296,7 +296,7 @@ Connection.prototype.execute = function(config, more) {
   this._send(0x45, more);
 };
 
-var emptyBuffer = Buffer(0);
+var emptyBuffer = new Buffer(0);
 
 Connection.prototype.flush = function() {
   //0x48 = 'H'


### PR DESCRIPTION
Avoid nodejs 7 warning:
DeprecationWarning: Using Buffer without `new` will soon stop working.
Use `new Buffer()`, or preferably `Buffer.from()`,
`Buffer.allocUnsafe()` or `Buffer.alloc()` instead.
