### PR TITLE
Properly insert buffers in arrays.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,6 +31,9 @@ function arrayString(val) {
     else if(Array.isArray(val[i])) {
       result = result + arrayString(val[i]);
     }
+    else if(val[i] instanceof Buffer) {
+      result += '\\\\x' + val[i].toString('hex');
+    }
     else
     {
       result += escapeElement(prepareValue(val[i]));

--- a/test/unit/utils-tests.js
+++ b/test/unit/utils-tests.js
@@ -126,6 +126,13 @@ test('prepareValue: date array prepared properly', function() {
   helper.resetTimezoneOffset();
 });
 
+test('prepareValue: buffer array prepared properly', function() {
+  var buffer1 = Buffer.from('dead', 'hex');
+  var buffer2 = Buffer.from('beef', 'hex');
+  var out = utils.prepareValue([buffer1, buffer2]);
+  assert.strictEqual(out, '{\\\\xdead,\\\\xbeef}');
+});
+
 test('prepareValue: arbitrary objects prepared properly', function() {
   var out = utils.prepareValue({ x: 42 });
   assert.strictEqual(out, '{"x":42}');

--- a/test/unit/utils-tests.js
+++ b/test/unit/utils-tests.js
@@ -127,8 +127,8 @@ test('prepareValue: date array prepared properly', function() {
 });
 
 test('prepareValue: buffer array prepared properly', function() {
-  var buffer1 = Buffer.from('dead', 'hex');
-  var buffer2 = Buffer.from('beef', 'hex');
+  var buffer1 = Buffer.from ? Buffer.from('dead', 'hex') : new Buffer('dead', 'hex');
+  var buffer2 = Buffer.from ? Buffer.from('beef', 'hex') : new Buffer('beef', 'hex');
   var out = utils.prepareValue([buffer1, buffer2]);
   assert.strictEqual(out, '{\\\\xdead,\\\\xbeef}');
 });


### PR DESCRIPTION
Before this commit, when someone tried to insert a Buffer into an array,
the library would try to escape it (by calling the `escapeElement` on
it), which would fail because buffers don't have a `replace` method.