### PR TITLE
Replace poolSize by max in error test

### DIFF
--- a/test/integration/connection-pool/error-tests.js
+++ b/test/integration/connection-pool/error-tests.js
@@ -2,10 +2,8 @@
 var helper = require('./test-helper')
 const pg = helper.pg
 
-// first make pool hold 2 clients
-pg.defaults.max = 2
-
-const pool = new pg.Pool()
+// make pool hold 2 clients
+const pool = new pg.Pool({ max: 2 })
 
 const suite = new helper.Suite()
 suite.test('connecting to invalid port', (cb) => {

--- a/test/integration/connection-pool/error-tests.js
+++ b/test/integration/connection-pool/error-tests.js
@@ -3,7 +3,7 @@ var helper = require('./test-helper')
 const pg = helper.pg
 
 // first make pool hold 2 clients
-pg.defaults.poolSize = 2
+pg.defaults.max = 2
 
 const pool = new pg.Pool()
 


### PR DESCRIPTION
It seems poolSize has been replaced by max end of 2017 in most places of the codebase but this one. I assume that was a miss.