### PR TITLE
Fix pg-query-stream implementation

### DIFF
--- a/packages/pg-cursor/index.js
+++ b/packages/pg-cursor/index.js
@@ -182,7 +182,7 @@ Cursor.prototype.end = util.deprecate(function (cb) {
 }, 'Cursor.end is deprecated. Call end on the client itself to end a connection to the database.')
 
 Cursor.prototype.close = function (cb) {
-  if (this.state === 'done') {
+  if (!this.connection || this.state === 'done') {
     if (cb) {
       return setImmediate(cb)
     } else {

--- a/packages/pg-cursor/test/close.js
+++ b/packages/pg-cursor/test/close.js
@@ -46,4 +46,9 @@ describe('close', function () {
       })
     })
   })
+
+  it('is a no-op to "close" the cursor before submitting it', function (done) {
+    const cursor = new Cursor(text)
+    cursor.close(done)
+  })
 })

--- a/packages/pg-query-stream/README.md
+++ b/packages/pg-query-stream/README.md
@@ -47,7 +47,7 @@ I'm very open to contribution!  Open a pull request with your code or idea and w
 
 The MIT License (MIT)
 
-Copyright (c) 2013 Brian M. Carlson
+Copyright (c) 2013-2019 Brian M. Carlson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/pg-query-stream/index.js
+++ b/packages/pg-query-stream/index.js
@@ -8,10 +8,6 @@ class PgQueryStream extends Readable {
     super({ objectMode: true, emitClose: true, autoDestroy: true, highWaterMark: batchSize })
     this.cursor = new Cursor(text, values, config)
 
-    this._reading = false
-    this._callbacks = []
-    this._err = undefined;
-
     // delegate Submittable callbacks to cursor
     this.handleRowDescription = this.cursor.handleRowDescription.bind(this.cursor)
     this.handleDataRow = this.cursor.handleDataRow.bind(this.cursor)
@@ -25,42 +21,16 @@ class PgQueryStream extends Readable {
     this.cursor.submit(connection)
   }
 
-  close(callback) {
-    if (this.destroyed) {
-      if (callback) setImmediate(callback)
-    } else {
-      if (callback) this.once('close', callback)
-      this.destroy()
-    }
-  }
-
-  _close() {
+  _destroy(_err, cb) {
     this.cursor.close((err) => {
-      let cb
-      while ((cb = this._callbacks.pop())) cb(err || this._err)
+      cb && cb(err || _err)
     })
-  }
-
-  _destroy(_err, callback) {
-    this._err = _err;
-    this._callbacks.push(callback)
-    if (!this._reading) {
-      this._close()
-    }
   }
 
   // https://nodejs.org/api/stream.html#stream_readable_read_size_1
   _read(size) {
-    // Prevent _destroy() from closing while reading
-    this._reading = true
-
     this.cursor.read(size, (err, rows, result) => {
-      this._reading = false
-
-      if (this.destroyed) {
-        // Destroyed while reading?
-        this._close()
-      } else if (err) {
+      if (err) {
         // https://nodejs.org/api/stream.html#stream_errors_while_reading
         this.destroy(err)
       } else {

--- a/packages/pg-query-stream/index.js
+++ b/packages/pg-query-stream/index.js
@@ -23,7 +23,7 @@ class PgQueryStream extends Readable {
 
   _destroy(_err, cb) {
     this.cursor.close((err) => {
-      cb && cb(err || _err)
+      cb(err || _err)
     })
   }
 

--- a/packages/pg-query-stream/test/async-iterator.es6
+++ b/packages/pg-query-stream/test/async-iterator.es6
@@ -59,7 +59,7 @@ describe('Async iterator', () => {
     const pool = new pg.Pool({ max: 1 })
     const client = await pool.connect()
     const rows = []
-    for await (const row of client.query(new QueryStream(queryText, []))) {
+    for await (const row of client.query(new QueryStream(queryText, [], { batchSize: 1 }))) {
       rows.push(row)
       break;
     }

--- a/packages/pg-query-stream/test/async-iterator.es6
+++ b/packages/pg-query-stream/test/async-iterator.es6
@@ -54,4 +54,59 @@ describe('Async iterator', () => {
     assert.equal(allRows.length, 603)
     await pool.end()
   })
+
+  it('can break out of iteration early', async () => {
+    const pool = new pg.Pool({ max: 1 })
+    const client = await pool.connect()
+    const rows = []
+    for await (const row of client.query(new QueryStream(queryText, []))) {
+      rows.push(row)
+      break;
+    }
+    for await (const row of client.query(new QueryStream(queryText, []))) {
+      rows.push(row)
+      break;
+    }
+    for await (const row of client.query(new QueryStream(queryText, []))) {
+      rows.push(row)
+      break;
+    }
+    assert.strictEqual(rows.length, 3)
+    client.release()
+    await pool.end()
+  })
+
+  it('only returns rows on first iteration', async () => {
+    const pool = new pg.Pool({ max: 1 })
+    const client = await pool.connect()
+    const rows = []
+    const stream = client.query(new QueryStream(queryText, []))
+    for await (const row of stream) {
+      rows.push(row)
+      break;
+    }
+    for await (const row of stream) {
+      rows.push(row)
+    }
+    for await (const row of stream) {
+      rows.push(row)
+    }
+    assert.strictEqual(rows.length, 1)
+    client.release()
+    await pool.end()
+  })
+
+  it('can read with delays', async () => {
+    const pool = new pg.Pool({ max: 1 })
+    const client = await pool.connect()
+    const rows = []
+    const stream = client.query(new QueryStream(queryText, [], { batchSize: 1 }))
+    for await (const row of stream) {
+      rows.push(row)
+      await new Promise((resolve) => setTimeout(resolve, 1))
+    }
+    assert.strictEqual(rows.length, 201)
+    client.release()
+    await pool.end()
+  })
 })

--- a/packages/pg-query-stream/test/close.js
+++ b/packages/pg-query-stream/test/close.js
@@ -45,6 +45,21 @@ helper('early close', function (client) {
     }, 100)
   })
 
+  it('emits an error when calling destroy with an error', function (done) {
+    var stream = new QueryStream('SELECT * FROM generate_series(0, 100), pg_sleep(1)')
+    client.query(stream)
+    stream.on('data', () => done(new Error('stream should not have returned rows')))
+    setTimeout(() => {
+      stream.destroy(new Error('intentional error'))
+      stream.on('error', (err) => {
+        // make sure there's an error
+        assert(err);
+        assert.strictEqual(err.message, 'intentional error');
+        done();
+      })
+    }, 100)
+  })
+
   it('can destroy stream while reading an error', function (done) {
     var stream = new QueryStream('SELECT * from pg_sleep(1), basdfasdf;')
     client.query(stream)

--- a/packages/pg-query-stream/test/close.js
+++ b/packages/pg-query-stream/test/close.js
@@ -6,16 +6,16 @@ var helper = require('./helper')
 
 helper('close', function (client) {
   it('emits close', function (done) {
-    var stream = new QueryStream('SELECT * FROM generate_series(0, $1) num', [3], {batchSize: 2, highWaterMark: 2})
+    var stream = new QueryStream('SELECT * FROM generate_series(0, $1) num', [3], { batchSize: 2, highWaterMark: 2 })
     var query = client.query(stream)
-    query.pipe(concat(function () {}))
+    query.pipe(concat(function () { }))
     query.on('close', done)
   })
 })
 
 helper('early close', function (client) {
   it('can be closed early', function (done) {
-    var stream = new QueryStream('SELECT * FROM generate_series(0, $1) num', [20000], {batchSize: 2, highWaterMark: 2})
+    var stream = new QueryStream('SELECT * FROM generate_series(0, $1) num', [20000], { batchSize: 2, highWaterMark: 2 })
     var query = client.query(stream)
     var readCount = 0
     query.on('readable', function () {
@@ -34,7 +34,7 @@ helper('early close', function (client) {
 
 helper('close callback', function (client) {
   it('notifies an optional callback when the conneciton is closed', function (done) {
-    var stream = new QueryStream('SELECT * FROM generate_series(0, $1) num', [10], {batchSize: 2, highWaterMark: 2})
+    var stream = new QueryStream('SELECT * FROM generate_series(0, $1) num', [10], { batchSize: 2, highWaterMark: 2 })
     var query = client.query(stream)
     query.once('readable', function () { // only reading once
       query.read()
@@ -44,9 +44,6 @@ helper('close callback', function (client) {
         // nothing to assert.  This test will time out if the callback does not work.
         done()
       })
-    })
-    query.on('close', function () {
-      assert(false, 'close event should not fire') // no close event because we did not read to the end of the stream.
     })
   })
 })

--- a/packages/pg-query-stream/test/config.js
+++ b/packages/pg-query-stream/test/config.js
@@ -2,9 +2,7 @@ var assert = require('assert')
 var QueryStream = require('../')
 
 var stream = new QueryStream('SELECT NOW()', [], {
-  highWaterMark: 999,
   batchSize: 88
 })
 
-assert.equal(stream._readableState.highWaterMark, 999)
-assert.equal(stream.batchSize, 88)
+assert.equal(stream._readableState.highWaterMark, 88)


### PR DESCRIPTION
There were some subtle behaviors with the stream being implemented incorrectly & not working as expected with async iteration.  I've modified the code based on #2050 and comments in #2035 to have better test coverage of async iterables and update the internals significantly to more closely match the readable stream interface.

Note: this is a __breaking__ (semver major) change to this package as the close event behavior is changed slightly so it now emits always, instead of improperly being suppressed when manually closing the stream, and `highWaterMark` is no longer supported.  It shouldn't impact most usage, but breaking regardless.

cc @matthieusieben - I think I covered the tests you were looking for in your previous comment, but please let me know if I missed anything! 🙏 