### PR TITLE
Update CI to allow tests to pass on Node.js >= 10.16.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ script/
 *.swp
 test/
 .travis.yml
+ci_scripts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
     - node_js: "10"
       addons:
         postgresql: "9.6"
+    - node_js: "12"
+      addons:
+        postgresql: "9.6"
     - node_js: "lts/carbon"
       addons:
         postgresql: "9.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: node_js
-sudo: false
+sudo: true
 dist: trusty
+
 before_script:
   - node script/create-test-tables.js pg://postgres@127.0.0.1:5432/postgres
+  
+before_install:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      if [[ $(node -v) =~ v[1-9][0-9] ]]; then
+        source ./ci_scripts/build.sh;
+      fi
+    fi
+    
 env:
   - CC=clang CXX=clang++ npm_config_clang=1 PGUSER=postgres PGDATABASE=postgres
 

--- a/ci_scripts/build.sh
+++ b/ci_scripts/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+BUILD_DIR="$(pwd)"
+source ./ci_scripts/install_openssl.sh 1.1.1b
+sudo updatedb
+source ./ci_scripts/install_libpq.sh
+sudo updatedb
+sudo ldconfig
+cd $BUILD_DIR

--- a/ci_scripts/install_libpq.sh
+++ b/ci_scripts/install_libpq.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+OPENSSL_DIR="$(pwd)/openssl-1.1.1b"
+POSTGRES_VERSION="11.3"
+POSTGRES_DIR="$(pwd)/postgres-${POSTGRES_VERSION}"
+TMP_DIR="/tmp/postgres"
+JOBS="-j$(nproc || echo 1)"
+
+if [ -d "${TMP_DIR}" ]; then
+  rm -rf "${TMP_DIR}"
+fi
+
+mkdir -p "${TMP_DIR}"
+
+curl https://ftp.postgresql.org/pub/source/v${POSTGRES_VERSION}/postgresql-${POSTGRES_VERSION}.tar.gz | \
+  tar -C "${TMP_DIR}" -xzf -
+
+cd "${TMP_DIR}/postgresql-${POSTGRES_VERSION}"
+
+if [ -d "${POSTGRES_DIR}" ]; then
+  rm -rf "${POSTGRES_DIR}"
+fi
+mkdir -p $POSTGRES_DIR
+
+./configure --prefix=$POSTGRES_DIR --with-openssl --with-includes=${OPENSSL_DIR}/include --with-libraries=${OPENSSL_DIR}/lib --without-readline
+
+cd src/interfaces/libpq; make; make install; cd -
+cd src/bin/pg_config; make install; cd -
+cd src/backend; make generated-headers; cd -
+cd src/include; make install; cd -
+
+export PATH="${POSTGRES_DIR}/bin:${PATH}"
+export CFLAGS="-I${POSTGRES_DIR}/include"
+export LDFLAGS="-L${POSTGRES_DIR}/lib"
+export LD_LIBRARY_PATH="${POSTGRES_DIR}/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="${POSTGRES_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH"

--- a/ci_scripts/install_openssl.sh
+++ b/ci_scripts/install_openssl.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+if [ ${#} -lt 1 ]; then
+  echo "OpenSSL version required." 1>&2
+  exit 1
+fi
+
+OPENSSL_VERSION="${1}"
+OPENSSL_DIR="$(pwd)/openssl-${OPENSSL_VERSION}"
+TMP_DIR="/tmp/openssl"
+JOBS="-j$(nproc)"
+
+if [ -d "${TMP_DIR}" ]; then
+  rm -rf "${TMP_DIR}"
+fi
+mkdir -p "${TMP_DIR}"
+curl -s https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | \
+  tar -C "${TMP_DIR}" -xzf -
+pushd "${TMP_DIR}/openssl-${OPENSSL_VERSION}"
+if [ -d "${OPENSSL_DIR}" ]; then
+  rm -rf "${OPENSSL_DIR}"
+fi
+./Configure \
+  --prefix=${OPENSSL_DIR} \
+  enable-crypto-mdebug enable-crypto-mdebug-backtrace \
+  linux-x86_64
+make -s $JOBS
+make install_sw
+popd
+
+export PATH="${OPENSSL_DIR}/bin:${PATH}"
+export CFLAGS="-I${OPENSSL_DIR}/include"
+export LDFLAGS="-L${OPENSSL_DIR}/lib"
+export LD_LIBRARY_PATH="${OPENSSL_DIR}/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="${OPENSSL_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH"


### PR DESCRIPTION
Hello ^^

Since Node.js 10.16.0 `libpq` must be compiled with `OpenSSL 1.1.1b` at least to avoid [those failures](https://travis-ci.org/brianc/node-postgres/jobs/546971383).

With this PR the Travis CI environment will meet all these requirements without any breaking change.

> NB: the configuration scripts have been added to .npmignore in order to avoid bundling them on release
