### PR TITLE
Libpq connection string escaping

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -65,10 +65,15 @@ var ConnectionParameters = function(config) {
   this.fallback_application_name = val('fallback_application_name', config, false);
 };
 
+// Convert arg to a string, surround in single quotes, and escape single quotes and backslashes
+var quoteParamValue = function(value) {
+  return "'" + ('' + value).replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "'";
+};
+
 var add = function(params, config, paramName) {
   var value = config[paramName];
   if(value) {
-    params.push(paramName+"='"+value+"'");
+    params.push(paramName + "=" + quoteParamValue(value));
   }
 };
 
@@ -87,23 +92,23 @@ ConnectionParameters.prototype.getLibpqConnectionString = function(cb) {
   add(params, ssl, 'sslcert');
   
   if(this.database) {
-    params.push("dbname='" + this.database + "'");
+    params.push("dbname=" + quoteParamValue(this.database));
   }
   if(this.replication) {
-    params.push("replication='" + this.replication + "'");
+    params.push("replication=" + quoteParamValue(this.replication));
   }
   if(this.host) {
-    params.push("host=" + this.host);
+    params.push("host=" + quoteParamValue(this.host));
   }
   if(this.isDomainSocket) {
     return cb(null, params.join(' '));
   }
   if(this.client_encoding) {
-    params.push("client_encoding='" + this.client_encoding + "'");
+    params.push("client_encoding=" + quoteParamValue(this.client_encoding));
   }
   dns.lookup(this.host, function(err, address) {
     if(err) return cb(err, null);
-    params.push("hostaddr=" + address);
+    params.push("hostaddr=" + quoteParamValue(address));
     return cb(null, params.join(' '));
   });
 };

--- a/test/unit/connection-parameters/creation-tests.js
+++ b/test/unit/connection-parameters/creation-tests.js
@@ -126,7 +126,7 @@ test('libpq connection string building', function() {
       checkForPart(parts, "user='brian'");
       checkForPart(parts, "password='xyz'");
       checkForPart(parts, "port='888'");
-      checkForPart(parts, "hostaddr=127.0.0.1");
+      checkForPart(parts, "hostaddr='127.0.0.1'");
       checkForPart(parts, "dbname='bam'");
     }));
   });
@@ -143,7 +143,7 @@ test('libpq connection string building', function() {
       assert.isNull(err);
       var parts = constring.split(" ");
       checkForPart(parts, "user='brian'");
-      checkForPart(parts, "hostaddr=127.0.0.1");
+      checkForPart(parts, "hostaddr='127.0.0.1'");
     }));
   });
 
@@ -173,7 +173,7 @@ test('libpq connection string building', function() {
       assert.isNull(err);
       var parts = constring.split(" ");
       checkForPart(parts, "user='brian'");
-      checkForPart(parts, "host=/tmp/");
+      checkForPart(parts, "host='/tmp/'");
     }));
   });
 

--- a/test/unit/connection-parameters/creation-tests.js
+++ b/test/unit/connection-parameters/creation-tests.js
@@ -177,6 +177,22 @@ test('libpq connection string building', function() {
     }));
   });
 
+  test('config contains quotes and backslashes', function() {
+    var config = {
+      user: 'not\\brian',
+      password: 'bad\'chars',
+      port: 5432,
+      host: '/tmp/'
+    };
+    var subject = new ConnectionParameters(config);
+    subject.getLibpqConnectionString(assert.calls(function(err, constring) {
+      assert.isNull(err);
+      var parts = constring.split(" ");
+      checkForPart(parts, "user='not\\\\brian'");
+      checkForPart(parts, "password='bad\\'chars'");
+    }));
+  });
+
   test("encoding can be specified by config", function() {
     var config = {
       client_encoding: "utf-8"


### PR DESCRIPTION
While silly, the following are perfectly legal identifiers for a username and database:

```sql
-- Username contains a single quote
postgres=# CREATE USER "dumb'user" WITH PASSWORD 'abcd1234';
CREATE ROLE

-- Database name contains a backslash
postgres=# CREATE DATABASE "dumb\db" WITH OWNER "dumb'user";
CREATE DATABASE
```

The existing libpq config code blindly surrounds the passed in parameters using single quotes (ex: `foo => 'foo'`). That breaks down when there are backslashes or single quotes in the values.

This PR fixes handling of single quotes and backslashes in connection config values used to generate libpq connection strings by escaping any occurrences of those characters.

For most property names there is no change in the valid case (i.e. no funky chars) as they were already quoted. This just corrects handling when they have funky chars.

The two exceptions are `host`, and `hostaddr` which previously weren't escaped at all. There's no *valid* value for either of those that could contain a single quote or even whitespace so it was fine for the valid case. But that also means that you have a config injection if you pass an invalid value like `somehost foo=bar`. It's not really possible right now as there's also a DNS lookup which presumably would fail for such a host, but if it were ever removed (which may be a good idea as hostaddr is an optional field anyway and having it unspecified has some value as well) it'd be broken.

Either way, the new code also escapes/quotes them as well and I've updated a couple tests to take that into account.