### PR TITLE
support ssl params for pg-native

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -79,6 +79,12 @@ ConnectionParameters.prototype.getLibpqConnectionString = function(cb) {
   add(params, this, 'application_name');
   add(params, this, 'fallback_application_name');
 
+  var ssl = typeof this.ssl === 'object' ? this.ssl : {sslmode: this.ssl};
+  add(params, ssl, 'sslmode');
+  add(params, ssl, 'sslca');
+  add(params, ssl, 'sslkey');
+  add(params, ssl, 'sslcert');
+  
   if(this.database) {
     params.push("dbname='" + this.database + "'");
   }


### PR DESCRIPTION
Make pg-native able to pass sslmode, sslca, sslkey and sslcert params to libpq