### PR TITLE
fix Check Result._types have getTypeParser method 

### DIFF
--- a/lib/result.js
+++ b/lib/result.js
@@ -95,7 +95,13 @@ Result.prototype.addFields = function (fieldDescriptions) {
   for (var i = 0; i < fieldDescriptions.length; i++) {
     var desc = fieldDescriptions[i]
     this.fields.push(desc)
-    var parser = (this._types || types).getTypeParser(desc.dataTypeID, desc.format || 'text')
+    var parser;
+    // this._type can be array of bind varibles type
+    if(this._type && this._type.getTypeParser){
+       parser = this._type.getTypeParser(desc.dataTypeID, desc.format || 'text');
+    } else {
+       parser = types.getTypeParser(desc.dataTypeID, desc.format || 'text');
+    }
     this._parsers.push(parser)
   }
 }

--- a/lib/result.js
+++ b/lib/result.js
@@ -95,12 +95,12 @@ Result.prototype.addFields = function (fieldDescriptions) {
   for (var i = 0; i < fieldDescriptions.length; i++) {
     var desc = fieldDescriptions[i]
     this.fields.push(desc)
-    var parser;
+    var parser
     // this._type can be array of bind varibles type
-    if(this._type && this._types.getTypeParser){
-       parser = this._types.getTypeParser(desc.dataTypeID, desc.format || 'text');
+    if (this._types && this._types.getTypeParser){
+      parser = this._types.getTypeParser(desc.dataTypeID, desc.format || 'text')
     } else {
-       parser = types.getTypeParser(desc.dataTypeID, desc.format || 'text');
+      parser = types.getTypeParser(desc.dataTypeID, desc.format || 'text')
     }
     this._parsers.push(parser)
   }

--- a/lib/result.js
+++ b/lib/result.js
@@ -96,7 +96,7 @@ Result.prototype.addFields = function (fieldDescriptions) {
     var desc = fieldDescriptions[i]
     this.fields.push(desc)
     var parser
-    // this._type can be array of bind varibles type
+    // this._type can be array of bind varible type
     if (this._types && this._types.getTypeParser){
       parser = this._types.getTypeParser(desc.dataTypeID, desc.format || 'text')
     } else {

--- a/lib/result.js
+++ b/lib/result.js
@@ -97,8 +97,8 @@ Result.prototype.addFields = function (fieldDescriptions) {
     this.fields.push(desc)
     var parser;
     // this._type can be array of bind varibles type
-    if(this._type && this._type.getTypeParser){
-       parser = this._type.getTypeParser(desc.dataTypeID, desc.format || 'text');
+    if(this._type && this._types.getTypeParser){
+       parser = this._types.getTypeParser(desc.dataTypeID, desc.format || 'text');
     } else {
        parser = types.getTypeParser(desc.dataTypeID, desc.format || 'text');
     }


### PR DESCRIPTION
query pass this.types to conn.parse. Conn.parse wont config.types as array of bind varible type.
query pass this.types to Result object on the next step, for type conversion features, but this one is array.