### PR TITLE
Better verifiication for query strings would save inexperienced users time.

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -127,6 +127,12 @@ Query.prototype.handleError = function(err, connection) {
 };
 
 Query.prototype.submit = function(connection) {
+  if (typeof this.text != 'string' && typeof this.name != 'string') {
+    const err = new Error('A query must have either text or a name. Supplying neither is unsupported.')
+    connection.emit('error', err)
+    connection.emit('readyForQuery')
+    return
+  }
   if(this.requiresPreparation()) {
     this.prepare(connection);
   } else {

--- a/test/integration/client/error-handling-tests.js
+++ b/test/integration/client/error-handling-tests.js
@@ -159,3 +159,16 @@ suite.test('connected, idle client error', (done) => {
     client.end(done)
   })
 })
+
+suite.test('cannot pass non-string values to query as text', (done) => {
+  const client = new Client()
+  client.connect()
+  client.query({ text: { } }, (err) => {
+    assert(err)
+    client.query({ }, (err) => {
+      client.on('drain', () => {
+        client.end(done)
+      })
+    })
+  })
+})


### PR DESCRIPTION
A query must have either `text:string` or `name:string` - supplying neither is undefined and previously resulted in a hard to catch error.  I was using `hub` from the cli & accidentally somehow blew away the original author's issue body.  whooooops.