### PR TITLE
tls.connect({checkServerIdentity}) option cannot be a null - must be …

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -94,7 +94,7 @@ Connection.prototype.connect = function (port, host) {
     self.stream = tls.connect({
       socket: self.stream,
       servername: host,
-      checkServerIdentity: self.ssl.checkServerIdentity,
+      checkServerIdentity: self.ssl.checkServerIdentity || tls.checkServerIdentity,
       rejectUnauthorized: self.ssl.rejectUnauthorized,
       ca: self.ssl.ca,
       pfx: self.ssl.pfx,


### PR DESCRIPTION
…a method or not exist.

Defaults to built-in `tls.checkServerIdentity` method in the event one is not passed into `pgConfig.ssl`

Found breaking in v7.4.2 vs v7.4.1 a la 49054717b4ec0c6d477f04c2becd1f9680b2d13a

cc @tobio @brianc 