### PR TITLE
Clear connection timeout on error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -251,6 +251,7 @@ Client.prototype._connect = function (callback) {
       ? new Error('Connection terminated')
       : new Error('Connection terminated unexpectedly')
 
+    clearTimeout(connectionTimeoutHandle)
     this._errorAllQueries(error)
 
     if (!this._ending) {


### PR DESCRIPTION
If the connection gets unexpectedly dropped during the connection phase (in my case because the database is too busy) then the error handler doesn't cancel the connection timeout.  This results in an 'unexpected disconnection' error, followed some seconds later by a 'connection timeout' error.

This prevents any user code from terminating while the second timeout handler is counting down, which in some environments (like AWS Lamba) where you pay by the second, will cost more money while the script sits there waiting for the now superfluous connection timeout to expire.

This PR cancels the connection timeout in the error handler, allowing scripts that wish to exit immediately to do so.