### PR TITLE
remove query.stream references

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -25,7 +25,6 @@ var Query = function (config, values, callback) {
   this.types = config.types
   this.name = config.name
   this.binary = config.binary
-  this.stream = config.stream
   // use unique portal name each time
   this.portal = config.portal || ''
   this.callback = config.callback
@@ -216,17 +215,10 @@ Query.prototype.prepare = function (connection) {
 }
 
 Query.prototype.handleCopyInResponse = function (connection) {
-  if (this.stream) this.stream.startStreamingToConnection(connection)
-  else connection.sendCopyFail('No source stream defined')
+  connection.sendCopyFail('No source stream defined')
 }
 
 Query.prototype.handleCopyData = function (msg, connection) {
-  var chunk = msg.chunk
-  if (this.stream) {
-    this.stream.handleChunk(chunk)
-  }
-  // if there are no stream (for example when copy to query was sent by
-  // query method instead of copyTo) error will be handled
-  // on copyOutResponse event, so silently ignore this error here
+  // noop
 }
 module.exports = Query


### PR DESCRIPTION
* This hasn't been supported since 0b2344b6b5afbb68e89eff1ef2b57ecf0726d80b
  * The `startStreamingToConnection` method only existed in `lib/copystream.js`
  * See: https://www.google.com/search?q=startStreamingToConnection
* `node-pg-copy-streams` relies on overriding the `handleCopyInResponse` method:
  * https://github.com/brianc/node-pg-copy-streams/blob/e15feb19/index.js#L53
  * Which is why I wrap the method calls in an if in the EE handlers