### PR TITLE
Add optional support for BufferList as zero-copy binary parameters

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -13,6 +13,7 @@ var util = require('util')
 
 var Writer = require('buffer-writer')
 var Reader = require('packet-reader')
+var utils = require('./utils')
 
 var TEXT_MODE = 0
 var BINARY_MODE = 1
@@ -246,20 +247,20 @@ Connection.prototype.bind = function (config, more) {
   var values = config.values || []
   var len = values.length
   var useBinary = false
-  for (var j = 0; j < len; j++) { useBinary |= values[j] instanceof Buffer }
+  for (var j = 0; j < len; j++) { useBinary |= utils.isBufferLike(values[j]) }
   var buffer = this.writer
     .addCString(config.portal)
     .addCString(config.statement)
   if (!useBinary) { buffer.addInt16(0) } else {
     buffer.addInt16(len)
-    for (j = 0; j < len; j++) { buffer.addInt16(values[j] instanceof Buffer) }
+    for (j = 0; j < len; j++) { buffer.addInt16(utils.isBufferLike(values[j])) }
   }
   buffer.addInt16(len)
   for (var i = 0; i < len; i++) {
     var val = values[i]
     if (val === null || typeof val === 'undefined') {
       buffer.addInt32(-1)
-    } else if (val instanceof Buffer) {
+    } else if (utils.isBufferLike(val)) {
       buffer.addInt32(val.length)
       buffer.add(val)
     } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,26 @@ const crypto = require('crypto')
 
 const defaults = require('./defaults')
 
+// Optionally include BufferList if the package is found:
+let BufferList
+try {
+  BufferList = require('bl')
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') {
+    throw e
+  }
+}
+let isBufferLike
+if (!BufferList) {
+  isBufferLike = function (value) {
+    return value instanceof Buffer
+  }
+} else {
+  isBufferLike = function (value) {
+    return value instanceof Buffer || value instanceof BufferList
+  }
+}
+
 function escapeElement (elementRepresentation) {
   var escaped = elementRepresentation
     .replace(/\\/g, '\\\\')
@@ -32,7 +52,7 @@ function arrayString (val) {
       result = result + 'NULL'
     } else if (Array.isArray(val[i])) {
       result = result + arrayString(val[i])
-    } else if (val[i] instanceof Buffer) {
+    } else if (isBufferLike(val[i])) {
       result += '\\\\x' + val[i].toString('hex')
     } else {
       result += escapeElement(prepareValue(val[i]))
@@ -47,7 +67,7 @@ function arrayString (val) {
 // note: you can override this function to provide your own conversion mechanism
 // for complex types, etc...
 var prepareValue = function (val, seen) {
-  if (val instanceof Buffer) {
+  if (isBufferLike(val)) {
     return val
   }
   if (ArrayBuffer.isView(val)) {
@@ -153,6 +173,7 @@ const postgresMd5PasswordHash = function (user, password, salt) {
 }
 
 module.exports = {
+  isBufferLike,
   prepareValue: function prepareValueWrapper (value) {
     // this ensures that extra arguments do not get passed into prepareValue
     // by accident, eg: from calling values.map(utils.prepareValue)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "eslint-plugin-standard": "3.0.1",
     "pg-copy-streams": "0.3.0"
   },
+  "peerDependencies": {
+    "bl": "^2"
+  },
   "minNativeVersion": "2.0.0",
   "scripts": {
     "test": "make test-all"


### PR DESCRIPTION
Adds handling of BufferList (via "bl" module) so that they are treated like Buffer parameters. Without built-in support in pg itself users have to call `.slice()` on the BufferList which forces creating a copy of all the data. With built-in support the BufferList parameters get written directly as binary parameters to the outbound socket just like regular Buffer parameters.

If the "bl" module is not found at init then this patch reverts to the original behavior of treating only Buffer objects as binary data. If it is found it treats either Buffer or BufferList objects as binary parameters. The "bl" module is listed as a peer dependency in package.json so it's not installed by default but is indicated as such.

PR passes all the existing tests with and without bl installed and I've tested it locally using BufferList parameters and parameters that are arrays that include BufferLists. Haven't added the test here though as the "bl" module isn't a required dependency so it doesn't get included in the Travis harness. Need to figure a more pleasant way of doing that as I think it'd involve breaking out the test infrastructure to be a custom script so we have more control over the order of installing deps, removing them, etc. Didn't want to include that in this yet as it seems more invasive and should best be handled separately (though I still do want to look into it).

Thoughts?