### PR TITLE
Fix ECONNRESET error emitted after failed connect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -182,6 +182,7 @@ Client.prototype.connect = function(callback) {
     if(!callback) {
       return self.emit('error', error);
     }
+    con.end(); // make sure ECONNRESET errors don't cause error events
     callback(error);
     callback = null;
   });


### PR DESCRIPTION
On Windows, after a connect attempt has failed, an error event with
ECONNRESET is emitted after the real connect error is propagated to the
connect callback, because the connection is not in ending state
(connection._ending) where ECONNRESET is ignored. This change ends the
connection when connect has failed.

This fixes #746.