### PR TITLE
Reject query immediately if connection is being terminated

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -369,6 +369,13 @@ Client.prototype.query = function (config, values, callback) {
     }
   }
 
+  if (this._ending) {
+    if (query.callback) {
+      query.callback(new Error('Could not accept query, because connection has ended'))
+    }
+    return
+  }
+
   if (this.binary && !query.binary) {
     query.binary = true
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -373,7 +373,7 @@ Client.prototype.query = function (config, values, callback) {
     if (query.callback) {
       query.callback(new Error('Could not accept query, because connection has ended'))
     }
-    return
+    return result
   }
 
   if (this.binary && !query.binary) {


### PR DESCRIPTION
Consider the following example:

```const { Client } = require('pg')
const client = new Client({user: "acn", password: "foo", database: "shard_1"})

async function main() {
    await client.connect();

    console.log("Client connected, ending connection");
    client.end();

    const promise = client.query('SELECT pg_sleep(20)');

    console.log("Now waiting for DB to respond")

    const res = await promise
    console.log(res.rows)

    process.exit(0)
}

main()
```

Error will be emitted:
```
Error: Connection terminated
    at Connection.con.once (/opt/acn/head/api/node_modules/pg/lib/client.js:170:29)
    at Object.onceWrapper (events.js:313:30)
    at emitNone (events.js:111:20)
    at Connection.emit (events.js:208:7)
    at Socket.<anonymous> (/opt/acn/head/api/node_modules/pg/lib/connection.js:128:10)
    at emitNone (events.js:111:20)
    at Socket.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1064:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```
It's not exactly clear what's going on. Now it is much more obvious if we reject query early:

```
Error: Could not accept query, because connection has ended
    at Client.query (/opt/acn/head/api/node_modules/pg/lib/client.js:378:22)
    at main (/opt/acn/head/api/test.js:10:28)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```
This is quite an edge case, but I'm debugging this exact issue on my production environment. It's hard to know if TCP connections just die or client is ended externally.