### PR TITLE
add missing sslrootcert for native bindings

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -91,6 +91,7 @@ ConnectionParameters.prototype.getLibpqConnectionString = function (cb) {
   add(params, ssl, 'sslca')
   add(params, ssl, 'sslkey')
   add(params, ssl, 'sslcert')
+  add(params, ssl, 'sslrootcert')
 
   if (this.database) {
     params.push('dbname=' + quoteParamValue(this.database))

--- a/test/unit/connection-parameters/creation-tests.js
+++ b/test/unit/connection-parameters/creation-tests.js
@@ -269,4 +269,32 @@ test('libpq connection string building', function () {
     var c = new Client('postgres://user@password:host/database')
     assert(c.ssl, 'Client should have ssl enabled via defaults')
   })
+
+  test('ssl is set on client', function () {
+    var sourceConfig = {
+      user: 'brian',
+      password: 'hello<ther>e',
+      port: 5432,
+      host: 'localhost',
+      database: 'postgres',
+      ssl: {
+        sslmode: 'verify-ca',
+        sslca: '/path/ca.pem',
+        sslkey: '/path/cert.key',
+        sslcert: '/path/cert.crt',
+        sslrootcert: '/path/root.crt'
+      }
+    }
+    var Client = require('../../../lib/client')
+    var defaults = require('../../../lib/defaults')
+    defaults.ssl = true
+    var c = new ConnectionParameters(sourceConfig)
+    c.getLibpqConnectionString(assert.calls(function (err, pgCString) {
+      assert(!err)
+      assert.equal(
+        pgCString.indexOf('sslrootcert=\'/path/root.crt\'') !== -1, true,
+        'libpqConnectionString should contain sslrootcert'
+      )
+    }))
+  })
 })


### PR DESCRIPTION
This fixes an error when using the native bindings, where the rootcert can never be found as it is just simply not passed by.

refers to #1358 