### PR TITLE
allow both connectionString and additional options

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -11,6 +11,8 @@ var dns = require('dns')
 
 var defaults = require('./defaults')
 
+var parse = require('pg-connection-string').parse // parses a connection string
+
 var val = function (key, config, envVar) {
   if (envVar === undefined) {
     envVar = process.env[ 'PG' + key.toUpperCase() ]
@@ -24,9 +26,6 @@ var val = function (key, config, envVar) {
     envVar ||
     defaults[key]
 }
-
-// parses a connection string
-var parse = require('pg-connection-string').parse
 
 var useSsl = function () {
   switch (process.env.PGSSLMODE) {
@@ -43,12 +42,14 @@ var useSsl = function () {
 
 var ConnectionParameters = function (config) {
   // if a string is passed, it is a raw connection string so we parse it into a config
-  config = typeof config === 'string' ? parse(config) : (config || {})
+  config = typeof config === 'string' ? parse(config) : config || {}
+
   // if the config has a connectionString defined, parse IT into the config we use
   // this will override other default values with what is stored in connectionString
   if (config.connectionString) {
-    config = parse(config.connectionString)
+    config = Object.assign({}, config, parse(config.connectionString))
   }
+
   this.user = val('user', config)
   this.database = val('database', config)
   this.port = parseInt(val('port', config), 10)

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,10 +15,7 @@ var Pool = require('pg-pool')
 
 const poolFactory = (Client) => {
   var BoundPool = function (options) {
-    var config = { Client: Client }
-    for (var key in options) {
-      config[key] = options[key]
-    }
+    var config = Object.assign({ Client: Client }, options)
     return new Pool(config)
   }
 

--- a/test/unit/connection-parameters/creation-tests.js
+++ b/test/unit/connection-parameters/creation-tests.js
@@ -67,6 +67,28 @@ test('ConnectionParameters initializing from config', function () {
   assert.ok(subject.isDomainSocket === false)
 })
 
+test('ConnectionParameters initializing from config and config.connectionString', function() {
+  var subject1 = new ConnectionParameters({
+    connectionString: 'postgres://test@host/db'
+  })
+  var subject2 = new ConnectionParameters({
+    connectionString: 'postgres://test@host/db?ssl=1'
+  })
+  var subject3 = new ConnectionParameters({
+    connectionString: 'postgres://test@host/db',
+    ssl: true
+  })
+  var subject4 = new ConnectionParameters({
+    connectionString: 'postgres://test@host/db?ssl=1',
+    ssl: false
+  })
+
+  assert.equal(subject1.ssl, false)
+  assert.equal(subject2.ssl, true)
+  assert.equal(subject3.ssl, true)
+  assert.equal(subject4.ssl, true)
+});
+
 test('escape spaces if present', function () {
   var subject = new ConnectionParameters('postgres://localhost/post gres')
   assert.equal(subject.database, 'post gres')


### PR DESCRIPTION
allows
```js
var pool = new Pool({connectionString: 'postgres://foo@dom.com/db', ssl:true, max:4})
// will be an ssl connection with this PR
```
connectionString params will still override other options to stay compatible