### PR TITLE
Save an array value to jsonb type column

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,25 +11,30 @@ var defaults = require('./defaults');
 // convert a JS array to a postgres array literal
 // uses comma separator so won't work for types like box that use
 // a different array separator.
+// for json type column, it should be return a json string
 function arrayString(val) {
-  var result = '{';
-  for (var i = 0 ; i < val.length; i++) {
-    if(i > 0) {
-      result = result + ',';
+  if (val && val.length > 0 && typeof(val[0]) === 'object' && typeof val[0].toPostgres != 'function') {
+    return JSON.stringify(val);
+  } else {
+    var result = '{';
+    for (var i = 0 ; i < val.length; i++) {
+      if(i > 0) {
+        result = result + ',';
+      }
+      if(val[i] === null || typeof val[i] === 'undefined') {
+        result = result + 'NULL';
+      }
+      else if(Array.isArray(val[i])) {
+        result = result + arrayString(val[i]);
+      }
+      else
+      {
+        result = result + JSON.stringify(prepareValue(val[i]));
+      }
     }
-    if(val[i] === null || typeof val[i] === 'undefined') {
-      result = result + 'NULL';
-    }
-    else if(Array.isArray(val[i])) {
-      result = result + arrayString(val[i]);
-    }
-    else
-    {
-      result = result + JSON.stringify(prepareValue(val[i]));
-    }
+    result = result + '}';
+    return result;
   }
-  result = result + '}';
-  return result;
 }
 
 //converts values from javascript types


### PR DESCRIPTION
```sql
CREATE TABLE public.jsontest (
	test jsonb NULL
)
WITH (
	OIDS=FALSE
);
```

```js
pool.connect(function(errp, client, done) {
  client.query('INSERT INTO jsontest(test1) VALUES($1::jsonb);', [[{"id":1, "name":"LFB"}, {"id":2, "name":"ZHM"}]], function(e,d) {
      console.log(e);
      console.log(d);
      done();
  });
});

* It returns:
{ error: invalid input syntax for type json
    at Connection.parseE (E:\develop\nodejs\mongoOPLog\node_modules\pg\lib\connection.js:546:11)
    at Connection.parseMessage (E:\develop\nodejs\mongoOPLog\node_modules\pg\lib\connection.js:371:19)
    at Socket.<anonymous> (E:\develop\nodejs\mongoOPLog\node_modules\pg\lib\connection.js:114:22)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at TCP.onread (net.js:547:20)
  name: 'error',
  length: 174,
  severity: 'ERROR',
  code: '22P02',
  detail: 'Expected ":", but found ",".',
  hint: undefined,
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: 'JSON data, line 1: {"{\\"id\\":1,\\"name\\":\\"LFB\\"}",...',
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'json.c',
  line: '1151',
  routine: 'report_parse_error' }
```

You can fix it by:
```js
pool.connect(function(errp, client, done) {
  client.query('INSERT INTO jsontest(test1) VALUES($1::jsonb);', [JSON.stringify([{"id":1, "name":"LFB"}, {"id":2, "name":"ZHM"}])], function(e,d) {
      console.log(e);
      console.log(d);
      done();
  });
});
```

But if modify the arrayString function in utils.js, It will be more convenient.