### PR TITLE
Some intial performance work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 node_modules/
 package-lock.json
 *.swp
+dist
+.DS_Store

--- a/packages/pg/bench.js
+++ b/packages/pg/bench.js
@@ -1,0 +1,43 @@
+const pg = require("./lib");
+const pool = new pg.Pool()
+
+const q = {
+  text:
+    "select typname, typnamespace, typowner, typlen, typbyval, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray from pg_type where typtypmod = $1 and typisdefined = $2",
+  values: [-1, true]
+};
+
+const exec = async client => {
+  const result = await client.query({
+    text: q.text,
+    values: q.values,
+    rowMode: "array"
+  });
+};
+
+const bench = async (client, time) => {
+  let start = Date.now();
+  let count = 0;
+  while (true) {
+    await exec(client);
+    count++;
+    if (Date.now() - start > time) {
+      return count;
+    }
+  }
+};
+
+const run = async () => {
+  const client = new pg.Client();
+  await client.connect();
+  await bench(client, 1000);
+  console.log("warmup done");
+  const seconds = 5;
+  const queries = await bench(client, seconds * 1000);
+  console.log("queries:", queries);
+  console.log("qps", queries / seconds);
+  console.log("on my laptop best so far seen 713 qps")
+  await client.end();
+};
+
+run().catch(e => console.error(e) || process.exit(-1));

--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -381,8 +381,8 @@ var Message = function (name, length) {
 
 Connection.prototype.parseMessage = function (buffer) {
   this.offset = 0
-  const length = buffer.length + 4;
-  const code = this._reader.header;
+  const length = buffer.length + 4
+  const code = this._reader.header
   switch (code) {
     case 0x52: // R
       return this.parseR(buffer, length)
@@ -447,7 +447,6 @@ Connection.prototype.parseMessage = function (buffer) {
     case 0x64: // d
       return this.parsed(buffer, length)
   }
-  console.log('could not parse', packet)
 }
 
 Connection.prototype.parseR = function (buffer, length) {

--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -21,7 +21,6 @@ var Connection = function (config) {
   EventEmitter.call(this)
   config = config || {}
   this.stream = config.stream || new net.Socket()
-  this.stream.setNoDelay(true)
   this._keepAlive = config.keepAlive
   this._keepAliveInitialDelayMillis = config.keepAliveInitialDelayMillis
   this.lastBuffer = false


### PR DESCRIPTION
I did some experiments with sending flush more regularly & I saw query throughput on a very, very basic benchmark improve by about 10%.  I'm wondering if this has more impact or less impact on situations with more latency as my benchmark was running locally.  I'm particularly trying to shake out what's impacting things in #1993 and #1952 

I also removed some sort of micro-optimization I made a long time ago that isn't helping anymore.  I saw small speed increases, but I think it might help the ClienRead delays in certain cases.  I was buffering up a bunch of messages in the process (parse, bind, execute) before sending any of them.  Now I'm just writing them all to the wire when the come in, and following each w/ a sync to help the backend send it's responses as quickly as possible as well.