### PR TITLE
Tie default DB name to database user name

### DIFF
--- a/lib/connection-parameters.js
+++ b/lib/connection-parameters.js
@@ -13,7 +13,7 @@ var defaults = require('./defaults')
 
 var parse = require('pg-connection-string').parse // parses a connection string
 
-var val = function (key, config, envVar) {
+var val = function (key, config, envVar, computed) {
   if (envVar === undefined) {
     envVar = process.env[ 'PG' + key.toUpperCase() ]
   } else if (envVar === false) {
@@ -22,9 +22,13 @@ var val = function (key, config, envVar) {
     envVar = process.env[ envVar ]
   }
 
+  if (computed === undefined) {
+    computed = function (key) { return defaults[key] }
+  }
+
   return config[key] ||
     envVar ||
-    defaults[key]
+    computed(key)
 }
 
 var useSsl = function () {
@@ -50,8 +54,11 @@ var ConnectionParameters = function (config) {
     config = Object.assign({}, config, parse(config.connectionString))
   }
 
+  var dbDefaulting = function () { return this.user || defaults['database'] }
+  dbDefaulting = dbDefaulting.bind(this)
+
   this.user = val('user', config)
-  this.database = val('database', config)
+  this.database = val('database', config, undefined, dbDefaulting)
   this.port = parseInt(val('port', config), 10)
   this.host = val('host', config)
   this.password = val('password', config)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg",
-  "version": "7.4.3",
+  "version": "8.0.0",
   "description": "PostgreSQL client - pure javascript & libpq with the same API",
   "keywords": [
     "database",

--- a/test/integration/client/configuration-tests.js
+++ b/test/integration/client/configuration-tests.js
@@ -40,7 +40,6 @@ suite.test('default values are used in new clients', function () {
 suite.test('modified values are passed to created clients', function () {
   pg.defaults.user = 'boom'
   pg.defaults.password = 'zap'
-  pg.defaults.database = 'pow'
   pg.defaults.port = 1234
   pg.defaults.host = 'blam'
 
@@ -48,7 +47,8 @@ suite.test('modified values are passed to created clients', function () {
   assert.same(client, {
     user: 'boom',
     password: 'zap',
-    database: 'pow',
+    // default database name is user name
+    database: 'boom',
     port: 1234,
     host: 'blam'
   })


### PR DESCRIPTION
The previous behaviour was at variance with the native client behaviour, per:
    
https://www.postgresql.org/docs/10/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS
    
> The database name. Defaults to be the same as the user name.
> In certain contexts, the value is checked for extended formats...