### PR TITLE
Enable eslint:recommended and plugin/node/recommended

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,16 @@
 {
-  "extends": "standard",
+  "extends": [
+    "eslint:recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
+  "env": {
+    "node": true,
+    "es6": true
+  },
   "rules": {
-    "no-new-func": "off"
+    "no-unused-vars": 0,
+    "no-console": 0
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,6 @@
     "es6": true
   },
   "rules": {
-    "no-unused-vars": 0,
-    "no-console": 0
+    "no-unused-vars": 0
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,5 @@
     "es6": true
   },
   "rules": {
-    "no-unused-vars": 0
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,10 @@
 {
+  "plugins": [
+    "node"
+  ],
   "extends": [
-    "eslint:recommended"
+    "eslint:recommended",
+    "plugin:node/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": 2017

--- a/lib/client.js
+++ b/lib/client.js
@@ -296,7 +296,7 @@ Client.prototype._attachListeners = function (con) {
     self.activeQuery.handlePortalSuspended(con)
   })
 
-  // deletagate emptyQuery to active query
+  // delegate emptyQuery to active query
   con.on('emptyQuery', function (msg) {
     self.activeQuery.handleEmptyQuery(con)
   })

--- a/lib/client.js
+++ b/lib/client.js
@@ -292,11 +292,13 @@ Client.prototype._attachListeners = function (con) {
   })
 
   // delegate portalSuspended to active query
+  // eslint-disable-next-line no-unused-vars
   con.on('portalSuspended', function (msg) {
     self.activeQuery.handlePortalSuspended(con)
   })
 
   // delegate emptyQuery to active query
+  // eslint-disable-next-line no-unused-vars
   con.on('emptyQuery', function (msg) {
     self.activeQuery.handleEmptyQuery(con)
   })
@@ -309,12 +311,14 @@ Client.prototype._attachListeners = function (con) {
   // if a prepared statement has a name and properly parses
   // we track that its already been executed so we don't parse
   // it again on the same client
+  // eslint-disable-next-line no-unused-vars
   con.on('parseComplete', function (msg) {
     if (self.activeQuery.name) {
       con.parsedStatements[self.activeQuery.name] = self.activeQuery.text
     }
   })
 
+  // eslint-disable-next-line no-unused-vars
   con.on('copyInResponse', function (msg) {
     self.activeQuery.handleCopyInResponse(self.connection)
   })

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -238,7 +238,7 @@ Connection.prototype.parse = function (query, more) {
   query.name = query.name || ''
   if (query.name.length > 63) {
     console.error('Warning! Postgres only supports 63 characters for query names.')
-    console.error('You supplied', query.name, '(', query.name.length, ')')
+    console.error('You supplied %s (%s)', query.name, query.name.length)
     console.error('This can cause conflicts and silent errors executing queries')
   }
   // normalize null type array

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -237,9 +237,11 @@ Connection.prototype.parse = function (query, more) {
   // normalize missing query names to allow for null
   query.name = query.name || ''
   if (query.name.length > 63) {
+    /* eslint-disable no-console */
     console.error('Warning! Postgres only supports 63 characters for query names.')
     console.error('You supplied %s (%s)', query.name, query.name.length)
     console.error('This can cause conflicts and silent errors executing queries')
+    /* eslint-enable no-console */
   }
   // normalize null type array
   query.types = query.types || []

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,9 @@ if (typeof process.env.NODE_PG_FORCE_NATIVE !== 'undefined') {
       if (err.code !== 'MODULE_NOT_FOUND') {
         throw err
       }
+      /* eslint-disable no-console */
       console.error(err.message)
+      /* eslint-enable no-console */
     }
     module.exports.native = native
     return native

--- a/lib/native/client.js
+++ b/lib/native/client.js
@@ -7,6 +7,7 @@
  * README.md file in the root directory of this source tree.
  */
 
+// eslint-disable-next-line node/no-missing-require
 var Native = require('pg-native')
 var TypeOverrides = require('../type-overrides')
 var semver = require('semver')

--- a/lib/native/query.js
+++ b/lib/native/query.js
@@ -131,7 +131,7 @@ NativeQuery.prototype.submit = function (client) {
   if (this.name) {
     if (this.name.length > 63) {
       console.error('Warning! Postgres only supports 63 characters for query names.')
-      console.error('You supplied', this.name, '(', this.name.length, ')')
+      console.error('You supplied %s (%s)', this.name, this.name.length)
       console.error('This can cause conflicts and silent errors executing queries')
     }
     var values = (this.values || []).map(utils.prepareValue)

--- a/lib/native/query.js
+++ b/lib/native/query.js
@@ -130,9 +130,11 @@ NativeQuery.prototype.submit = function (client) {
   // named query
   if (this.name) {
     if (this.name.length > 63) {
+      /* eslint-disable no-console */
       console.error('Warning! Postgres only supports 63 characters for query names.')
       console.error('You supplied %s (%s)', this.name, this.name.length)
       console.error('This can cause conflicts and silent errors executing queries')
+      /* eslint-enable no-console */
     }
     var values = (this.values || []).map(utils.prepareValue)
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -222,6 +222,7 @@ Query.prototype.handleCopyInResponse = function (connection) {
   connection.sendCopyFail('No source stream defined')
 }
 
+// eslint-disable-next-line no-unused-vars
 Query.prototype.handleCopyData = function (msg, connection) {
   // noop
 }

--- a/lib/sasl.js
+++ b/lib/sasl.js
@@ -1,3 +1,4 @@
+'use strict'
 const crypto = require('crypto')
 
 function startSession (mechanisms) {

--- a/package.json
+++ b/package.json
@@ -32,11 +32,6 @@
     "bluebird": "3.5.2",
     "co": "4.6.0",
     "eslint": "^4.19.1",
-    "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-standard": "^3.1.0",
     "pg-copy-streams": "0.3.0"
   },
   "minNativeVersion": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bluebird": "3.5.2",
     "co": "4.6.0",
     "eslint": "^4.19.1",
+    "eslint-plugin-node": "^6.0.1",
     "pg-copy-streams": "0.3.0"
   },
   "minNativeVersion": "2.0.0",

--- a/test/suite.js
+++ b/test/suite.js
@@ -76,7 +76,7 @@ class Suite {
 
 process.on('unhandledRejection', (e) => {
   setImmediate(() => {
-    console.error('Uhandled promise rejection')
+    console.error('Unhandled promise rejection')
     throw e
   })
 })


### PR DESCRIPTION
Couple of commits to progressively enable tighter eslint config via adding missing strict tag and disabling rule violations locally via comments. Also removes a couple unused eslint plugin dependencies.