### PR TITLE
Remove unreachable branch in `parseE`

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -594,27 +594,19 @@ Connection.prototype._readValue = function (buffer) {
 // parses error
 Connection.prototype.parseE = function (buffer, length) {
   var fields = {}
-  var msg, item
-  var input = new Message('error', length)
   var fieldType = this.readString(buffer, 1)
   while (fieldType !== '\0') {
     fields[fieldType] = this.parseCString(buffer)
     fieldType = this.readString(buffer, 1)
   }
-  if (input.name === 'error') {
-    // the msg is an Error instance
-    msg = new Error(fields.M)
-    for (item in input) {
-      // copy input properties to the error
-      if (Object.prototype.hasOwnProperty.call(input, item)) {
-        msg[item] = input[item]
-      }
-    }
-  } else {
-    // the msg is an object literal
-    msg = input
-    msg.message = fields.M
-  }
+
+  // the msg is an Error instance
+  var msg = new Error(fields.M)
+
+  // for compatibility with Message
+  msg.name = 'error'
+  msg.length = length
+
   msg.severity = fields.S
   msg.code = fields.C
   msg.detail = fields.D


### PR DESCRIPTION
The message is created with a fixed name.

56b7c4168d5aa084b2821279ee88d437a2b7636d, released in pg 2.4.0, was when this became applicable and the type of a `notice` event’s argument changed to an Error.