### PR TITLE
Pass through portal properly

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -175,7 +175,7 @@ Query.prototype.handlePortalSuspended = function (connection) {
 
 Query.prototype._getRows = function (connection, rows) {
   connection.execute({
-    portal: this.portalName,
+    portal: this.portal,
     rows: rows
   }, true)
   connection.flush()
@@ -201,7 +201,7 @@ Query.prototype.prepare = function (connection) {
 
   // http://developer.postgresql.org/pgdocs/postgres/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
   connection.bind({
-    portal: self.portalName,
+    portal: self.portal,
     statement: self.name,
     values: self.values,
     binary: self.binary
@@ -209,7 +209,7 @@ Query.prototype.prepare = function (connection) {
 
   connection.describe({
     type: 'P',
-    name: self.portalName || ''
+    name: self.portal || ''
   }, true)
 
   this._getRows(connection, this.rows)


### PR DESCRIPTION
This happened to work before because `Query.portalName` was undefined,
but in order to be able to set the portal explicitly it should be using
`Query.portal`.