### PR TITLE
feat: extend errors for trackability

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -29,6 +29,7 @@ var Query = function (config, values, callback) {
   this.portal = config.portal || ''
   this.callback = config.callback
   this._rowMode = config.rowMode
+  this.extendedError = config.extendedError || false
   if (process.domain && config.callback) {
     this.callback = process.domain.bind(config.callback)
   }
@@ -135,6 +136,10 @@ Query.prototype.handleError = function (err, connection) {
   if (this._canceledDueToError) {
     err = this._canceledDueToError
     this._canceledDueToError = false
+  }
+
+  if (this.extendedError) {
+    err._text = this.text 
   }
   // if callback supplied do not emit error event as uncaught error
   // events will bubble up to node process

--- a/test/integration/client/error-handling-tests.js
+++ b/test/integration/client/error-handling-tests.js
@@ -192,6 +192,18 @@ suite.test('within a simple query', (done) => {
   })
 })
 
+suite.test('within a simple query, returning extended error properties', (done) => {
+  var client = createErorrClient()
+  var text = "select eeeee from yodas_dsflsd where pixistix = 'zoiks!!!'"
+  var query = client.query(new pg.Query({ text: text, extendedError: true }))
+
+  assert.emits(query, 'error', function (error) {
+    assert.equal(error.severity, 'ERROR')
+    assert.equal(error._text, text)
+    done()
+  })
+})
+
 suite.test('connected, idle client error', (done) => {
   const client = new Client()
   client.connect((err) => {


### PR DESCRIPTION
Naive PR incoming. Intention, below.

While the low level pg error message is sufficient for tracking low level issues with pg, finding the root cause for a deeply passed error is hard.

Implementers should be able to opt into enhanced error behaviour, such es simply sending the root query / text.

Signed-off-by: Robert Jefe Lindstaedt <robert.lindstaedt@gmail.com>

The error trace is often not useful, e.g. on statement cancelled due to timeout. Ideally the error being returned should have a stacktrace actually stating the origin of that call to client.query. However I assume this is rather hard and a nice opt-in addition would be sending query.text

![error__canceling_statement_due_to_statement_timeout](https://user-images.githubusercontent.com/3899684/61385998-bc1adc00-a8b3-11e9-853a-aa6319b91259.png)

![error__canceling_statement_due_to_statement_timeout](https://user-images.githubusercontent.com/3899684/61386022-cb9a2500-a8b3-11e9-9153-29c1229f753f.png)
