### PR TITLE
Make client.end return promise with active query

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -400,7 +400,7 @@ Client.prototype.end = function (cb) {
     // if we have an active query we need to force a disconnect
     // on the socket - otherwise a hung query could block end forever
     this.connection.stream.destroy(new Error('Connection terminated by user'))
-    return
+    return cb ? cb() : Promise.resolve()
   }
   if (cb) {
     this.connection.end()

--- a/test/integration/gh-issues/1382-tests.js
+++ b/test/integration/gh-issues/1382-tests.js
@@ -1,0 +1,34 @@
+"use strict"
+var helper = require('./../test-helper')
+
+const suite = new helper.Suite()
+
+suite.test('calling end during active query should return a promise', (done) => {
+  const client = new helper.pg.Client()
+  let callCount = 0
+  // ensure both the query rejects and the end promise resolves
+  const after = () => {
+    if (++callCount > 1) {
+      done()
+    }
+  }
+  client.connect().then(() => {
+    client.query('SELECT NOW()').catch(after)
+    client.end().then(after)
+  })
+})
+
+suite.test('calling end during an active query should call end callback', (done) => {
+  const client = new helper.pg.Client()
+  let callCount = 0
+  // ensure both the query rejects and the end callback fires
+  const after = () => {
+    if (++callCount > 1) {
+      done()
+    }
+  }
+  client.connect().then(() => {
+    client.query('SELECT NOW()').catch(after)
+    client.end(after)
+  })
+})


### PR DESCRIPTION
Previous it returned `undefined` by mistake, causing an exception to be thrown in certain cases when calling `client.end().then()`.