### PR TITLE
Replace crypto usage for crypto-js to generate md5 when using AuthenticationMD5Password

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,7 @@
  * README.md file in the root directory of this source tree.
  */
 
-const crypto = require('crypto')
+const cryptojs = require('crypto-js')
 
 const defaults = require('./defaults')
 
@@ -142,7 +142,7 @@ function normalizeQueryConfig (config, values, callback) {
 }
 
 const md5 = function (string) {
-  return crypto.createHash('md5').update(string, 'utf-8').digest('hex')
+  return cryptojs.MD5(string).toString()
 }
 
 // See AuthenticationMD5Password at https://www.postgresql.org/docs/current/static/protocol-flow.html

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "main": "./lib",
   "dependencies": {
     "buffer-writer": "1.0.1",
+    "crypto-js": "3.1.9-1",
     "packet-reader": "0.3.1",
     "pg-connection-string": "0.1.3",
     "pg-pool": "~2.0.3",


### PR DESCRIPTION
Replaces the usage crypto.md5 in favour of crypto-js.md5 to generate the md5 when using AuthenticationMD5Password.
When using a FIPS build of NodeJS which uses the OpenSSL FIPS module calling crypto.md5 causes the underlying OpenSSL FIPS module to fail with the error: 
`Message: Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips`

By replacing the usage of crypto this allows AuthenticationMD5Password to be used even with a FIPS build of NodeJS. In my particular case I ran into this issue because I'm using Amazon RDS and it does not allow configuring the authentication method.