### PR TITLE
Fix pg.connect pool storage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,6 @@ PG.prototype.connect = function(config, callback) {
     callback = config;
     config = null;
   }
-  var poolName = JSON.stringify(config || {});
   if (typeof config == 'string') {
     config = new ConnectionParameters(config);
   }
@@ -65,6 +64,8 @@ PG.prototype.connect = function(config, callback) {
   config.max = config.max || config.poolSize || defaults.poolSize;
   config.idleTimeoutMillis = config.idleTimeoutMillis || config.poolIdleTimeout || defaults.poolIdleTimeout;
   config.log = config.log || config.poolLog || defaults.poolLog;
+
+  var poolName = JSON.stringify(config);
 
   this._pools[poolName] = this._pools[poolName] || new this.Pool(config);
   var pool = this._pools[poolName];


### PR DESCRIPTION
Fixes: #1294 by serializing the config object after all mutations that affect it.
May be better to non mutate params, but it will require more changes.