### PR TITLE
Fixing invalid custom type check

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,7 +70,7 @@ var prepareValue = function (val, seen) {
 }
 
 function prepareObject (val, seen) {
-  if (val.toPostgres && typeof val.toPostgres === 'function') {
+  if (val && typeof val.toPostgres === 'function') {
     seen = seen || []
     if (seen.indexOf(val) !== -1) {
       throw new Error('circular reference detected while preparing "' + val + '" for query')


### PR DESCRIPTION
The old check did nothing useful, and the code would fail if `null` or `undefined` were passed in.
