### PR TITLE
Transaction status is handled by `readyForQuery` message. Please, share!

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -138,7 +138,8 @@ Client.prototype.connect = function (callback) {
 
   // hook up query handling events to connection
   // after the connection initially becomes ready for queries
-  con.once('readyForQuery', function () {
+  con.once('readyForQuery', function (msg) {
+    self._transactionStatus = msg.status
     self._connecting = false
     self._connected = true
     self._attachListeners(con)
@@ -155,8 +156,9 @@ Client.prototype.connect = function (callback) {
     self.emit('connect')
   })
 
-  con.on('readyForQuery', function () {
+  con.on('readyForQuery', function (msg) {
     var activeQuery = self.activeQuery
+    self._transactionStatus = msg.status
     self.activeQuery = null
     self.readyForQuery = true
     if (activeQuery) {


### PR DESCRIPTION
`readyForQuery` message on `Connection` can receive one of this state:

This is code from [`fe-protocol3.c`](https://github.com/postgres/postgres/blob/master/src/interfaces/libpq/fe-protocol3.c#L1499..L1526) from latest postgres source.
```c
/*
 * getReadyForQuery - process ReadyForQuery message
 */
static int
getReadyForQuery(PGconn *conn)
{
    charxact_status;

    if (pqGetc(&xact_status, conn)              )
        return EOF;
    switch (xact_status)
    {
        case 'I':
            conn->xactStatus = PQTRANS_IDLE;
            break;
        case 'T':
            conn->xactStatus = PQTRANS_INTRANS;
            break;
        case 'E':
            conn->xactStatus = PQTRANS_INERROR;
            break;
        default:
            conn->xactStatus = PQTRANS_UNKNOWN;
            break;
    }

    return 0;
}
```