### PR TITLE
Update Travis-CI Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,22 @@ matrix:
     - node_js: "6"
       addons:
         postgresql: "9.6"
+    - node_js: "8"
+      addons:
+        postgresql: "9.1"
+      dist: precise
+    - node_js: "8"
+      addons:
+        postgresql: "9.2"
+    - node_js: "8"
+      addons:
+        postgresql: "9.3"
+    - node_js: "8"
+      addons:
+        postgresql: "9.4"
+    - node_js: "8"
+      addons:
+        postgresql: "9.5"
+    - node_js: "8"
+      addons:
+        postgresql: "9.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ before_script:
 env:
   - CC=clang CXX=clang++ npm_config_clang=1 PGUSER=postgres PGDATABASE=postgres
 
-node_js: "6"
-addons:
-  postgresql: "9.6"
-
 matrix:
   include:
     - node_js: "4"
@@ -34,3 +30,6 @@ matrix:
     - node_js: "6"
       addons:
         postgresql: "9.5"
+    - node_js: "6"
+      addons:
+        postgresql: "9.6"


### PR DESCRIPTION
Two commits in this PR:

* First one normalizes the Travis-CI matrix by moving the default node 6 / PG 9.6 combo into the matrix.
* Second one adds Node 8.x to the matrix as it's going to be the next LTS version of node. For 8.x I've included the full set of PG versions from 9.1 - 9.6.

The entire test suite passes for 8.x and it's starting to become the default target for new apps so would be good to be a step a head on compatibility testing and keep things green.

Also, granted it's a small sample size, but the latest Travis build matrix shows 8.x running the test suite 25% faster than 4.x or 6.x. Pretty nifty!