### PR TITLE
Make pool name consistent on missing config params

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,6 @@ PG.prototype.connect = function(config, callback) {
     callback = config;
     config = null;
   }
-  var poolName = JSON.stringify(config || {});
   if (typeof config == 'string') {
     config = new ConnectionParameters(config);
   }
@@ -66,6 +65,7 @@ PG.prototype.connect = function(config, callback) {
   config.idleTimeoutMillis = config.idleTimeoutMillis || config.poolIdleTimeout || defaults.poolIdleTimeout;
   config.log = config.log || config.poolLog || defaults.poolLog;
 
+  var poolName = JSON.stringify(config || {});
   this._pools[poolName] = this._pools[poolName] || new this.Pool(config);
   var pool = this._pools[poolName];
   if(!pool.listeners('error').length) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ PG.prototype.connect = function(config, callback) {
   config.idleTimeoutMillis = config.idleTimeoutMillis || config.poolIdleTimeout || defaults.poolIdleTimeout;
   config.log = config.log || config.poolLog || defaults.poolLog;
 
-  var poolName = JSON.stringify(config || {});
+  var poolName = JSON.stringify(config);
   this._pools[poolName] = this._pools[poolName] || new this.Pool(config);
   var pool = this._pools[poolName];
   if(!pool.listeners('error').length) {

--- a/test/integration/connection-pool/single-pool-on-object-config-tests.js
+++ b/test/integration/connection-pool/single-pool-on-object-config-tests.js
@@ -1,0 +1,13 @@
+var helper = require(__dirname + "/../test-helper");
+var pg = require(__dirname + "/../../../lib");
+
+pg.connect(helper.config, assert.success(function(client, done) {
+    assert.equal(Object.keys(pg._pools).length, 1);
+    pg.connect(helper.config, assert.success(function(client2, done2) {
+      assert.equal(Object.keys(pg._pools).length, 1);
+
+      done();
+      done2();
+      pg.end();
+    }));
+}));


### PR DESCRIPTION
When using a config object to connect, if the config object misses some params, it will generate a pool name without those missing params. However, the next time, the object will have the missing params already in place with the default values, generating a different pool name.

By delaying the pool name generation, we ensure the name for the pool is consistent.