### PR TITLE
Avoid modifying package.json or creating package-lock when running tests with npm 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-missing-native:
 	@rm -rf node_modules/libpq
 
 node_modules/pg-native/index.js:
-	@npm i pg-native
+	@npm i --no-save pg-native
 
 test-native: node_modules/pg-native/index.js test-connection
 	@echo "***Testing native bindings***"


### PR DESCRIPTION
Should save some confusion in future pull requests (#1465, #1436, #1363).