### PR TITLE
Cache parsed connection strings

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -26,7 +26,17 @@ var val = function(key, config, envVar) {
 };
 
 //parses a connection string
-var parse = require('pg-connection-string').parse;
+var pgCS = require('pg-connection-string');
+
+var parsedConnectionStrings = {};
+
+function parse(cs) {
+  if(cs in parsedConnectionStrings) {
+    return parsedConnectionStrings[cs];
+  }
+  parsedConnectionStrings[cs] = pgCS.parse(cs);
+  return parsedConnectionStrings[cs];
+}
 
 var useSsl = function() {
   switch(process.env.PGSSLMODE) {


### PR DESCRIPTION
Cache parsed connection strings, to avoid continuous re-parsing.

A typical client that uses a connection string is passing it in every time it is trying to connect. There is no point running all the parsing every time this happens, which is a lot in a busy environment.

