### PR TITLE
Parse connection string into config object before creting pool.

### DIFF
--- a/lib/pool-factory.js
+++ b/lib/pool-factory.js
@@ -1,10 +1,13 @@
 var Client = require('./client');
 var util = require('util');
 var Pool = require('pg-pool');
+var parse = require('pg-connection-string').parse;
 
 module.exports = function(Client) {
 
   var BoundPool = function(options) {
+    // Handle connection string based pool creation
+    options = typeof options == 'string' ? parse(options) : (options || {});
     var config = { Client: Client };
     for (var key in options) {
       config[key] = options[key];


### PR DESCRIPTION
This should resolve https://github.com/brianc/node-postgres/issues/1141 at least it seems to work locally for me doing something like:

```
var pg = require('pg');
var cn = "postgres://postgres@localhost:5433/testing";
var pool = new pg.Pool(cn);
pool.connect(function (err, client, done) { ... });
```

I didn't add any tests because I'm having trouble getting the existing tests to pass (and it looks like all the recent PR's have failed the Travis build). If you've got advice for getting things to pass locally I can add something to the existing `connection-string` unit tests. Unless you'd prefer them somewhere else.
