### PR TITLE
Deprecate event query events

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -112,52 +112,8 @@ Client.prototype.connect = function(callback) {
   //after the connection initially becomes ready for queries
   con.once('readyForQuery', function() {
     self._connecting = false;
+    self._attachListeners(con);
 
-    //delegate rowDescription to active query
-    con.on('rowDescription', function(msg) {
-      self.activeQuery.handleRowDescription(msg);
-    });
-
-    //delegate dataRow to active query
-    con.on('dataRow', function(msg) {
-      self.activeQuery.handleDataRow(msg);
-    });
-
-    //delegate portalSuspended to active query
-    con.on('portalSuspended', function(msg) {
-      self.activeQuery.handlePortalSuspended(con);
-    });
-
-    //deletagate emptyQuery to active query
-    con.on('emptyQuery', function(msg) {
-      self.activeQuery.handleEmptyQuery(con);
-    });
-
-    //delegate commandComplete to active query
-    con.on('commandComplete', function(msg) {
-      self.activeQuery.handleCommandComplete(msg, con);
-    });
-
-    //if a prepared statement has a name and properly parses
-    //we track that its already been executed so we don't parse
-    //it again on the same client
-    con.on('parseComplete', function(msg) {
-      if(self.activeQuery.name) {
-        con.parsedStatements[self.activeQuery.name] = true;
-      }
-    });
-
-    con.on('copyInResponse', function(msg) {
-      self.activeQuery.handleCopyInResponse(self.connection);
-    });
-
-    con.on('copyData', function (msg) {
-      self.activeQuery.handleCopyData(msg, self.connection);
-    });
-
-    con.on('notification', function(msg) {
-      self.emit('notification', msg);
-    });
 
     //process possible callback argument to Client#connect
     if (callback) {
@@ -241,10 +197,58 @@ Client.prototype.connect = function(callback) {
       })
     })
   }
-
 };
 
