### PR TITLE
Package json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "pg",
     "postgre",
     "postgres",
+    "postgresql",
     "rdbms"
   ],
   "homepage": "http://github.com/brianc/node-postgres",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "7.3.0",
   "description": "PostgreSQL client - pure javascript & libpq with the same API",
   "keywords": [
-    "postgres",
-    "pg",
-    "libpq",
-    "postgre",
     "database",
+    "libpq",
+    "pg",
+    "postgre",
+    "postgres",
     "rdbms"
   ],
   "homepage": "http://github.com/brianc/node-postgres",


### PR DESCRIPTION
Sorts (for cleaner diffs down the road) and adds "postgresql" to the keywords section of package.json. Kind of odd that it wasn't there till now ...

The list includes an entry for "postgre" (no "s" or "sql"). Not sure if that was intentional or a typo of "postgresql" but I've left it in there for now.