### PR TITLE
fix: end stream on Connection.end()

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -309,7 +309,9 @@ Connection.prototype.end = function () {
   // 0x58 = 'X'
   this.writer.add(emptyBuffer)
   this._ending = true
-  return this.stream.write(END_BUFFER)
+  return this.stream.write(END_BUFFER, () => {
+    this.stream.end()
+  })
 }
 
 Connection.prototype.close = function (msg, more) {

--- a/test/unit/connection/outbound-sending-tests.js
+++ b/test/unit/connection/outbound-sending-tests.js
@@ -183,6 +183,7 @@ test('sends end command', function () {
   con.end()
   var expected = Buffer.from([0x58, 0, 0, 0, 4])
   assert.received(stream, expected)
+  assert.equal(stream.closed, true)
 })
 
 test('sends describe command', function () {

--- a/test/unit/test-helper.js
+++ b/test/unit/test-helper.js
@@ -13,12 +13,19 @@ helper.sys.inherits(MemoryStream, EventEmitter)
 
 var p = MemoryStream.prototype
 
-p.write = function (packet) {
+p.write = function (packet, cb) {
   this.packets.push(packet)
+  if(cb){
+    cb();
+  }
+}
+
+p.end = function() {
+  p.closed = true;
 }
 
 p.setKeepAlive = function () {}
-
+p.closed = false;
 p.writable = true
 
 const createClient = function () {


### PR DESCRIPTION
We are having issues with both `pg 6.4.2` and `pg 7.4.1` when disconnecting from Azure Postgres managed database. The socket never gets closed. I am able to replicate it with this simple script: 
*(excuse my TypeScript)*

```TypeScript
import * as pg from 'pg';
const opts = {
  host: process.env.DB_HOST,
  password: process.env.DB_PASSWORD,
  port: Number(process.env.DB_PORT),
  user: process.env.DB_USER,
  database: process.env.DB_DB,
  ssl: Boolean(process.env.DB_SSL),
};

console.log(opts);

async function testDb() {
  const client = new pg.Client(opts);

  await client.connect();
  console.log('Connection opened');
  const result = await client.query('SELECT 1+1');
  console.log(result);
  await client.end(err => {
    // This never gets called on Azure Postgres
    console.log('Connection closed.');
    console.log(err);
  });
}

testDb().catch(e => {
  console.log(`Error during execution: ${e}`);
});

```

The socket always stays hanging as can be verified by:

```
myMac:~ user$ lsof -P -i :5432
COMMAND    PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
node     52890  user   15u  IPv4 0xfddc5262efdff88b      0t0  TCP myMac:59923->191.237.232.75:5432 (ESTABLISHED)
```

When looking through official postgres documentation, the following passage about the connection termination can be found:

*The normal, graceful termination procedure is that the **frontend sends a Terminate message and immediately closes the connection**. On receipt of this message, the backend closes the connection and terminates.*

(taken from https://www.postgresql.org/docs/9.6/static/protocol-flow.html#AEN113373)

It seems that Azure postgres is really waiting for the client to close the connection first, otherwise it won't close the socket.

This PR adds a `this.stream.end()` after the termination message has been sent to the SQL server.  This resolves our issue with Azure. 

If needed I can provide instance of Microsoft Azure Postgres for replication and testing.

Also, since we are running on `v6.4.2` in combination with sequelize, I can also offer this fix for the 6.x.x branch: 

https://github.com/brianc/node-postgres/compare/v6.4.2...Vratislav:end-stream

