### PR TITLE
Make `native` non-enumerable

### DIFF
--- a/packages/pg/lib/index.js
+++ b/packages/pg/lib/index.js
@@ -44,20 +44,27 @@ if (typeof process.env.NODE_PG_FORCE_NATIVE !== 'undefined') {
   module.exports = new PG(Client)
 
   // lazy require native module...the native module may not have installed
-  module.exports.__defineGetter__('native', function () {
-    delete module.exports.native
-    var native = null
-    try {
-      native = new PG(require('./native'))
-    } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND') {
-        throw err
+  Object.defineProperty(module.exports, 'native', {
+    configurable: true,
+    get () {
+      var native = null
+      try {
+        native = new PG(require('./native'))
+      } catch (err) {
+        if (err.code !== 'MODULE_NOT_FOUND') {
+          throw err
+        }
+        /* eslint-disable no-console */
+        console.error(err.message)
+        /* eslint-enable no-console */
       }
-      /* eslint-disable no-console */
-      console.error(err.message)
-      /* eslint-enable no-console */
+
+      // overwrite module.exports.native so that getter is never called again
+      Object.defineProperty(module.exports, 'native', {
+        value: native
+      })
+
+      return native
     }
-    module.exports.native = native
-    return native
   })
 }


### PR DESCRIPTION
Making it non-enumerable means less spurious "Cannot find module" errors in your logs when iterating over `pg` objects.

`Object.defineProperty` has been available since Node 0.12.

See https://github.com/brianc/node-postgres/issues/1894#issuecomment-543300178