### PR TITLE
Use arrow character in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install pg
 
 * Pure JavaScript client and native libpq bindings share _the same API_
 * Connection pooling
-* Extensible JS<->PostgreSQL data-type coercion
+* Extensible JS ↔ PostgreSQL data-type coercion
 * Supported PostgreSQL features
   * Parameterized queries
   * Named statements with query plan caching


### PR DESCRIPTION
You could definitely see this as a useless PR, but it annoyed me and I figured "why not try to fix it".

Feel free to close this if you want.