### PR TITLE
Remove excess `module.exports.native` assignment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,6 @@ if (typeof process.env.NODE_PG_FORCE_NATIVE !== 'undefined') {
       }
       console.error(err.message)
     }
-    module.exports.native = native
     return native
   })
 }


### PR DESCRIPTION
I believe assigning `native` to `module.exports.native` is redundant.
The getter definition on line 43 should immediately replace the value.