### PR TITLE
Remove deprecated pool options from defaults

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -35,23 +35,15 @@ module.exports = {
   // binary result mode
   binary: false,
 
-  // Connection pool options - see https://github.com/coopernurse/node-pool
+  // Connection pool options - see https://github.com/brianc/node-pg-pool
+
   // number of connections to use in connection pool
   // 0 will disable connection pooling
   poolSize: 10,
 
   // max milliseconds a client can go unused before it is removed
   // from the pool and destroyed
-  poolIdleTimeout: 30000,
-
-  // frequency to check for idle clients within the client pool
-  reapIntervalMillis: 1000,
-
-  // if true the most recently released resources will be the first to be allocated
-  returnToHead: false,
-
-  // pool log function / boolean
-  poolLog: false,
+  idleTimeoutMillis: 30000,
 
   client_encoding: '',
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -39,7 +39,7 @@ module.exports = {
 
   // number of connections to use in connection pool
   // 0 will disable connection pooling
-  poolSize: 10,
+  max: 10,
 
   // max milliseconds a client can go unused before it is removed
   // from the pool and destroyed

--- a/test/integration/client/configuration-tests.js
+++ b/test/integration/client/configuration-tests.js
@@ -19,6 +19,13 @@ suite.test('default values are used in new clients', function () {
     port: 5432,
     rows: 0,
     max: 10,
+    binary: false,
+    idleTimeoutMillis: 30000,
+    client_encoding: '',
+    ssl: false,
+    application_name: undefined,
+    fallback_application_name: undefined,
+    parseInputDatesAsUTC: false
   })
 
   var client = new pg.Client()

--- a/test/integration/client/configuration-tests.js
+++ b/test/integration/client/configuration-tests.js
@@ -18,7 +18,7 @@ suite.test('default values are used in new clients', function () {
     password: null,
     port: 5432,
     rows: 0,
-    poolSize: 10
+    max: 10,
   })
 
   var client = new pg.Client()


### PR DESCRIPTION
Since the upgrade of pg-pool to version 2.X, some properties seemingly have been removed from the pool options : 
- `reapIntervalMillis`, `returnToHead` and `poolLog` no more exist : I didn't find any occurrence of them in the code
- `poolIdleTimeout` has been replaced by `idleTimeoutMillis`

I also change `poolSize` to `max` : while `poolSize` is still allowed in node-pg-pool, only the option `max` is documented in the readme, see https://github.com/brianc/node-pg-pool/blob/master/README.md

In configuration test, I add more default properties assertions.

I also changed the pool url to link to node-pg-pool in the comments.

