### PR TITLE
Fix integration test for v1.0.4 of postgres-date sub-dependency

### DIFF
--- a/test/integration/client/type-coercion-tests.js
+++ b/test/integration/client/type-coercion-tests.js
@@ -179,7 +179,7 @@ suite.test('date range extremes', function (done) {
     }))
 
     client.query('SELECT $1::TIMESTAMPTZ as when', ['4713-12-31 12:31:59 BC GMT'], assert.success(function (res) {
-      assert.equal(res.rows[0].when.getFullYear(), -4713)
+      assert.equal(res.rows[0].when.getFullYear(), -4712)
     }))
 
     client.query('SELECT $1::TIMESTAMPTZ as when', ['275760-09-13 00:00:00 -15:00'], assert.success(function (res) {


### PR DESCRIPTION
Should probably depend on brianc/node-pg-types#79, which contains more details.

Edit: That PR was merged.