### PR TITLE
Bump buffer-writer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Brian Carlson <brian.m.carlson@gmail.com>",
   "main": "./lib",
   "dependencies": {
-    "buffer-writer": "1.0.1",
+    "buffer-writer": "2.0.0",
     "packet-reader": "0.3.1",
     "pg-connection-string": "0.1.3",
     "pg-pool": "~2.0.3",


### PR DESCRIPTION
Fixes the deprecation warning for using `new Buffer`.

The change is semver major in buffer-writer since we dropped support for node < 4.x, but otherwise it's a non-breaking change.  Since node-postgres already requires node >= 4.x it's fine and can be released here as semver patch.