### PR TITLE
Ensure query.callback is always valid

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -487,7 +487,7 @@ Client.prototype.query = function (config, values, callback) {
         query.handleError(error, this.connection)
       })
 
-      queryCallback(error)
+      if (queryCallback) queryCallback(error)
 
       // we already returned an error,
       // just do nothing if query completes


### PR DESCRIPTION
Consider an object such as a `pgCursor` being passed to `query()`, and no callback is supplied as the caller is expecting a promise to be returned.  The code will go via `client.js:465` which results in `query.callback` being left undefined.  If the query takes too long and times out, `client.js:490` will try to use the callback to report the timeout, causing an error:
```
TypeError: queryCallback is not a function
    at Timeout.setTimeout (node_modules/pg/lib/client.js:501:7)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)
```
This appears to be the cause of #1860.

This PR fixes the issue by ensuring that the callback is always valid, however I don't fully understand the implications of this change so would appreciate some expert opinions on whether this is the correct solution for this bug.

For one, if the database connection gets terminated, without this PR I immediately get an error:
```
 Error: Connection terminated
    at Connection.con.once (node_modules/pg/lib/client.js:251:9)
    at Object.onceWrapper (events.js:286:20)
```
Followed a few moments later by the above `queryCallback` error.  If I instead use the patch in the PR, the "Connection terminated" error never appears, and I get nothing for a few seconds until the promise fails nicely with the query timeout error.

It would be nicer if the promise failed immediately with the "Connection terminated" error instead, but I'm not sure if that's possible.  It appears that with or without this PR, an error arriving in the `pgCursor` object never makes it back up to reject the promise returned by `query()`.