### PR TITLE
use net.Socket instead of net.Stream

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -19,7 +19,7 @@ var BINARY_MODE = 1
 var Connection = function (config) {
   EventEmitter.call(this)
   config = config || {}
-  this.stream = config.stream || new net.Stream()
+  this.stream = config.stream || new net.Socket()
   this._keepAlive = config.keepAlive
   this.lastBuffer = false
   this.lastOffset = 0


### PR DESCRIPTION
`net.Stream` is a undocumented legacy naming from node 0.x
https://github.com/nodejs/node/blob/4ae320f2b3c745402955019d6a57a22ee2b8d3bd/lib/net.js#L1762