### PR TITLE
Centralize md5 hash logic

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -106,10 +106,7 @@ Client.prototype.connect = function (callback) {
 
   // password request handling
   con.on('authenticationMD5Password', checkPgPass(function (msg) {
-    var inner = utils.md5(self.password + self.user)
-    var outer = utils.md5(Buffer.concat([Buffer.from(inner), msg.salt]))
-    var md5password = 'md5' + outer
-    con.password(md5password)
+    con.password(utils.postgresMd5PasswordHash(self.user, self.password, msg.salt))
   }))
 
   con.once('backendKeyData', function (msg) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -151,7 +151,7 @@ module.exports = {
     // by accident, eg: from calling values.map(utils.prepareValue)
     return prepareValue(value)
   },
-  normalizeQueryConfig: normalizeQueryConfig,
-  postgresMd5PasswordHash: postgresMd5PasswordHash,
-  md5: md5
+  normalizeQueryConfig,
+  postgresMd5PasswordHash,
+  md5
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -138,6 +138,13 @@ const md5 = function (string) {
   return crypto.createHash('md5').update(string, 'utf-8').digest('hex')
 }
 
+// See AuthenticationMD5Password at https://www.postgresql.org/docs/current/static/protocol-flow.html
+const postgresMd5PasswordHash = function (user, password, salt) {
+  var inner = md5(password + user)
+  var outer = md5(Buffer.concat([Buffer.from(inner), salt]))
+  return 'md5' + outer
+}
+
 module.exports = {
   prepareValue: function prepareValueWrapper (value) {
     // this ensures that extra arguments do not get passed into prepareValue
@@ -145,5 +152,6 @@ module.exports = {
     return prepareValue(value)
   },
   normalizeQueryConfig: normalizeQueryConfig,
+  postgresMd5PasswordHash: postgresMd5PasswordHash,
   md5: md5
 }

--- a/test/integration/connection/test-helper.js
+++ b/test/integration/connection/test-helper.js
@@ -21,9 +21,7 @@ var connect = function (callback) {
       con.password(helper.args.password)
     })
     con.once('authenticationMD5Password', function (msg) {
-      var inner = utils.md5(helper.args.password + helper.args.user)
-      var outer = utils.md5(Buffer.concat([Buffer.from(inner), msg.salt]))
-      con.password('md5' + outer)
+      con.password(utils.postgresMd5PasswordHash(helper.args.user, helper.args.password, msg.salt));
     })
     con.once('readyForQuery', function () {
       con.query('create temp table ids(id integer)')

--- a/test/integration/connection/test-helper.js
+++ b/test/integration/connection/test-helper.js
@@ -2,6 +2,7 @@
 var net = require('net')
 var helper = require(__dirname + '/../test-helper')
 var Connection = require(__dirname + '/../../../lib/connection')
+var utils = require(__dirname + '/../../../lib/utils')
 var connect = function (callback) {
   var username = helper.args.user
   var database = helper.args.database
@@ -20,10 +21,8 @@ var connect = function (callback) {
       con.password(helper.args.password)
     })
     con.once('authenticationMD5Password', function (msg) {
-      // need js client even if native client is included
-      var client = require(__dirname + '/../../../lib/client')
-      var inner = client.md5(helper.args.password + helper.args.user)
-      var outer = client.md5(inner + msg.salt.toString('binary'))
+      var inner = utils.md5(helper.args.password + helper.args.user)
+      var outer = utils.md5(Buffer.concat([Buffer.from(inner), msg.salt]))
       con.password('md5' + outer)
     })
     con.once('readyForQuery', function () {

--- a/test/unit/client/md5-password-tests.js
+++ b/test/unit/client/md5-password-tests.js
@@ -11,9 +11,7 @@ test('md5 authentication', function () {
   test('responds', function () {
     assert.lengthIs(client.connection.stream.packets, 1)
     test('should have correct encrypted data', function () {
-      var encrypted = utils.md5(client.password + client.user)
-      encrypted = utils.md5(encrypted + salt.toString('binary'))
-      var password = 'md5' + encrypted
+      var password = utils.postgresMd5PasswordHash(client.user, client.password, salt)
       // how do we want to test this?
       assert.equalBuffers(client.connection.stream.packets[0], new BufferList()
                         .addCString(password).join(true, 'p'))


### PR DESCRIPTION
Two commits in this PR. The second replaces a bit of the first one but I've kept it separate as they have different purposes.

The first commit fixes references to the `client.md5(...)` helper function that was moved to `utils.js` in 2300445646db264fe03a6194e2e7a77887204027.

This had broken the connection integration tests when run with md5 auth for the test credentials. My local setup connects to a PG database inside a VM via md5 auth and I ran into this trying to run the full test suite locally.

I believe we never noticed in Travis because it's connecting to localhost without a password and that code is never executing (the no-password auth piece runs instead). I was initially worried that they weren't being run at all... but they are an all the tests pass both locally and on Travis (:thumbsup:). 

The second commit centralizes the Postgres MD5 password hashing logic so that it's in one function in `utils`. Duplication of that logic in client.js and in the tests has been updated with calls to the new function.

We should look into adding a "with a password" auth environment to CI so that these tests get run regularly as well.