### PR TITLE
Remove single line comments from query text

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -222,9 +222,9 @@ Connection.prototype.parse = function(query, more) {
 
   //remove single line comments from query text
   if (query.text) {
-    query.text = query.text.replace(/--.+\n/g, ' ');
+    query.text = query.text.replace(/--.+\n?/g, ' ');
   }
-  
+
   //normalize null type array
   query.types = query.types || [];
   var len = query.types.length;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -219,6 +219,12 @@ Connection.prototype.parse = function(query, more) {
     console.error('You supplied', query.name, '(', query.name.length, ')');
     console.error('This can cause conflicts and silent errors executing queries');
   }
+
+  //remove single line comments from query text
+  if (query.text) {
+    query.text = query.text.replace(/--.+\n/g, ' ');
+  }
+  
   //normalize null type array
   query.types = query.types || [];
   var len = query.types.length;

--- a/test/integration/connection/query-tests.js
+++ b/test/integration/connection/query-tests.js
@@ -6,7 +6,7 @@ var rows = [];
 //it's cumbersome to use the api this way
 test('simple query', function() {
   helper.connect(function(con) {
-    con.query('select * from ids');
+    con.query('select * from ids -- sample SQL comment');
     assert.emits(con, 'dataRow');
     con.on('dataRow', function(msg) {
       rows.push(msg.fields);


### PR DESCRIPTION
For a complex app with lots of long SQL queries I'm using .sql files to write queries and reading them into memory (an object with .sql filenames as keys and content as string values) before app starts.

In SQL queries small, single line comments sometimes are very useful and this 3 lines of code removes them before feeding to addCString(query.text)