### PR TITLE
Change Makefile to use local eslint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ test-pool:
 
 lint:
 	@echo "***Starting lint***"
-	eslint lib
+	node_modules/.bin/eslint lib


### PR DESCRIPTION
Changes the Makefile lint target to use the local copy of eslint that would be installed in node_modules rather than a global copy that may not be installed.