### PR TITLE
fix managed PG on Azure

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -309,7 +309,8 @@ Connection.prototype.end = function () {
   // 0x58 = 'X'
   this.writer.add(emptyBuffer)
   this._ending = true
-  return this.stream.write(END_BUFFER)
+  this.stream.write(END_BUFFER)
+  return this.stream.end()
 }
 
 Connection.prototype.close = function (msg, more) {


### PR DESCRIPTION
`.end()` never returned when connecting with managed PG on Azure.