### PR TITLE
Fix over-eager deprecation warnings

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -57,8 +57,18 @@ Query.prototype.catch = function(callback) {
 Query.prototype._getPromise = function () {
   if (this._promise) return this._promise;
   this._promise = new Promise(function(resolve, reject) {
-    this._once('end', resolve);
-    this._once('error', reject);
+    var onEnd = function (result) {
+      this.removeListener('error', onError);
+      this.removeListener('end', onEnd);
+      resolve(result);
+    };
+    var onError = function (err) {
+      this.removeListener('error', onError);
+      this.removeListener('end', onEnd);
+      reject(err);
+    };
+    this._on('end', onEnd);
+    this._on('error', onError);
   }.bind(this));
   return this._promise;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -139,7 +139,7 @@ function normalizeQueryConfig (config, values, callback) {
   return config;
 }
 
-var queryEventEmitterOverloadDeprecationMessage = 'Using the automatically created return value from client.query as an event emitter is deprecated. Please see the upgrade guide at https://node-postgres.com/guides/upgrading';
+var queryEventEmitterOverloadDeprecationMessage = 'Using the automatically created return value from client.query as an event emitter is deprecated and will be removed in pg@7.0. Please see the upgrade guide at https://node-postgres.com/guides/upgrading';
 
 var deprecateEventEmitter = function(Emitter) {
   var Result = function () {

--- a/test/integration/client/deprecation-tests.js
+++ b/test/integration/client/deprecation-tests.js
@@ -1,0 +1,23 @@
+var helper = require('./test-helper')
+process.noDeprecation = false
+process.on('warning', function () {
+  throw new Error('Should not emit deprecation warning')
+})
+
+var client = new helper.pg.Client()
+
+client.connect(function (err) {
+  console.log('connected')
+  client.query('SELECT NOW()')
+    .then(function (res) {
+      console.log('got result')
+      console.log(res.rows)
+      client.end(function () {
+        console.log('ended')
+      })
+    }).catch(function (err) {
+      setImmediate(function () {
+        throw err
+      })
+    })
+})

--- a/test/integration/client/deprecation-tests.js
+++ b/test/integration/client/deprecation-tests.js
@@ -7,13 +7,12 @@ process.on('warning', function () {
 var client = new helper.pg.Client()
 
 client.connect(function (err) {
-  console.log('connected')
+  if (err) throw err
   client.query('SELECT NOW()')
     .then(function (res) {
-      console.log('got result')
-      console.log(res.rows)
-      client.end(function () {
-        console.log('ended')
+      client.query('SELECT NOW()', function () {
+        client.end(function () {
+        })
       })
     }).catch(function (err) {
       setImmediate(function () {


### PR DESCRIPTION
Deprecation warnings were being printed even when not using `query.on`.