### PR TITLE
Run inbound parser tests

### DIFF
--- a/test/unit/connection/inbound-parser-tests.js
+++ b/test/unit/connection/inbound-parser-tests.js
@@ -1,5 +1,4 @@
 require(__dirname+'/test-helper');
-return false;
 var Connection = require(__dirname + '/../../../lib/connection');
 var buffers = require(__dirname + '/../../test-buffers');
 var PARSE = function(buffer) {


### PR DESCRIPTION
They were disabled by 4cdd7a116bab03c6096ab1af8f0f522b04993768 without comment; it seems that this might have been unintentional?

In any case, they should probably be enabled, updated, or removed.