### PR TITLE
Using correct JSON format for Array

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,7 +23,7 @@ function escapeElement (elementRepresentation) {
 // uses comma separator so won't work for types like box that use
 // a different array separator.
 function arrayString (val) {
-  var result = '{'
+  var result = '['
   for (var i = 0; i < val.length; i++) {
     if (i > 0) {
       result = result + ','
@@ -38,7 +38,7 @@ function arrayString (val) {
       result += escapeElement(prepareValue(val[i]))
     }
   }
-  result = result + '}'
+  result = result + ']'
   return result
 }
 

--- a/test/unit/utils-tests.js
+++ b/test/unit/utils-tests.js
@@ -134,12 +134,12 @@ test('prepareValue: string prepared properly', function () {
 
 test('prepareValue: simple array prepared properly', function () {
   var out = utils.prepareValue([1, null, 3, undefined, [5, 6, 'squ,awk']])
-  assert.strictEqual(out, '{"1",NULL,"3",NULL,{"5","6","squ,awk"}}')
+  assert.strictEqual(out, '["1",NULL,"3",NULL,["5","6","squ,awk"]]')
 })
 
 test('prepareValue: complex array prepared properly', function () {
   var out = utils.prepareValue([{ x: 42 }, { y: 84 }])
-  assert.strictEqual(out, '{"{\\"x\\":42}","{\\"y\\":84}"}')
+  assert.strictEqual(out, '["{\\"x\\":42}","{\\"y\\":84}"]')
 })
 
 test('prepareValue: date array prepared properly', function () {

--- a/test/unit/utils-tests.js
+++ b/test/unit/utils-tests.js
@@ -147,7 +147,7 @@ test('prepareValue: date array prepared properly', function () {
 
   var date = new Date(2014, 1, 1, 11, 11, 1, 7)
   var out = utils.prepareValue([date])
-  assert.strictEqual(out, '{"2014-02-01T11:11:01.007+05:30"}')
+  assert.strictEqual(out, '["2014-02-01T11:11:01.007+05:30"]')
 
   helper.resetTimezoneOffset()
 })
@@ -171,7 +171,7 @@ test('prepareValue: buffer array prepared properly', function() {
    var buffer1 = Buffer.from('dead', 'hex')
    var buffer2 = Buffer.from('beef', 'hex')
    var out = utils.prepareValue([buffer1, buffer2])
-   assert.strictEqual(out, '{\\\\xdead,\\\\xbeef}')
+   assert.strictEqual(out, '[\\\\xdead,\\\\xbeef]')
  })
 
 test('prepareValue: objects with complex toPostgres prepared properly', function () {
@@ -182,7 +182,7 @@ test('prepareValue: objects with complex toPostgres prepared properly', function
     }
   }
   var out = utils.prepareValue(customType)
-  assert.strictEqual(out, '{"1","2"}')
+  assert.strictEqual(out, '["1","2"]')
 })
 
 test('prepareValue: objects with toPostgres receive prepareValue', function () {


### PR DESCRIPTION
There is fix for array to string conversion.
It's correct to use square brackets instead braces.