### PR TITLE
Add node v10 to Travis matrix and clean up some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
     - node_js: "9"
       addons:
         postgresql: "9.6"
+    - node_js: "10"
+      addons:
+        postgresql: "9.6"
     - node_js: "lts/carbon"
       addons:
         postgresql: "9.1"

--- a/test/integration/client/network-partition-tests.js
+++ b/test/integration/client/network-partition-tests.js
@@ -46,7 +46,7 @@ Server.prototype.start = function (cb) {
 }
 
 Server.prototype.drop = function () {
-  this.socket.end()
+  this.socket.destroy()
 }
 
 Server.prototype.close = function (cb) {

--- a/test/integration/client/network-partition-tests.js
+++ b/test/integration/client/network-partition-tests.js
@@ -22,7 +22,7 @@ Server.prototype.start = function (cb) {
       this.socket.on('data', function (data) {
         // deny request for SSL
         if (data.length == 8) {
-          this.socket.write(new Buffer('N', 'utf8'))
+          this.socket.write(Buffer.from('N', 'utf8'))
         // consider all authentication requests as good
         } else if (!data[0]) {
           this.socket.write(buffers.authenticationOk())


### PR DESCRIPTION
Three commits in this PR:

* First adds node v10 to the Travis build matrix (which fails)
* Second changes the network partition test to use `socket.destroy()` rather than `socket.end()` (which fixes Travis)
* Third updates deprecated `new Buffer(...)` to use `Buffer.from(...)`. 

I'm not sure what exactly changed in node v10 to require updating the test from `socket.end()` to `socket.destroy()` but suspect it's something internal to waiting for the socket to gracefully close. Haven't been able to find anything online regarding it either though that may be because v10 is so new.

I'm going to take a look if applying #1608 would correct this as well. Either way I think using `destroy(...)` is probably a good idea as that's what the test is simulated right? (i.e. network partition immediately killing the connection mid flight)