### PR TITLE
deps: update pg-types to 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "packet-reader": "0.3.1",
     "pg-connection-string": "0.1.3",
     "pg-pool": "^2.0.4",
-    "pg-types": "~1.12.1",
+    "pg-types": "~2.0.0",
     "pgpass": "1.x",
     "semver": "4.3.2"
   },


### PR DESCRIPTION
pg-types@2 drops node < 4 support but pg previously did so, so the upgrade isn't major for pg itself

See also: https://github.com/brianc/node-pg-types/pull/76