### PR TITLE
use consistent syntax for semver ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pg-connection-string": "0.1.3",
     "pg-pool": "1.*",
     "pg-types": "1.*",
-    "pgpass": "1.x",
+    "pgpass": "1.*",
     "semver": "4.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The mixing of `1.*` and `1.x` syntax confused me a little at first.