### PR TITLE
Make `BoundPool` an es6 subclass of `Pool`

### DIFF
--- a/packages/pg/test/integration/gh-issues/1542-tests.js
+++ b/packages/pg/test/integration/gh-issues/1542-tests.js
@@ -1,0 +1,25 @@
+
+"use strict"
+const helper = require('./../test-helper')
+const assert = require('assert')
+
+const suite = new helper.Suite()
+
+suite.testAsync('BoundPool can be subclassed', async () => {
+  const Pool = helper.pg.Pool;
+  class SubPool extends Pool {
+
+  }
+  const subPool = new SubPool()
+  const client = await subPool.connect()
+  client.release()
+  await subPool.end()
+  assert(subPool instanceof helper.pg.Pool)
+})
+
+suite.test('calling pg.Pool without new throws', () => {
+  const Pool = helper.pg.Pool;
+  assert.throws(() => {
+    const pool = Pool()
+  })
+})


### PR DESCRIPTION
This fixes subtle subclassing bugs using es6 classes.  It is a semver breaking change targeting 8.0 release...though it's not likely to cause issues in the general case.

I'm merging this into the `bmc/8.0` branch.  This closes #1541 as it had merge conflicts since it got quite old & doesn't have tests...but I still appreciate the thought and work that went into it!