### PR TITLE
Improve error reporting

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -535,26 +535,14 @@ Connection.prototype._readValue = function (buffer) {
 Connection.prototype.parseE = function (buffer, length) {
   var fields = {}
   var msg, item
-  var input = new Message('error', length)
   var fieldType = this.readString(buffer, 1)
   while (fieldType !== '\0') {
     fields[fieldType] = this.parseCString(buffer)
     fieldType = this.readString(buffer, 1)
   }
-  if (input.name === 'error') {
-    // the msg is an Error instance
-    msg = new Error(fields.M)
-    for (item in input) {
-      // copy input properties to the error
-      if (input.hasOwnProperty(item)) {
-        msg[item] = input[item]
-      }
-    }
-  } else {
-    // the msg is an object literal
-    msg = input
-    msg.message = fields.M
-  }
+  msg = new Error(fields.M)
+  msg.name = 'error' // change this to properly distinguish pg errors
+  msg.length = length // why??
   msg.severity = fields.S
   msg.code = fields.C
   msg.detail = fields.D


### PR DESCRIPTION
There is scope for improvement in the errors thrown. As of now, it is hard to distinguish postgres errors from other errors when many are mixed together. The proper way, I believe, is to give a unique `name` to the `Error`. If this is acceptable, I'll update this pull request accordingly.