### PR TITLE
Make tests compatible with PostgreSQL 10

### DIFF
--- a/test/integration/client/json-type-parsing-tests.js
+++ b/test/integration/client/json-type-parsing-tests.js
@@ -4,7 +4,7 @@ var assert = require('assert')
 
 const pool = new helper.pg.Pool()
 pool.connect(assert.success(function (client, done) {
-  helper.versionGTE(client, '9.2.0', assert.success(function (jsonSupported) {
+  helper.versionGTE(client, 90200, assert.success(function (jsonSupported) {
     if (!jsonSupported) {
       console.log('skip json test on older versions of postgres')
       done()

--- a/test/integration/client/query-error-handling-prepared-statement-tests.js
+++ b/test/integration/client/query-error-handling-prepared-statement-tests.js
@@ -44,7 +44,7 @@ function killIdleQuery (targetQuery, cb) {
   var pidColName = 'procpid'
   var queryColName = 'current_query'
   client2.connect(assert.success(function () {
-    helper.versionGTE(client2, '9.2.0', assert.success(function (isGreater) {
+    helper.versionGTE(client2, 90200, assert.success(function (isGreater) {
       if (isGreater) {
         pidColName = 'pid'
         queryColName = 'query'

--- a/test/integration/client/query-error-handling-tests.js
+++ b/test/integration/client/query-error-handling-tests.js
@@ -10,7 +10,7 @@ test('error during query execution', function() {
     var sleepQuery = new Query(queryText);
     var pidColName = 'procpid'
     var queryColName = 'current_query';
-    helper.versionGTE(client, '9.2.0', assert.success(function(isGreater) {
+    helper.versionGTE(client, 90200, assert.success(function(isGreater) {
       if(isGreater) {
         pidColName = 'pid';
         queryColName = 'query';
@@ -48,7 +48,7 @@ if (helper.config.native) {
 test('9.3 column error fields', function() {
   var client = new Client(helper.args);
   client.connect(assert.success(function() {
-    helper.versionGTE(client, '9.3.0', assert.success(function(isGreater) {
+    helper.versionGTE(client, 90300, assert.success(function(isGreater) {
       if(!isGreater) {
         return client.end();
       }
@@ -68,7 +68,7 @@ test('9.3 column error fields', function() {
 test('9.3 constraint error fields', function() {
   var client = new Client(helper.args);
   client.connect(assert.success(function() {
-    helper.versionGTE(client, '9.3.0', assert.success(function(isGreater) {
+    helper.versionGTE(client, 90300, assert.success(function(isGreater) {
       if(!isGreater) {
         console.log('skip 9.3 error field on older versions of postgres');
         return client.end();

--- a/test/integration/client/result-metadata-tests.js
+++ b/test/integration/client/result-metadata-tests.js
@@ -7,7 +7,7 @@ new helper.Suite().test('should return insert metadata', function () {
   pool.connect(assert.calls(function (err, client, done) {
     assert(!err)
 
-    helper.versionGTE(client, '9.0.0', assert.success(function (hasRowCount) {
+    helper.versionGTE(client, 90000, assert.success(function (hasRowCount) {
       client.query('CREATE TEMP TABLE zugzug(name varchar(10))', assert.calls(function (err, result) {
         assert(!err)
         assert.equal(result.oid, null)

--- a/test/integration/connection-pool/error-tests.js
+++ b/test/integration/connection-pool/error-tests.js
@@ -21,7 +21,7 @@ suite.test('errors emitted on pool', (cb) => {
       pool.connect(assert.success(function (client2, done2) {
         client2.id = 2
         var pidColName = 'procpid'
-        helper.versionGTE(client2, '9.2.0', assert.success(function (isGreater) {
+        helper.versionGTE(client2, 90200, assert.success(function (isGreater) {
           var killIdleQuery = 'SELECT pid, (SELECT pg_terminate_backend(pid)) AS killed FROM pg_stat_activity WHERE state = $1'
           var params = ['idle']
           if (!isGreater) {

--- a/test/integration/test-helper.js
+++ b/test/integration/test-helper.js
@@ -14,12 +14,11 @@ helper.client = function (cb) {
   return client
 }
 
-var semver = require('semver')
-helper.versionGTE = function (client, versionString, callback) {
-  client.query('SELECT version()', assert.calls(function (err, result) {
+helper.versionGTE = function (client, testVersion, callback) {
+  client.query('SHOW server_version_num', assert.calls(function (err, result) {
     if (err) return callback(err)
-    var version = result.rows[0].version.split(' ')[1]
-    return callback(null, semver.gte(version, versionString))
+    var version = parseInt(result.rows[0].server_version_num, 10)
+    return callback(null, version >= testVersion)
   }))
 }
 


### PR DESCRIPTION
PostgreSQL 10 reports its version as only `major.minor`, so it can’t be parsed with semver. The `server_version_num` setting is a major version followed by a four-digit minor version since version 10, and was a three-digit major version followed by a two-digit minor version before that.

It might be best not to merge this until CI supports PostgreSQL 10.