### PR TITLE
Don't call connect until connect handler is set up

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -65,12 +65,6 @@ Client.prototype.connect = function (callback) {
   }
   this._connecting = true
 
-  if (this.host && this.host.indexOf('/') === 0) {
-    con.connect(this.host + '/.s.PGSQL.' + this.port)
-  } else {
-    con.connect(this.port, this.host)
-  }
-
   // once connection is established send startup message
   con.on('connect', function () {
     if (self.ssl) {
@@ -193,6 +187,12 @@ Client.prototype.connect = function (callback) {
   con.on('notice', function (msg) {
     self.emit('notice', msg)
   })
+
+  if (this.host && this.host.indexOf('/') === 0) {
+    con.connect(this.host + '/.s.PGSQL.' + this.port)
+  } else {
+    con.connect(this.port, this.host)
+  }
 
   if (!callback) {
     return new global.Promise((resolve, reject) => {


### PR DESCRIPTION
If a `stream` is specified, the connect event will be emitted immediately, and it will be dropped unless the event handlers are set up.