### PR TITLE
Skip TLS SNI if host is IP address

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -91,7 +91,7 @@ Connection.prototype.connect = function (port, host) {
         return self.emit('error', new Error('There was an error establishing an SSL connection'))
     }
     var tls = require('tls')
-    let options = {
+    const options = {
       socket: self.stream,
       checkServerIdentity: self.ssl.checkServerIdentity || tls.checkServerIdentity,
       rejectUnauthorized: self.ssl.rejectUnauthorized,
@@ -102,12 +102,11 @@ Connection.prototype.connect = function (port, host) {
       cert: self.ssl.cert,
       secureOptions: self.ssl.secureOptions,
       NPNProtocols: self.ssl.NPNProtocols
-    };
-    if( net.isIP(host) === 0 ) {
-      options.servername = host;
     }
-
-    self.stream = tls.connect(options);
+    if (net.isIP(host) === 0) {
+      options.servername = host
+    }
+    self.stream = tls.connect(options)
     self.attachListeners(self.stream)
     self.stream.on('error', reportStreamError)
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -91,9 +91,8 @@ Connection.prototype.connect = function (port, host) {
         return self.emit('error', new Error('There was an error establishing an SSL connection'))
     }
     var tls = require('tls')
-    self.stream = tls.connect({
+    let options = {
       socket: self.stream,
-      servername: host,
       checkServerIdentity: self.ssl.checkServerIdentity || tls.checkServerIdentity,
       rejectUnauthorized: self.ssl.rejectUnauthorized,
       ca: self.ssl.ca,
@@ -103,7 +102,12 @@ Connection.prototype.connect = function (port, host) {
       cert: self.ssl.cert,
       secureOptions: self.ssl.secureOptions,
       NPNProtocols: self.ssl.NPNProtocols
-    })
+    };
+    if( net.isIP(host) === 0 ) {
+      options.servername = host;
+    }
+
+    self.stream = tls.connect(options);
     self.attachListeners(self.stream)
     self.stream.on('error', reportStreamError)
 


### PR DESCRIPTION
Currently the ```host``` is always set to the tls.connect() servername option, even if the host is a ip address.  This triggers the following depreciation warning: ```Setting the TLS ServerName to an IP address is not permitted by RFC 6066```.

The patch will only set the servername option in tls.connect() if ```net.isIP(host) === 0```.