### PR TITLE
Deprecate implicit TLS `rejectUnauthorized: false`

### DIFF
--- a/packages/pg/lib/compat/warn-deprecation.js
+++ b/packages/pg/lib/compat/warn-deprecation.js
@@ -5,7 +5,7 @@ const util = require('util')
 const dummyFunctions = new Map()
 
 // Node 4 doesn’t support process.emitWarning(message, 'DeprecationWarning', code).
-const emitDeprecationWarning = (message, code) => {
+const warnDeprecation = (message, code) => {
   let dummy = dummyFunctions.get(code)
 
   if (dummy === undefined) {
@@ -16,4 +16,4 @@ const emitDeprecationWarning = (message, code) => {
   dummy()
 }
 
-module.exports = emitDeprecationWarning
+module.exports = warnDeprecation

--- a/packages/pg/lib/connection-fast.js
+++ b/packages/pg/lib/connection-fast.js
@@ -15,6 +15,8 @@ var Writer = require('buffer-writer')
 // eslint-disable-next-line
 var PacketStream = require('pg-packet-stream')
 
+var warnDeprecation = require('./compat/warn-deprecation')
+
 var TEXT_MODE = 0
 
 // TODO(bmc) support binary mode here
@@ -104,6 +106,9 @@ Connection.prototype.connect = function (port, host) {
       cert: self.ssl.cert,
       secureOptions: self.ssl.secureOptions,
       NPNProtocols: self.ssl.NPNProtocols
+    }
+    if (typeof self.ssl.rejectUnauthorized !== 'boolean') {
+      warnDeprecation('Implicit disabling of certificate verification is deprecated and will be removed in pg 8. Specify `rejectUnauthorized: true` to require a valid CA or `rejectUnauthorized: false` to explicitly opt out of MITM protection.', 'PG-SSL-VERIFY')
     }
     if (net.isIP(host) === 0) {
       options.servername = host

--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -14,6 +14,8 @@ var util = require('util')
 var Writer = require('buffer-writer')
 var Reader = require('packet-reader')
 
+var warnDeprecation = require('./compat/warn-deprecation')
+
 var TEXT_MODE = 0
 var BINARY_MODE = 1
 var Connection = function (config) {
@@ -102,6 +104,9 @@ Connection.prototype.connect = function (port, host) {
       cert: self.ssl.cert,
       secureOptions: self.ssl.secureOptions,
       NPNProtocols: self.ssl.NPNProtocols
+    }
+    if (typeof self.ssl.rejectUnauthorized !== 'boolean') {
+      warnDeprecation('Implicit disabling of certificate verification is deprecated and will be removed in pg 8. Specify `rejectUnauthorized: true` to require a valid CA or `rejectUnauthorized: false` to explicitly opt out of MITM protection.', 'PG-SSL-VERIFY')
     }
     if (net.isIP(host) === 0) {
       options.servername = host


### PR DESCRIPTION
Yes, it treats `undefined` as `false`. Discussion in #2009. Introduced unintentionally in pg 0.8.7.