### PR TITLE
Allow custom Promise dependency to be used on clients instead of the global Promise

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -48,6 +48,7 @@ var Client = function (config) {
   this.processID = null
   this.secretKey = null
   this.ssl = this.connectionParameters.ssl || false
+  this.Promise = c.Promise || global.Promise
 }
 
 util.inherits(Client, EventEmitter)
@@ -61,7 +62,7 @@ Client.prototype.connect = function (callback) {
       callback(err)
       return undefined
     }
-    return Promise.reject(err)
+    return this.Promise.reject(err)
   }
   this._connecting = true
 
@@ -195,7 +196,7 @@ Client.prototype.connect = function (callback) {
   })
 
   if (!callback) {
-    return new global.Promise((resolve, reject) => {
+    return new this.Promise((resolve, reject) => {
       this.once('error', reject)
       this.once('connect', () => {
         this.removeListener('error', reject)
@@ -374,7 +375,7 @@ Client.prototype.query = function (config, values, callback) {
     query = new Query(config, values, callback)
     if (!query.callback) {
       let resolveOut, rejectOut
-      result = new Promise((resolve, reject) => {
+      result = new this.Promise((resolve, reject) => {
         resolveOut = resolve
         rejectOut = reject
       })
@@ -400,13 +401,13 @@ Client.prototype.end = function (cb) {
     // if we have an active query we need to force a disconnect
     // on the socket - otherwise a hung query could block end forever
     this.connection.stream.destroy(new Error('Connection terminated by user'))
-    return cb ? cb() : Promise.resolve()
+    return cb ? cb() : this.Promise.resolve()
   }
   if (cb) {
     this.connection.end()
     this.connection.once('end', cb)
   } else {
-    return new global.Promise((resolve, reject) => {
+    return new this.Promise((resolve, reject) => {
       this.connection.end()
       this.connection.once('end', resolve)
     })


### PR DESCRIPTION
Hi,

I was using connection pooling and passed in a bluebird Promise configuration and noticed that whenever I got a new Client from the pool it wouldn't get a bluebird Promise.

With these changes clients should pickup the Promise configuration from their pool as well as the option to specify any Promise dependency one might want.

Thanks,