### PR TITLE
fix: tls.checkServerIdentity cannot be undefined

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -94,7 +94,7 @@ Connection.prototype.connect = function (port, host) {
     self.stream = tls.connect({
       socket: self.stream,
       servername: host,
-      checkServerIdentity: self.ssl.checkServerIdentity,
+      checkServerIdentity: self.ssl.checkServerIdentity || tls.checkServerIdentity,
       rejectUnauthorized: self.ssl.rejectUnauthorized,
       ca: self.ssl.ca,
       pfx: self.ssl.pfx,


### PR DESCRIPTION
If this configuration option is provided explicitly and is not a function (ie. the intention was to "use default value") this assertion will not pass because Node applies default values to the configuration options via prototypal inheritance, however the property lookup will stop immediately because the `checkServerIdentity` property actually exists on the provided object (with a value of `undefined`).

Related: #1444