### PR TITLE
feat: Add dynamic retrieval for client password

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -114,27 +114,23 @@ Client.prototype._connect = function (callback) {
 
   function checkPgPass (cb) {
     return function (msg) {
-      if (typeof(self.password) === 'function') {
-        try {
-          self._Promise.resolve(self.password())
-            .then(pass => {
-              if (undefined !== pass) {
-                if (typeof(pass) !== 'string') {
-                  con.emit('error', new TypeError('Password must be a string'))
-                  return
-                }
-                self.connectionParameters.password = self.password = pass
-              } else {
-                self.connectionParameters.password = self.password = null
+      if (typeof self.password === 'function') {
+        self._Promise.resolve()
+          .then(self.password)
+          .then(pass => {
+            if (pass !== undefined) {
+              if (typeof pass !== 'string') {
+                con.emit('error', new TypeError('Password must be a string'))
+                return
               }
-              cb(msg)
-            })
-            .catch(err => {
-              con.emit('error', err)
-            })
-        } catch (err) {
-          con.emit('error', err)
-        }
+              self.connectionParameters.password = self.password = pass
+            } else {
+              self.connectionParameters.password = self.password = null
+            }
+            cb(msg)
+          }).catch(err => {
+            con.emit('error', err)
+          })
       } else if (self.password !== null) {
         cb(msg)
       } else {

--- a/lib/client.js
+++ b/lib/client.js
@@ -116,7 +116,7 @@ Client.prototype._connect = function (callback) {
     return function (msg) {
       if (typeof self.password === 'function') {
         self._Promise.resolve()
-          .then(self.password)
+          .then(() => self.password())
           .then(pass => {
             if (pass !== undefined) {
               if (typeof pass !== 'string') {

--- a/lib/client.js
+++ b/lib/client.js
@@ -114,7 +114,28 @@ Client.prototype._connect = function (callback) {
 
   function checkPgPass (cb) {
     return function (msg) {
-      if (self.password !== null) {
+      if (typeof(self.password) === 'function') {
+        try {
+          self._Promise.resolve(self.password())
+            .then(pass => {
+              if (undefined !== pass) {
+                if (typeof(pass) !== 'string') {
+                  con.emit('error', new TypeError('Password must be a string'))
+                  return
+                }
+                self.connectionParameters.password = self.password = pass
+              } else {
+                self.connectionParameters.password = self.password = null
+              }
+              cb(msg)
+            })
+            .catch(err => {
+              con.emit('error', err)
+            })
+        } catch (err) {
+          con.emit('error', err)
+        }
+      } else if (self.password !== null) {
         cb(msg)
       } else {
         pgPass(self.connectionParameters, function (pass) {

--- a/test/integration/connection/dynamic-password.js
+++ b/test/integration/connection/dynamic-password.js
@@ -8,7 +8,7 @@ const Client = pg.Client;
 const password = process.env.PGPASSWORD || null
 const sleep = millis => new Promise(resolve => setTimeout(resolve, millis))
 
-suite.testAsync('Get password from a sync function', function () {
+suite.testAsync('Get password from a sync function', () => {
     let wasCalled = false
     function getPassword() {
         wasCalled = true
@@ -24,7 +24,7 @@ suite.testAsync('Get password from a sync function', function () {
         })
 })
 
-suite.testAsync('Throw error from a sync function', function () {
+suite.testAsync('Throw error from a sync function', () => {
     let wasCalled = false
     const myError = new Error('Oops!')
     function getPassword() {
@@ -47,7 +47,7 @@ suite.testAsync('Throw error from a sync function', function () {
         })
 })
 
-suite.testAsync('Get password from a function asynchronously', function () {
+suite.testAsync('Get password from a function asynchronously', () => {
     let wasCalled = false
     function getPassword() {
         wasCalled = true
@@ -63,7 +63,7 @@ suite.testAsync('Get password from a function asynchronously', function () {
         })
 })
 
-suite.testAsync('Throw error from an async function', function () {
+suite.testAsync('Throw error from an async function', () => {
     let wasCalled = false
     const myError = new Error('Oops!')
     function getPassword() {
@@ -88,7 +88,7 @@ suite.testAsync('Throw error from an async function', function () {
         })
 })
 
-suite.testAsync('Password function must return a string', function () {
+suite.testAsync('Password function must return a string', () => {
     let wasCalled = false
     function getPassword() {
         wasCalled = true

--- a/test/integration/connection/dynamic-password.js
+++ b/test/integration/connection/dynamic-password.js
@@ -1,0 +1,113 @@
+'use strict'
+const assert = require('assert')
+const helper = require('./../test-helper')
+const suite = new helper.Suite()
+const pg = require('../../../lib/index');
+const Client = pg.Client;
+
+const password = process.env.PGPASSWORD || null;
+const sleep = millis => new Promise(resolve => setTimeout(resolve, millis))
+
+suite.testAsync('Get password from a sync function', function () {
+    let wasCalled = false
+    function getPassword() {
+        wasCalled = true
+        return password;
+    }
+    const client = new Client({
+        password: getPassword,
+    })
+    return client.connect()
+        .then(() => {
+            assert.ok(wasCalled, 'Our password function should have been called')
+            return client.end()
+        })
+})
+
+suite.testAsync('Throw error from a sync function', function () {
+    let wasCalled = false
+    const myError = new Error('Oops!')
+    function getPassword() {
+        wasCalled = true
+        throw myError
+    }
+    const client = new Client({
+        password: getPassword,
+    })
+    let wasThrown = false
+    return client.connect()
+        .catch(err => {
+            assert.equal(err, myError, 'Our sync error should have been thrown')
+            wasThrown = true
+        })
+        .then(() => {
+            assert.ok(wasCalled, 'Our password function should have been called')
+            assert.ok(wasThrown, 'Our error should have been thrown')
+            return client.end()
+        })
+})
+
+suite.testAsync('Get password from a function asynchronously', function () {
+    let wasCalled = false
+    function getPassword() {
+        wasCalled = true
+        return sleep(100).then(() => password)
+    }
+    const client = new Client({
+        password: getPassword,
+    })
+    return client.connect()
+        .then(() => {
+            assert.ok(wasCalled, 'Our password function should have been called')
+            return client.end()
+        })
+})
+
+suite.testAsync('Throw error from an async function', function () {
+    let wasCalled = false
+    const myError = new Error('Oops!')
+    function getPassword() {
+        wasCalled = true
+        return sleep(100).then(() => {
+            throw myError
+        })
+    }
+    const client = new Client({
+        password: getPassword,
+    })
+    let wasThrown = false
+    return client.connect()
+        .catch(err => {
+            assert.equal(err, myError, 'Our async error should have been thrown')
+            wasThrown = true
+        })
+        .then(() => {
+            assert.ok(wasCalled, 'Our password function should have been called')
+            assert.ok(wasThrown, 'Our error should have been thrown')
+            return client.end()
+        })
+})
+
+suite.testAsync('Password function must return a string', function () {
+    let wasCalled = false
+    function getPassword() {
+        wasCalled = true
+        // Return a password that is not a string
+        return 12345
+    }
+    const client = new Client({
+        password: getPassword,
+    })
+    let wasThrown = false
+    return client.connect()
+        .catch(err => {
+            assert.ok(err instanceof TypeError, 'A TypeError should have been thrown')
+            assert.equal(err.message, 'Password must be a string')
+            wasThrown = true
+        })
+        .then(() => {
+            assert.ok(wasCalled, 'Our password function should have been called')
+            assert.ok(wasThrown, 'Our error should have been thrown')
+            return client.end()
+        })
+})

--- a/test/integration/connection/dynamic-password.js
+++ b/test/integration/connection/dynamic-password.js
@@ -2,17 +2,17 @@
 const assert = require('assert')
 const helper = require('./../test-helper')
 const suite = new helper.Suite()
-const pg = require('../../../lib/index');
+const pg = require('../../../lib/index')
 const Client = pg.Client;
 
-const password = process.env.PGPASSWORD || null;
+const password = process.env.PGPASSWORD || null
 const sleep = millis => new Promise(resolve => setTimeout(resolve, millis))
 
 suite.testAsync('Get password from a sync function', function () {
     let wasCalled = false
     function getPassword() {
         wasCalled = true
-        return password;
+        return password
     }
     const client = new Client({
         password: getPassword,

--- a/test/suite.js
+++ b/test/suite.js
@@ -73,6 +73,11 @@ class Suite {
     this._queue.push(test)
   }
 
+  /**
+   * Run an async test that can return a Promise. If the Promise resolves
+   * successfully then the test will pass. If the Promise rejects with an
+   * error then the test will be considered failed.
+   */
   testAsync (name, action) {
     const test = new Test(name, cb => {
       Promise.resolve()

--- a/test/suite.js
+++ b/test/suite.js
@@ -72,6 +72,19 @@ class Suite {
     const test = new Test(name, cb)
     this._queue.push(test)
   }
+
+  testAsync (name, action) {
+    const test = new Test(name, cb => {
+      try {
+        Promise.resolve(action())
+          .then(() => cb(null))
+          .catch((err) => cb(err))
+      } catch (err) {
+        cb(err)
+      }
+    })
+    this._queue.push(test)
+  }
 }
 
 process.on('unhandledRejection', (e) => {

--- a/test/suite.js
+++ b/test/suite.js
@@ -75,13 +75,9 @@ class Suite {
 
   testAsync (name, action) {
     const test = new Test(name, cb => {
-      try {
-        Promise.resolve(action())
-          .then(() => cb(null))
-          .catch((err) => cb(err))
-      } catch (err) {
-        cb(err)
-      }
+      Promise.resolve()
+        .then(action)
+        .then(() => cb(null), cb)
     })
     this._queue.push(test)
   }


### PR DESCRIPTION
PR to add support for dynamic password retrieval. There was already something quite similar to this to support reading passwords from a PGPASS file. This PR expands that section a bit to support invoking an arbitrary function.

Rather than supporting a callback parameter, this PR allows for either a synchronous function that returns a string or one that returns a Promise that resolves to a string. As there's Promise support on every supported runtime I figure it's a better choice for anything new being added.

Here's some examples of how to use it:

```js
// Existing hard coded password:
const pool = new pg.Pool({
    password: 'test',
});

// Sync return a static string
const pool = new pg.Pool({
    password: () => {
        return 'test';
    }
});

// Async API
const pool = new pg.Pool({
    password: async () => {
        await new Promise(resolve => setTimeout(resolve, 1000));
        const value = await someAsyncFunc();
        return value;
    }
});
```

This PR does not have any new tests yet, I just tested it with some local examples. If the concept itself seems workable then should be easy to add a few that use a function and check for its side effects. Let me know.