### PR TITLE
Revert "Support additional tls.connect() options"

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -91,9 +91,18 @@ Connection.prototype.connect = function (port, host) {
         return self.emit('error', new Error('There was an error establishing an SSL connection'))
     }
     var tls = require('tls')
-    const options = Object.assign({
-      socket: self.stream
-    }, self.ssl)
+    const options = {
+      socket: self.stream,
+      checkServerIdentity: self.ssl.checkServerIdentity || tls.checkServerIdentity,
+      rejectUnauthorized: self.ssl.rejectUnauthorized,
+      ca: self.ssl.ca,
+      pfx: self.ssl.pfx,
+      key: self.ssl.key,
+      passphrase: self.ssl.passphrase,
+      cert: self.ssl.cert,
+      secureOptions: self.ssl.secureOptions,
+      NPNProtocols: self.ssl.NPNProtocols
+    }
     if (net.isIP(host) === 0) {
       options.servername = host
     }


### PR DESCRIPTION
Reverts brianc/node-postgres#1996

This is causing backwards compatibility issues.  We don't have an tests in travis covering the expected behavior when connecting to a postgres server over SSL with a self-signed cert.  Until we can get some tests up for that behavior I'm going to revert this to not break all existing folks who do a minor version upgrade.

For v8.0 we'll need to nail this down and make sure it's behaving properly.  As this is the first I've heard of this I haven't dug in yet, but I will figure out what the proper behavior should be, do as much as we can in the next semver minor release (like supporting more ssl options), and make sure it behaves the same way a raw `tls.connect` call is made in node.  It kinda blows my mind that node would treat `self.ssl.rejectUnauthorized: undefined` as `false`...