-Client.prototype.getStartupConf = function() {
+Client.prototype._attachListeners = function(con) {
+  const self = this
+  //delegate rowDescription to active query
+  con.on('rowDescription', function (msg) {
+    self.activeQuery.handleRowDescription(msg);
+  });
+
+  //delegate dataRow to active query
+  con.on('dataRow', function (msg) {
+    self.activeQuery.handleDataRow(msg);
+  });
+
+  //delegate portalSuspended to active query
+  con.on('portalSuspended', function (msg) {
+    self.activeQuery.handlePortalSuspended(con);
+  });
+
+  //deletagate emptyQuery to active query
+  con.on('emptyQuery', function (msg) {
+    self.activeQuery.handleEmptyQuery(con);
+  });
+
+  //delegate commandComplete to active query
+  con.on('commandComplete', function (msg) {
+    self.activeQuery.handleCommandComplete(msg, con);
+  });
+
+  //if a prepared statement has a name and properly parses
+  //we track that its already been executed so we don't parse
+  //it again on the same client
+  con.on('parseComplete', function (msg) {
+    if (self.activeQuery.name) {
+      con.parsedStatements[self.activeQuery.name] = true;
+    }
+  });
+
+  con.on('copyInResponse', function (msg) {
+    self.activeQuery.handleCopyInResponse(self.connection);
+  });
+
+  con.on('copyData', function (msg) {
+    self.activeQuery.handleCopyData(msg, self.connection);
+  });
+
+  con.on('notification', function (msg) {
+    self.emit('notification', msg);
+  });
+}
+
+Client.prototype.getStartupConf = function () {
   var params = this.connectionParameters;
 
   var data = {
@@ -263,41 +267,41 @@ Client.prototype.getStartupConf = function() {
   return data;
 };
 
-Client.prototype.cancel = function(client, query) {
-  if(client.activeQuery == query) {
+Client.prototype.cancel = function (client, query) {
+  if (client.activeQuery == query) {
     var con = this.connection;
 
-    if(this.host && this.host.indexOf('/') === 0) {
+    if (this.host && this.host.indexOf('/') === 0) {
       con.connect(this.host + '/.s.PGSQL.' + this.port);
     } else {
       con.connect(this.port, this.host);
     }
 
     //once connection is established send cancel message
-    con.on('connect', function() {
+    con.on('connect', function () {
       con.cancel(client.processID, client.secretKey);
     });
-  } else if(client.queryQueue.indexOf(query) != -1) {
+  } else if (client.queryQueue.indexOf(query) != -1) {
     client.queryQueue.splice(client.queryQueue.indexOf(query), 1);
   }
 };
 
-Client.prototype.setTypeParser = function(oid, format, parseFn) {
+Client.prototype.setTypeParser = function (oid, format, parseFn) {
   return this._types.setTypeParser(oid, format, parseFn);
 };
 
-Client.prototype.getTypeParser = function(oid, format) {
+Client.prototype.getTypeParser = function (oid, format) {
   return this._types.getTypeParser(oid, format);
 };
 
 // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
-Client.prototype.escapeIdentifier = function(str) {
+Client.prototype.escapeIdentifier = function (str) {
 
   var escaped = '"';
 
-  for(var i = 0; i < str.length; i++) {
+  for (var i = 0; i < str.length; i++) {
     var c = str[i];
-    if(c === '"') {
+    if (c === '"') {
       escaped += c + c;
     } else {
       escaped += c;
@@ -310,14 +314,14 @@ Client.prototype.escapeIdentifier = function(str) {
 };
 
 // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
-Client.prototype.escapeLiteral = function(str) {
+Client.prototype.escapeLiteral = function (str) {
 
   var hasBackslash = false;
   var escaped = '\'';
 
-  for(var i = 0; i < str.length; i++) {
+  for (var i = 0; i < str.length; i++) {
     var c = str[i];
-    if(c === '\'') {
+    if (c === '\'') {
       escaped += c + c;
     } else if (c === '\\') {
       escaped += c + c;
@@ -329,21 +333,21 @@ Client.prototype.escapeLiteral = function(str) {
 
   escaped += '\'';
 
-  if(hasBackslash === true) {
+  if (hasBackslash === true) {
     escaped = ' E' + escaped;
   }
 
   return escaped;
 };
 
-Client.prototype._pulseQueryQueue = function() {
-  if(this.readyForQuery===true) {
+Client.prototype._pulseQueryQueue = function () {
+  if (this.readyForQuery === true) {
     this.activeQuery = this.queryQueue.shift();
-    if(this.activeQuery) {
+    if (this.activeQuery) {
       this.readyForQuery = false;
       this.hasExecuted = true;
       this.activeQuery.submit(this.connection);
-    } else if(this.hasExecuted) {
+    } else if (this.hasExecuted) {
       this.activeQuery = null;
       this.emit('drain');
     }
@@ -358,7 +362,7 @@ Client.prototype.copyTo = function (text) {
   throw new Error("For PostgreSQL COPY TO/COPY FROM support npm install pg-copy-streams");
 };
 
-Client.prototype.query = function(config, values, callback) {
+Client.prototype.query = function (config, values, callback) {
   //can take in strings, config object or query object
   var query;
   var result;
@@ -376,10 +380,10 @@ Client.prototype.query = function(config, values, callback) {
     })
   }
 
-  if(this.binary && !query.binary) {
+  if (this.binary && !query.binary) {
     query.binary = true;
   }
-  if(query._result) {
+  if (query._result) {
     query._result._getTypeParser = this._types.getTypeParser.bind(this._types);
   }
 
@@ -388,7 +392,7 @@ Client.prototype.query = function(config, values, callback) {
   return result
 };
 
-Client.prototype.end = function(cb) {
+Client.prototype.end = function (cb) {
   this._ending = true;
   if (this.activeQuery) {
     // if we have an active query we need to force a disconnect
@@ -407,7 +411,7 @@ Client.prototype.end = function(cb) {
   }
 };
 
-Client.md5 = function(string) {
+Client.md5 = function (string) {
   return crypto.createHash('md5').update(string, 'utf-8').digest('hex');
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -374,7 +374,6 @@ Client.prototype.query = function (config, values, callback) {
     }
   } else {
     query = new Query(config, values, callback)
-    query._deprecateListeners()
     result = query
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -362,6 +362,8 @@ Client.prototype.copyTo = function (text) {
   throw new Error("For PostgreSQL COPY TO/COPY FROM support npm install pg-copy-streams");
 };
 
+const DeprecatedQuery = require('./utils').deprecateEventEmitter(Query)
+
 Client.prototype.query = function (config, values, callback) {
   //can take in strings, config object or query object
   var query;
@@ -373,7 +375,7 @@ Client.prototype.query = function (config, values, callback) {
       query.callback = query.callback || values
     }
   } else {
-    query = new Query(config, values, callback)
+    query = new DeprecatedQuery(config, values, callback)
     result = query
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -374,10 +374,8 @@ Client.prototype.query = function (config, values, callback) {
     }
   } else {
     query = new Query(config, values, callback)
-    result = query.callback ? undefined : new global.Promise((resolve, reject) => {
-      query.once('end', resolve)
-      query.once('error', reject)
-    })
+    query._deprecateListeners()
+    result = query
   }
 
   if (this.binary && !query.binary) {

--- a/lib/native/client.js
+++ b/lib/native/client.js
@@ -131,14 +131,9 @@ Client.prototype.query = function(config, values, callback) {
   }
 
   var query = new NativeQuery(config, values, callback);
-  var result = query.callback ? query : new global.Promise(function(resolve, reject) {
-    query.on('end', resolve);
-    query.on('error', reject);
-  });
-
   this._queryQueue.push(query);
   this._pulseQueryQueue();
-  return result;
+  return query;
 };
 
 //disconnect from the backend server

--- a/lib/native/client.js
+++ b/lib/native/client.js
@@ -109,6 +109,8 @@ Client.prototype.connect = function(cb) {
   return result
 };
 
+const DeprecatedQuery = require('../utils').deprecateEventEmitter(NativeQuery)
+
 //send a query to the server
 //this method is highly overloaded to take
 //1) string query, optional array of parameters, optional function callback
@@ -130,7 +132,7 @@ Client.prototype.query = function(config, values, callback) {
     return config;
   }
 
-  var query = new NativeQuery(config, values, callback);
+  var query = new DeprecatedQuery(config, values, callback);
   this._queryQueue.push(query);
   this._pulseQueryQueue();
   return query;

--- a/lib/native/query.js
+++ b/lib/native/query.js
@@ -78,8 +78,8 @@ NativeQuery.prototype.catch = function(callback) {
 NativeQuery.prototype._getPromise = function() {
   if (this._promise) return this._promise;
   this._promise = new Promise(function(resolve, reject) {
-    this.once('end', resolve);
-    this.once('error', reject);
+    this._once('end', resolve);
+    this._once('error', reject);
   }.bind(this));
   return this._promise;
 };

--- a/lib/native/query.js
+++ b/lib/native/query.js
@@ -67,6 +67,23 @@ NativeQuery.prototype.handleError = function(err) {
   self.state = 'error';
 };
 
+NativeQuery.prototype.then = function(onSuccess, onFailure) {
+  return this._getPromise().then(onSuccess, onFailure);
+};
+
+NativeQuery.prototype.catch = function(callback) {
+  return this._getPromise().catch(callback);
+};
+
+NativeQuery.prototype._getPromise = function() {
+  if (this._promise) return this._promise;
+  this._promise = new Promise(function(resolve, reject) {
+    this.once('end', resolve);
+    this.once('error', reject);
+  }.bind(this));
+  return this._promise;
+};
+
 NativeQuery.prototype.submit = function(client) {
   this.state = 'running';
   var self = this;

--- a/lib/query.js
+++ b/lib/query.js
@@ -64,8 +64,8 @@ Query.prototype.catch = function(callback) {
 Query.prototype._getPromise = function() {
   if (this._promise) return this._promise;
   this._promise = new Promise(function(resolve, reject) {
-    this.once('end', resolve);
-    this.once('error', reject);
+    this._once('end', resolve);
+    this._once('error', reject);
   }.bind(this));
   return this._promise;
 };

--- a/lib/query.js
+++ b/lib/query.js
@@ -70,9 +70,6 @@ Query.prototype._getPromise = function() {
   return this._promise;
 };
 
-Query.prototype._deprecateListeners = function() {
-}
-
 //associates row metadata from the supplied
 //message with this query object
 //metadata used when parsing row results

--- a/lib/query.js
+++ b/lib/query.js
@@ -53,6 +53,25 @@ Query.prototype.requiresPreparation = function() {
   return this.values.length > 0;
 };
 
+Query.prototype.then = function(onSuccess, onFailure) {
+  return this._getPromise().then(onSuccess, onFailure);
+};
+
+Query.prototype.catch = function(callback) {
+  return this._getPromise().catch(callback);
+};
+
+Query.prototype._getPromise = function() {
+  if (this._promise) return this._promise;
+  this._promise = new Promise(function(resolve, reject) {
+    this.once('end', resolve);
+    this.once('error', reject);
+  }.bind(this));
+  return this._promise;
+};
+
+Query.prototype._deprecateListeners = function() {
+}
 
 //associates row metadata from the supplied
 //message with this query object

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@
  * README.md file in the root directory of this source tree.
  */
 
+const util = require('util')
 var defaults = require('./defaults');
 
 function escapeElement(elementRepresentation) {
@@ -137,11 +138,29 @@ function normalizeQueryConfig (config, values, callback) {
   return config;
 }
 
+const queryEventEmitterOverloadDeprecationMessage = `
+Using the automatically created return value from client.query as an event emitter is deprecated.
+Use either the callback or promise interface.
+`
+
+const deprecateEventEmitter = function(Emitter) {
+  const Result = function () {
+    Emitter.apply(this, arguments)
+  }
+  util.inherits(Result, Emitter)
+  Result.prototype._on = Result.prototype.on
+  Result.prototype._once = Result.prototype.once
+  Result.prototype.on = util.deprecate(Result.prototype.on, queryEventEmitterOverloadDeprecationMessage)
+  Result.prototype.once = util.deprecate(Result.prototype.once, queryEventEmitterOverloadDeprecationMessage)
+  return Result
+}
+
 module.exports = {
   prepareValue: function prepareValueWrapper (value) {
     //this ensures that extra arguments do not get passed into prepareValue
     //by accident, eg: from calling values.map(utils.prepareValue)
     return prepareValue(value);
   },
-  normalizeQueryConfig: normalizeQueryConfig
+  normalizeQueryConfig: normalizeQueryConfig,
+  deprecateEventEmitter: deprecateEventEmitter,
 };

--- a/test/integration/client/deprecated-listener-tests.js
+++ b/test/integration/client/deprecated-listener-tests.js
@@ -1,0 +1,30 @@
+const helper = require('./test-helper')
+const pg = helper.pg
+const suite = new helper.Suite()
+
+suite.test('Query with a callback should still support event-listeners', (done) => {
+  const client = new pg.Client()
+  const sink = new helper.Sink(3, 1000, () => {
+    client.end()
+    done()
+  })
+  client.connect()
+  const query = client.query('SELECT NOW()', (err, res) => {
+    sink.add()
+  })
+  query.on('row', () => sink.add())
+  query.on('end', () => sink.add())
+})
+
+suite.test('Query with a promise should still support event-listeners', (done) => {
+  const client = new pg.Client()
+  const sink = new helper.Sink(3, 1000, () => {
+    client.end()
+    done()
+  })
+  client.connect()
+  const query = client.query('SELECT NOW()')
+  query.on('row', () => sink.add())
+  query.on('end', () => sink.add())
+  query.then(() => sink.add())
+})

--- a/test/unit/client/test-helper.js
+++ b/test/unit/client/test-helper.js
@@ -1,5 +1,6 @@
-var helper = require(__dirname+'/../test-helper');
-var Connection = require(__dirname + '/../../../lib/connection');
+var helper = require('../test-helper');
+var Connection = require('../../../lib/connection');
+
 var makeClient = function() {
   var connection = new Connection({stream: "no"});
   connection.startup = function() {};
@@ -14,6 +15,6 @@ var makeClient = function() {
   return client;
 };
 
-module.exports = {
+module.exports = Object.assign({
   client: makeClient
-};
+}, helper);

--- a/test/unit/client/throw-in-type-parser-tests.js
+++ b/test/unit/client/throw-in-type-parser-tests.js
@@ -1,112 +1,69 @@
 var helper = require("./test-helper");
-var Query = require('../../../lib/query')
-var types = require('pg-types')
+var Query = require("../../../lib/query");
+var types = require("pg-types");
 
-test('handles throws in type parsers', function() {
-  var typeParserError = new Error('TEST: Throw in type parsers');
+const suite = new helper.Suite();
 
-  types.setTypeParser('special oid that will throw', function () {
-    throw typeParserError;
-  });
+var typeParserError = new Error("TEST: Throw in type parsers");
 
-  test('emits error', function() {
-    var handled;
-    var client = helper.client();
-    var con = client.connection;
-    var query = client.query(new Query('whatever'));
+types.setTypeParser("special oid that will throw", function() {
+  throw typeParserError;
+});
 
-    handled = con.emit('readyForQuery');
-    assert.ok(handled, "should have handled ready for query");
+const emitFakeEvents = con => {
+  setImmediate(() => {
+    con.emit("readyForQuery");
 
-    con.emit('rowDescription',{
-      fields: [{
-        name: 'boom',
-        dataTypeID: 'special oid that will throw'
-      }]
-    });
-    assert.ok(handled, "should have handled row description");
-
-    assert.emits(query, 'error', function(err) {
-      assert.equal(err, typeParserError);
+    con.emit("rowDescription", {
+      fields: [
+        {
+          name: "boom",
+          dataTypeID: "special oid that will throw"
+        }
+      ]
     });
 
-    handled = con.emit('dataRow', { fields: ["hi"] });
-    assert.ok(handled, "should have handled first data row message");
+    con.emit("dataRow", { fields: ["hi"] });
+    con.emit("dataRow", { fields: ["hi"] });
+    con.emit("commandComplete", { text: "INSERT 31 1" });
+    con.emit("readyForQuery");
+  });
+};
 
-    handled = con.emit('commandComplete', { text: 'INSERT 31 1' });
-    assert.ok(handled, "should have handled command complete");
+suite.test("emits error", function(done) {
+  var handled;
+  var client = helper.client();
+  var con = client.connection;
+  var query = client.query(new Query("whatever"));
+  emitFakeEvents(con)
 
-    handled = con.emit('readyForQuery');
-    assert.ok(handled, "should have handled ready for query");
+  assert.emits(query, "error", function(err) {
+    assert.equal(err, typeParserError);
+    done();
+  });
+});
+
+suite.test("calls callback with error", function(done) {
+  var handled;
+
+  var callbackCalled = 0;
+
+  var client = helper.client();
+  var con = client.connection;
+  emitFakeEvents(con);
+  var query = client.query("whatever", function(err) {
+    assert.equal(err, typeParserError);
+    done();
   });
 
-  test('calls callback with error', function() {
-    var handled;
+});
 
-    var callbackCalled = 0;
-
-    var client = helper.client();
-    var con = client.connection;
-    var query = client.query('whatever', assert.calls(function (err) {
-      callbackCalled += 1;
-
-      assert.equal(callbackCalled, 1);
-      assert.equal(err, typeParserError);
-    }));
-
-    handled = con.emit('readyForQuery');
-    assert.ok(handled, "should have handled ready for query");
-
-    handled = con.emit('rowDescription',{
-      fields: [{
-        name: 'boom',
-        dataTypeID: 'special oid that will throw'
-      }]
-    });
-    assert.ok(handled, "should have handled row description");
-
-    handled = con.emit('dataRow', { fields: ["hi"] });
-    assert.ok(handled, "should have handled first data row message");
-
-    handled = con.emit('dataRow', { fields: ["hi"] });
-    assert.ok(handled, "should have handled second data row message");
-
-    con.emit('commandComplete', { text: 'INSERT 31 1' });
-    assert.ok(handled, "should have handled command complete");
-
-    handled = con.emit('readyForQuery');
-    assert.ok(handled, "should have handled ready for query");
+suite.test("rejects promise with error", function(done) {
+  var client = helper.client();
+  var con = client.connection;
+  emitFakeEvents(con);
+  client.query("whatever").catch(err => {
+    assert.equal(err, typeParserError);
+    done();
   });
-
-  test('rejects promise with error', function() {
-    var handled;
-    var client = helper.client();
-    var con = client.connection;
-    var queryPromise = client.query('whatever');
-
-    handled = con.emit('readyForQuery');
-    assert.ok(handled, "should have handled ready for query");
-
-    handled = con.emit('rowDescription',{
-      fields: [{
-        name: 'boom',
-        dataTypeID: 'special oid that will throw'
-      }]
-    });
-    assert.ok(handled, "should have handled row description");
-
-    handled = con.emit('dataRow', { fields: ["hi"] });
-    assert.ok(handled, "should have handled first data row message");
-
-    handled = con.emit('commandComplete', { text: 'INSERT 31 1' });
-    assert.ok(handled, "should have handled command complete");
-
-    handled = con.emit('readyForQuery');
-    assert.ok(handled, "should have handled ready for query");
-
-    queryPromise.catch(assert.calls(function (err) {
-      assert.equal(err, typeParserError);
-    }));
-  });
-
 });

--- a/test/unit/test-helper.js
+++ b/test/unit/test-helper.js
@@ -1,6 +1,8 @@
-var helper = require(__dirname+'/../test-helper');
 var EventEmitter = require('events').EventEmitter;
-var Connection = require(__dirname + '/../../lib/connection');
+
+var helper = require('../test-helper');
+var Connection = require('../../lib/connection');
+
 MemoryStream = function() {
   EventEmitter.call(this);
   this.packets = [];


### PR DESCRIPTION
This adds a deprecation warning to using events on automatically constructed and returned query instances.  Passing your own instance of query to the `client.query` function is still supported & wont be deprecated.  This  is related to the effort to clean up the API and return `undefined` when calling `client.query` with a callback, and returning a pure `Promise` instance when calling `client.query` without a callback.

see: https://github.com/brianc/node-postgres/issues/1299