### PR TITLE
fix: Catch and emit query parameter prepareValue(...) errors

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -194,7 +194,12 @@ Query.prototype.prepare = function (connection) {
   }
 
   if (self.values) {
-    self.values = self.values.map(utils.prepareValue)
+    try {
+      self.values = self.values.map(utils.prepareValue)
+    } catch (err) {
+      this.handleError(err, connection)
+      return
+    }
   }
 
   // http://developer.postgresql.org/pgdocs/postgres/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY

--- a/test/integration/gh-issues/1854-tests.js
+++ b/test/integration/gh-issues/1854-tests.js
@@ -1,0 +1,33 @@
+"use strict"
+var helper = require('./../test-helper')
+
+const suite = new helper.Suite()
+
+suite.test('Parameter serialization errors should not cause query to hang', (done) => {
+  if (helper.config.native) {
+    // pg-native cannot handle non-string parameters so skip this entirely
+    return done()
+  }
+  const client = new helper.pg.Client()
+  const expectedErr = new Error('Serialization error')
+  client.connect()
+    .then(() => {
+      const obj = {
+        toPostgres: function () {
+          throw expectedErr
+        }
+      }
+      return client.query('SELECT $1::text', [obj])
+        .then(() => {
+          throw new Error('Expected a serialization error to be thrown but no error was thrown')
+        })
+    })
+    .catch((err) => {
+      client.end(() => {})
+      if (err !== expectedErr) {
+        done(new Error('Expected a serialization error to be thrown but instead caught: ' + err))
+        return
+      }
+      done()
+    })
+})


### PR DESCRIPTION
Adds a try/catch block around the `prepareValue(...)` invocations in `query.prepare(...)` to ensure that any that throw an error are caught and bubbled up to the caller. Otherwise the `.prepare(...)` stops halfway through without reporting the error back, hanging the connection.

Also adds a test that uses a custom serialization function to simulate an error. That should match up with any other serialization errors include circular references or unsupported `JSON.stringify(...)` types. The test is disabled for `pg-native` as it can't handle non-string parameters (it just segfaults if you try giving it an object).

Should fix #1854 to actually report the `JSON.stringify(...)` bignum error back to the caller.