### PR TITLE
Update minimum Node version to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 4.5.0"
   }
 }


### PR DESCRIPTION
`Buffer.alloc` and `Buffer.from` were only backported then. Addresses #1373.