### PR TITLE
Remove unreachable default

### DIFF
--- a/lib/result.js
+++ b/lib/result.js
@@ -40,10 +40,9 @@ Result.prototype.addCommandComplete = function (msg) {
   }
   if (match) {
     this.command = match[1]
-    // match 3 will only be existing on insert commands
+    // match 3 will only exist on insert commands
     if (match[3]) {
-      // msg.value is from native bindings
-      this.rowCount = parseInt(match[3] || msg.value, 10)
+      this.rowCount = parseInt(match[3], 10)
       this.oid = parseInt(match[2], 10)
     } else {
       this.rowCount = parseInt(match[2], 10)


### PR DESCRIPTION
`match[3]` is always truthy in this block. Introduced in 102a069bd2360783eb106b4bbcfa93b3f7fd7030, for context if the correct fix is something else.