### PR TITLE
Pin child modules to tighter semver ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "packet-reader": "0.3.1",
     "js-string-escape": "1.0.1",
     "pg-connection-string": "0.1.3",
-    "pg-pool": "2.*",
-    "pg-types": "1.*",
+    "pg-pool": "~2.0.3",
+    "pg-types": "~1.12.1",
     "pgpass": "1.x",
     "semver": "4.3.2"
   },


### PR DESCRIPTION
Installing any semver major child for pg-types and pg-pool is good in theory but it makes it too easy to accidentally introduce a breaking change on semver minor bumps in those modules.  While we do our best to make sure not to break backwards compat in semver minor bumps there, mistakes can happen.  This pins things to patch only which will require me to release a new minor of pg whenever a child minor bump is required, but I think that's probably better for visiblity and changelog-ability.  And safer for the community so definitely a tradeoff I'm willing to support!