### PR TITLE
fixes utf password md5 bug

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -344,7 +344,7 @@ Client.prototype.end = function(cb) {
 };
 
 Client.md5 = function(string) {
-  return crypto.createHash('md5').update(string).digest('hex');
+  return crypto.createHash('md5').update(string, 'utf-8').digest('hex');
 };
 
 // expose a Query constructor


### PR DESCRIPTION
fixes the bug described in
http://stackoverflow.com/questions/33935749/node-js-postgres-utf-connect-string
In short: 
utf password md5 generated is wrong because of binary encoding