### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,20 @@
 
 Non-blocking PostgreSQL client for Node.js.  Pure JavaScript and optional native libpq bindings.
 
-## Install
+## Monorepo
 
-```sh
-$ npm install pg
-```
+This repo is a monorepo which contains the core [pg](https://github.com/brianc/node-postgres) module as well as a handful of related modules.
 
----
-## :star: [Documentation](https://node-postgres.com) :star:
+- [pg-cursor](https://github.com/brianc/node-postgres/tree/master/packages/pg-cursor)
 
+_(more to come, I'm in the process of migrating repos over here)_
+
+
+## Documenation
+
+Each package in this repo should have it's own readme more focused on how to develop/contribute.  For overall documentation on the project and the related modules managed by this repo please see:
+
+### :star: [Documentation](https://node-postgres.com) :star:
 
 ### Features
 
@@ -44,13 +49,11 @@ When you open an issue please provide:
 
 You can also follow me [@briancarlson](https://twitter.com/briancarlson) if that's your thing. I try to always announce noteworthy changes & developments with node-postgres on Twitter.
 
-### Professional Support
-
-I offer professional support for node-postgres.  I provide implementation, training, and many years of expertise on how to build applications with Node, Express, PostgreSQL, and React/Redux.  Please contact me at [brian.m.carlson@gmail.com](mailto:brian.m.carlson@gmail.com) to discuss how I can help your company be more successful!
-
 ### Sponsorship :star:
 
-If you are benefiting from node-postgres and would like to help keep the project financially sustainable please visit Brian Carlson's [Patreon page](https://www.patreon.com/node_postgres).
+[If you or your company are benefiting from node-postgres and would like to help keep the project financially sustainable please consider supporting](https://github.com/sponsors/brianc) its development.
+
+Also, you can view a historical list of all [previous and existing sponsors](https://github.com/brianc/node-postgres/blob/master/SPONSORS.md).
 
 ## Contributing
 
@@ -60,6 +63,8 @@ I will __happily__ accept your pull request if it:
 - __has tests__
 - looks reasonable
 - does not break backwards compatibility
+
+If your change involves breaking backwards compatibility please please point that out in the pull request & we can discuss & plan when and how to release it and what type of documentation or communicate it will require.
 
 ## Troubleshooting and FAQ
 
@@ -86,4 +91,3 @@ Copyright (c) 2010-2019 Brian Carlson (brian.m.carlson@gmail.com)
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
-

--- a/packages/pg/README.md
+++ b/packages/pg/README.md
@@ -7,15 +7,18 @@
 
 Non-blocking PostgreSQL client for Node.js.  Pure JavaScript and optional native libpq bindings.
 
-## Install
+## Monorepo
 
-```sh
-$ npm install pg
-```
+This repo is a monorepo which contains the core [pg](https://github.com/brianc/node-postgres) module as well as a handful of related modules.
 
----
-## :star: [Documentation](https://node-postgres.com) :star:
+- [pg-cursor](https://github.com/brianc/node-postgres/tree/master/packages/pg-cursor)
 
+
+## Documenation
+
+Each package in this repo should have it's own readme more focused on how to develop/contribute.  For overall documentation on the project and the related modules managed by this repo please see:
+
+### :star: [Documentation](https://node-postgres.com) :star:
 
 ### Features
 
@@ -50,7 +53,9 @@ I offer professional support for node-postgres.  I provide implementation, train
 
 ### Sponsorship :star:
 
-If you are benefiting from node-postgres and would like to help keep the project financially sustainable please visit Brian Carlson's [Patreon page](https://www.patreon.com/node_postgres).
+[If you or your company are benefiting from node-postgres and would like to help keep the project financially sustainable please consider supporting](https://github.com/sponsors/brianc) to its development.
+
+Also, you can view a historical list of all [previous and existing sponsors](https://github.com/brianc/node-postgres/blob/master/SPONSORS.md).
 
 ## Contributing
 
@@ -60,6 +65,8 @@ I will __happily__ accept your pull request if it:
 - __has tests__
 - looks reasonable
 - does not break backwards compatibility
+
+If your change involves breaking backwards compatibility please please point that out in the pull request & we can discuss & plan when and how to release it and what type of documentation or communicate it will require.
 
 ## Troubleshooting and FAQ
 
@@ -86,4 +93,3 @@ Copyright (c) 2010-2019 Brian Carlson (brian.m.carlson@gmail.com)
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
-

--- a/packages/pg/README.md
+++ b/packages/pg/README.md
@@ -7,18 +7,15 @@
 
 Non-blocking PostgreSQL client for Node.js.  Pure JavaScript and optional native libpq bindings.
 
-## Monorepo
+## Install
 
-This repo is a monorepo which contains the core [pg](https://github.com/brianc/node-postgres) module as well as a handful of related modules.
+```sh
+$ npm install pg
+```
 
-- [pg-cursor](https://github.com/brianc/node-postgres/tree/master/packages/pg-cursor)
+---
+## :star: [Documentation](https://node-postgres.com) :star:
 
-
-## Documenation
-
-Each package in this repo should have it's own readme more focused on how to develop/contribute.  For overall documentation on the project and the related modules managed by this repo please see:
-
-### :star: [Documentation](https://node-postgres.com) :star:
 
 ### Features
 
@@ -47,15 +44,12 @@ When you open an issue please provide:
 
 You can also follow me [@briancarlson](https://twitter.com/briancarlson) if that's your thing. I try to always announce noteworthy changes & developments with node-postgres on Twitter.
 
-### Professional Support
-
-I offer professional support for node-postgres.  I provide implementation, training, and many years of expertise on how to build applications with Node, Express, PostgreSQL, and React/Redux.  Please contact me at [brian.m.carlson@gmail.com](mailto:brian.m.carlson@gmail.com) to discuss how I can help your company be more successful!
-
 ### Sponsorship :star:
 
-[If you or your company are benefiting from node-postgres and would like to help keep the project financially sustainable please consider supporting](https://github.com/sponsors/brianc) to its development.
+[If you or your company are benefiting from node-postgres and would like to help keep the project financially sustainable please consider supporting](https://github.com/sponsors/brianc) its development.
 
 Also, you can view a historical list of all [previous and existing sponsors](https://github.com/brianc/node-postgres/blob/master/SPONSORS.md).
+
 
 ## Contributing
 
@@ -67,6 +61,7 @@ I will __happily__ accept your pull request if it:
 - does not break backwards compatibility
 
 If your change involves breaking backwards compatibility please please point that out in the pull request & we can discuss & plan when and how to release it and what type of documentation or communicate it will require.
+
 
 ## Troubleshooting and FAQ
 
@@ -93,3 +88,4 @@ Copyright (c) 2010-2019 Brian Carlson (brian.m.carlson@gmail.com)
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
+


### PR DESCRIPTION
I noticed the most recent published version [on npm](https://www.npmjs.com/package/pg) is lacking a readme now that I moved it into the `./packages/pg` folder but left the readme at the top of the repo.  I _mostly_ copied the parent readme into the child folder, but updated the wording a bit.  I know it's duplicated on both places, but I think that's fine as its better to have too much documentation than not enough!  I also changed the sponsor section to point to github sponsors instead of patreon.