### PR TITLE
Remove `noAssert` argument

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -617,13 +617,13 @@ Connection.prototype.parsed = function (buffer, length) {
 }
 
 Connection.prototype.parseInt32 = function (buffer) {
-  var value = buffer.readInt32BE(this.offset, true)
+  var value = buffer.readInt32BE(this.offset)
   this.offset += 4
   return value
 }
 
 Connection.prototype.parseInt16 = function (buffer) {
-  var value = buffer.readInt16BE(this.offset, true)
+  var value = buffer.readInt16BE(this.offset)
   this.offset += 2
   return value
 }


### PR DESCRIPTION
The support for the `noAssert` argument dropped in the upcoming
Node.js v.10.x. All input is then validated no matter if this
is set to true or not. Just remove the argument because of that.

Refs: https://github.com/nodejs/node/pull/18395