### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pool.connect(function(err, client, done) {
     return console.error('error fetching client from pool', err);
   }
   client.query('SELECT $1::int AS number', ['1'], function(err, result) {
-    //call `done(err)` to release the client back to the pool (or destroy it if there was an error)
+    //call `done(err)` to release the client back to the pool (or destroy it if there is an error)
     done(err);
 
     if(err) {

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ pool.connect(function(err, client, done) {
     return console.error('error fetching client from pool', err);
   }
   client.query('SELECT $1::int AS number', ['1'], function(err, result) {
-    //call `done()` to release the client back to the pool
-    done();
+    //call `done(err)` to release the client back to the pool (or destroy it if there was an error)
+    done(err);
 
     if(err) {
       return console.error('error running query', err);


### PR DESCRIPTION
There is callback which releases the client back to the pool. It works fine, however when `client.query` throws an error (_eg.: "Connection terminated"_), we need to destroy the client instead of release.

Fortunately the `pg-pool` [handles](https://github.com/brianc/node-pg-pool/blob/master/index.js#L99) this issue, but we need to pass the error object to the callback function.