### PR TITLE
Handle SSL negotiation errors more robustly

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -82,8 +82,13 @@ Connection.prototype.connect = function (port, host) {
 
   this.stream.once('data', function (buffer) {
     var responseCode = buffer.toString('utf8')
-    if (responseCode !== 'S') {
-      return self.emit('error', new Error('The server does not support SSL connections'))
+    switch (responseCode) {
+      case 'N':
+        return self.emit('error', new Error('The server does not support SSL connections'))
+      case 'S':
+        break
+      default:
+        return self.emit('error', new Error('There was an error establishing an SSL connection'))
     }
     var tls = require('tls')
     self.stream = tls.connect({


### PR DESCRIPTION
This commit adds some finer grained detail to handling the postmaster's
response to SSL negotiation packets, by accounting for the possibility
of an 'E' byte being sent back, and emitting an appropriate error.

In the naive case, the postmaster will respond with either 'S' (proceed
with an SSL connection) or 'N' (SSL is not supported). However, the
current if statement doesn't account for an 'E' byte being returned
by the postmaster, where an error is encountered (perhaps unable to
fork due to being out of memory).

By adding this case, we can prevent confusing error messages when SSL is
enforced and the postmaster returns an error after successful SSL
connections.

This also brings the connection handling further in line with
`libpq`, where 'E' is handled similarly as of this commit:

https://github.com/postgres/postgres/commit/a49fbaaf8d461ff91912c30b3563d54649474c80

('E' is handled when the status is `CONNECTION_AWAITING_RESPONSE`)

Given that there are no longer pre-7.0 databases out in the wild, I
believe this is a safe change to make, and should not break backwards
compatibility (unless matching on error message content(!)).

* Replace if statement with switch, to catch 'S', 'E' and 'N' bytes
  returned by the postmaster
* Return an Error for non 'S' or 'N' cases
* Expand and restructure unit tests for SSL negotiation packets