### PR TITLE
Error Handling for null Params to Client.prototype.query()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -365,7 +365,10 @@ Client.prototype.query = function (config, values, callback) {
   // can take in strings, config object or query object
   var query
   var result
-  if (typeof config.submit === 'function') {
+
+  if (config === null || config === undefined) {
+    throw new TypeError('Client was passed a null or undefined query')
+  } else if (typeof config.submit === 'function') {
     result = query = config
     if (typeof values === 'function') {
       query.callback = query.callback || values

--- a/test/unit/client/simple-query-tests.js
+++ b/test/unit/client/simple-query-tests.js
@@ -120,4 +120,24 @@ test('executing query', function () {
       })
     })
   })
+
+  test('handles errors', function () {
+    var client = helper.client()
+
+    test('throws an error when config is null', function () {
+      try {
+        client.query(null, undefined)
+      } catch (error) {
+        assert.equal(error.message, 'Client was passed a null or undefined query', 'Should have thrown an Error for null queries')
+      }
+    })
+
+    test('throws an error when config is undefined', function () {
+      try {
+        client.query()
+      } catch (error) {
+        assert.equal(error.message, 'Client was passed a null or undefined query', 'Should have thrown an Error for null queries')
+      }
+    })
+  })
 })


### PR DESCRIPTION
Add's a basic assertion to `Client.prototype.query()` ensuring that `config` is not `null` or `undefined`. This fixes #628 — which was closed, but the behavior described in that issue lives on. I added some additional tests around the new logic.

I ran into the same problem described in that issue — some bad destructing logic on my end led to `config` being `undefined` when calling `query()`. That results in a `TypeError` when the `typeof config.submit === 'function'` assertion is executed. The behavior is still basically the same, except that the error is detected, described, and sent to the users `callback` or `Promise.reject`ed.