### PR TITLE
Update the package main to point to index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git://github.com/brianc/node-postgres.git"
   },
   "author": "Brian Carlson <brian.m.carlson@gmail.com>",
-  "main": "./lib",
+  "main": "./lib/index.js",
   "dependencies": {
     "buffer-writer": "1.0.1",
     "js-string-escape": "1.0.1",


### PR DESCRIPTION
The specs demands it and some tooling that are not as forgiving as npm complain
about it.