### PR TITLE
Warn when functions intended as constructors are called without new

### DIFF
--- a/lib/compat/check-constructor.js
+++ b/lib/compat/check-constructor.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const warnDeprecation = require('./warn-deprecation')
+
+// Node 4 doesn’t support new.target.
+let hasNewTarget
+
+try {
+  // eslint-disable-next-line no-eval
+  eval('(function () { new.target })')
+  hasNewTarget = true
+} catch (error) {
+  hasNewTarget = false
+}
+
+const checkConstructor = (name, code, getNewTarget) => {
+  if (hasNewTarget && getNewTarget() === undefined) {
+    warnDeprecation(`Constructing a ${name} without new is deprecated and will stop working in pg 8.`, code)
+  }
+}
+
+module.exports = checkConstructor

--- a/lib/compat/warn-deprecation.js
+++ b/lib/compat/warn-deprecation.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const util = require('util')
+
+const dummyFunctions = new Map()
+
+// Node 4 doesn’t support process.emitWarning(message, 'DeprecationWarning', code).
+const emitDeprecationWarning = (message, code) => {
+  let dummy = dummyFunctions.get(code)
+
+  if (dummy === undefined) {
+    dummy = util.deprecate(() => {}, message)
+    dummyFunctions.set(code, dummy)
+  }
+
+  dummy()
+}
+
+module.exports = emitDeprecationWarning

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,26 +12,12 @@ var Client = require('./client')
 var defaults = require('./defaults')
 var Connection = require('./connection')
 var Pool = require('pg-pool')
-
-let hasNewTarget
-
-try {
-  // eslint-disable-next-line no-eval
-  eval('(function () { new.target })')
-  hasNewTarget = true
-} catch (error) {
-  hasNewTarget = false
-}
+const checkConstructor = require('./compat/check-constructor')
 
 const poolFactory = (Client) => {
   var BoundPool = function (options) {
-    // new.target is a syntax error in Node 4
     // eslint-disable-next-line no-eval
-    if (hasNewTarget && eval('new.target') === undefined) {
-      // process.emitWarning is supported when new.target is supported
-      // eslint-disable-next-line node/no-unsupported-features/node-builtins
-      process.emitWarning('Constructing a pg.Pool without new is deprecated and will stop working in pg 8.', 'DeprecationWarning', 'PG-POOL-NEW')
-    }
+    checkConstructor('pg.Pool', 'PG-POOL-NEW', () => eval('new.target'))
 
     var config = Object.assign({ Client: Client }, options)
     return new Pool(config)

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,8 +13,26 @@ var defaults = require('./defaults')
 var Connection = require('./connection')
 var Pool = require('pg-pool')
 
+let hasNewTarget
+
+try {
+  // eslint-disable-next-line no-eval
+  eval('(function () { new.target })')
+  hasNewTarget = true
+} catch (error) {
+  hasNewTarget = false
+}
+
 const poolFactory = (Client) => {
   var BoundPool = function (options) {
+    // new.target is a syntax error in Node 4
+    // eslint-disable-next-line no-eval
+    if (hasNewTarget && eval('new.target') === undefined) {
+      // process.emitWarning is supported when new.target is supported
+      // eslint-disable-next-line node/no-unsupported-features/node-builtins
+      process.emitWarning('Constructing a pg.Pool without new is deprecated and will stop working in pg 8.', 'DeprecationWarning', 'PG-POOL-NEW')
+    }
+
     var config = Object.assign({ Client: Client }, options)
     return new Pool(config)
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -9,12 +9,15 @@
 
 var EventEmitter = require('events').EventEmitter
 var util = require('util')
+const checkConstructor = require('./compat/check-constructor')
 
 var Result = require('./result')
 var utils = require('./utils')
 
 var Query = function (config, values, callback) {
-  // use of "new" optional
+  // use of "new" optional in pg 7
+  // eslint-disable-next-line no-eval
+  checkConstructor('Query', 'PG-QUERY-NEW', () => eval('new.target'))
   if (!(this instanceof Query)) { return new Query(config, values, callback) }
 
   config = utils.normalizeQueryConfig(config, values, callback)


### PR DESCRIPTION
in preparation for #1541. `eval` is a bit awkward, but it’s more accurate than an `instanceof` check and will work on platforms new enough to support pg 8 (i.e. only not Node 4).