### PR TITLE
Fix input preparation for date objects with a BC year

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -97,7 +97,12 @@ function pad (number, digits) {
 
 function dateToString (date) {
   var offset = -date.getTimezoneOffset()
-  var ret = pad(date.getFullYear(), 4) + '-' +
+
+  var year = date.getFullYear()
+  var isBCYear = year < 1
+  if (isBCYear) year = Math.abs(year) + 1 // negative years are 1 off their BC representation
+
+  var ret = pad(year, 4) + '-' +
     pad(date.getMonth() + 1, 2) + '-' +
     pad(date.getDate(), 2) + 'T' +
     pad(date.getHours(), 2) + ':' +
@@ -110,11 +115,17 @@ function dateToString (date) {
     offset *= -1
   } else { ret += '+' }
 
-  return ret + pad(Math.floor(offset / 60), 2) + ':' + pad(offset % 60, 2)
+  ret += pad(Math.floor(offset / 60), 2) + ':' + pad(offset % 60, 2)
+  if (isBCYear) ret += ' BC'
+  return ret
 }
 
 function dateToStringUTC (date) {
-  var ret = pad(date.getUTCFullYear(), 4) + '-' +
+  var year = date.getUTCFullYear()
+  var isBCYear = year < 1
+  if (isBCYear) year = Math.abs(year) + 1 // negative years are 1 off their BC representation
+
+  var ret = pad(year, 4) + '-' +
     pad(date.getUTCMonth() + 1, 2) + '-' +
     pad(date.getUTCDate(), 2) + 'T' +
     pad(date.getUTCHours(), 2) + ':' +
@@ -122,7 +133,9 @@ function dateToStringUTC (date) {
     pad(date.getUTCSeconds(), 2) + '.' +
     pad(date.getUTCMilliseconds(), 3)
 
-  return ret + '+00:00'
+  ret += '+00:00'
+  if (isBCYear) ret += ' BC'
+  return ret
 }
 
 function normalizeQueryConfig (config, values, callback) {

--- a/test/unit/utils-tests.js
+++ b/test/unit/utils-tests.js
@@ -81,6 +81,27 @@ test('prepareValues: date prepared properly as UTC', function () {
   defaults.parseInputDatesAsUTC = false
 })
 
+test('prepareValues: BC date prepared properly', function () {
+  helper.setTimezoneOffset(-330)
+
+  var date = new Date(-3245, 1, 1, 11, 11, 1, 7)
+  var out = utils.prepareValue(date)
+  assert.strictEqual(out, '3246-02-01T11:11:01.007+05:30 BC')
+
+  helper.resetTimezoneOffset()
+})
+
+test('prepareValues: 1 BC date prepared properly', function () {
+  helper.setTimezoneOffset(-330)
+
+  // can't use the multi-argument constructor as year 0 would be interpreted as 1900
+  var date = new Date('0000-02-01T11:11:01.007')
+  var out = utils.prepareValue(date)
+  assert.strictEqual(out, '0001-02-01T11:11:01.007+05:30 BC')
+
+  helper.resetTimezoneOffset()
+})
+
 test('prepareValues: undefined prepared properly', function () {
   var out = utils.prepareValue(void 0)
   assert.strictEqual(out, null)


### PR DESCRIPTION
JavaScript `Date` objects can represent BC years, represented as negative years (or `0`). However they're currently not serialized correctly for input:

```js
> var date = new Date('-000024-01-01')
> date.toISOString()
'-000024-01-01T00:00:00.000Z'
> prepareValue(date)
'0-24-01-01T00:00:00.000+00:00'  // Just causes an error when sent to the DB
```

This PR fixes it so that it produces PostgreSQL's accepted format:

```js
> prepareValue(date)
'0025-01-01T00:00:00.000+00:00 BC'
```

There is a bit of a tricky aspect to all this. You may notice that the "year -24" gets changed to "25 BC" - this is not an accident, it arises because of the discrepancy in representation of BC dates between JS and Postgres. Please read the issue I opened at bendrucker/postgres-date#5, as it outlines the issue and provides proof that this is the correct behaviour.

I should note that with this PR, currently a round trip will fail, because the output parsing doesn't account for this nuance, as seen in the linked issue. Moreover fixing that end of things might be considered a breaking change.

Edit: I've opened a PR for that at bendrucker/postgres-date#6