### PR TITLE
Bump packet-reader version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ matrix:
     - node_js: "10"
       addons:
         postgresql: "9.6"
-    - node_js: "11"
-      addons:
-        postgresql: "9.6"
     - node_js: "lts/carbon"
       addons:
         postgresql: "9.1"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "./lib",
   "dependencies": {
     "buffer-writer": "2.0.0",
-    "packet-reader": "0.3.1",
+    "packet-reader": "1.0.0",
     "pg-connection-string": "0.1.3",
     "pg-pool": "^2.0.4",
     "pg-types": "~2.0.0",


### PR DESCRIPTION
This should fix the deprecation warning from using `new Buffer`.

closes #1811 