### PR TITLE
Fix disconnection tests for pg-pool 2.0.7

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -64,9 +64,8 @@ Connection.prototype.connect = function (port, host) {
   })
 
   const reportStreamError = function (error) {
-    // don't raise ECONNRESET errors - they can & should be ignored
-    // during disconnect
-    if (self._ending && error.code === 'ECONNRESET') {
+    // errors about disconnections should be ignored during disconnect
+    if (self._ending && (error.code === 'ECONNRESET' || error.code === 'EPIPE')) {
       return
     }
     self.emit('error', error)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "buffer-writer": "2.0.0",
     "packet-reader": "1.0.0",
     "pg-connection-string": "0.1.3",
-    "pg-pool": "^2.0.4",
+    "pg-pool": "^2.0.7",
     "pg-types": "^2.1.0",
     "pgpass": "1.x",
     "semver": "4.3.2"

--- a/test/integration/gh-issues/130-tests.js
+++ b/test/integration/gh-issues/130-tests.js
@@ -5,19 +5,21 @@ var exec = require('child_process').exec
 helper.pg.defaults.poolIdleTimeout = 1000
 
 const pool = new helper.pg.Pool()
-pool.connect(function (err, client) {
+pool.connect(function (err, client, done) {
+  assert.ifError(err)
+  client.once('error', function (err) {
+    client.on('error', (err) => {})
+    done(err)
+  })
   client.query('SELECT pg_backend_pid()', function (err, result) {
+    assert.ifError(err)
     var pid = result.rows[0].pg_backend_pid
     var psql = 'psql'
     if (helper.args.host) psql = psql + ' -h ' + helper.args.host
     if (helper.args.port) psql = psql + ' -p ' + helper.args.port
     if (helper.args.user) psql = psql + ' -U ' + helper.args.user
     exec(psql + ' -c "select pg_terminate_backend(' + pid + ')" template1', assert.calls(function (error, stdout, stderr) {
-      assert.isNull(error)
+      assert.ifError(error)
     }))
   })
-})
-
-pool.on('error', function (err, client) {
-  // swallow errors
 })


### PR DESCRIPTION
In pg-pool 2.0.7, checked-out clients became responsible for their own 'error' events.

brianc/node-pg-pool#123