### PR TITLE
Emit an event after submitting the query.

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -158,11 +158,13 @@ Query.prototype.submit = function (connection) {
     connection.emit('readyForQuery')
     return
   }
+
   if (this.requiresPreparation()) {
     this.prepare(connection)
   } else {
     connection.query(this.text)
   }
+  this.emit('submit')
 }
 
 Query.prototype.hasBeenParsed = function (connection) {


### PR DESCRIPTION
Makes it possible to profile queries.
Fixes brianc/node-postgres#874

If this event is emitted, then anyone who wants can profile their queries by comparing the time of this and the first row returned. like this:

``` javascript
let submit_time, response_time

query.on('submit', () => {
   submit_time = process.hrtime()
})

query.once('row', () => {
  response_time = process.hrtime(submit_time)
  const [seconds, nanoseconds] = process.hrtime(submit_time)
  const elapsed = Math.round((seconds * 1000) + (nanoseconds * 1e-6))
  console.log(`Elapsed: ${elapsed}`)
})