### PR TITLE
Fix for utf-8 characters in md5 passwords

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -344,7 +344,7 @@ Client.prototype.end = function(cb) {
 };
 
 Client.md5 = function(string) {
-  return crypto.createHash('md5').update(string).digest('hex');
+  return crypto.createHash('md5').update(string, 'utf-8').digest('hex');
 };
 
 // expose a Query constructor

--- a/test/unit/client/md5-password-tests.js
+++ b/test/unit/client/md5-password-tests.js
@@ -17,5 +17,8 @@ test('md5 authentication', function() {
                         .addCString(password).join(true,'p'));
     });
   });
+});
 
+test('md5 of utf-8 strings', function() {
+  assert.equal(Client.md5('😊'), '5deda34cd95f304948d2bc1b4a62c11e');
 });


### PR DESCRIPTION
This is the same fix as supplied in 1178 but includes a test.

Closes #1178