### PR TITLE
Fix network partition test race

### DIFF
--- a/test/integration/client/network-partition-tests.js
+++ b/test/integration/client/network-partition-tests.js
@@ -65,10 +65,12 @@ var testServer = function (server, cb) {
         server.close(cb)
       })
 
-    // after 50 milliseconds, drop the client
-    setTimeout(function () {
-      server.drop()
-    }, 50)
+    server.server.on('connection', () => {
+      // after 50 milliseconds, drop the client
+      setTimeout(function () {
+        server.drop()
+      }, 50)
+    })
 
     // blow up if we don't receive an error
     var timeoutId = setTimeout(function () {


### PR DESCRIPTION
Fixes a race condition in the network partition test that was repeatedly popping up on older (slower!) versions of node. You can simulate the race condition more easily by dropping the timeout from 50 ms to 1 ms. Here's the error:

```
network-partition-tests.js
  readyForQuery server Message: Cannot read property 'destroy' of undefined
TypeError: Cannot read property 'destroy' of undefined
    at Server.drop (/home/travis/build/sehrope/node-postgres/test/integration/client/network-partition-tests.js:49:14)
    at Timeout._onTimeout (/home/travis/build/sehrope/node-postgres/test/integration/client/network-partition-tests.js:70:14)
    at ontimeout (timers.js:386:11)
    at tryOnTimeout (timers.js:250:5)
    at Timer.listOnTimeout (timers.js:214:5)
```

First commit changes the dummy server to only issue the destroy if the socket exists.

Second commit changes the test harness to wait for the `connection` event on the server prior to issuing the destroy.