### PR TITLE
Removes extra 'use strict'

### DIFF
--- a/test/integration/client/promise-api-tests.js
+++ b/test/integration/client/promise-api-tests.js
@@ -1,5 +1,4 @@
 'use strict'
-'use strict'
 
 const helper = require('./test-helper')
 const pg = helper.pg

--- a/test/suite.js
+++ b/test/suite.js
@@ -1,5 +1,4 @@
 'use strict'
-'use strict'
 
 const async = require('async')
 


### PR DESCRIPTION
Two of the test files have 'use strict' twice at the top. Probably from some copy pasta.