### PR TITLE
Continue support for creating a pg.Pool from another instance’s options

### DIFF
--- a/packages/pg/lib/index.js
+++ b/packages/pg/lib/index.js
@@ -15,8 +15,7 @@ var Pool = require('pg-pool')
 const poolFactory = (Client) => {
   return class BoundPool extends Pool {
     constructor (options) {
-      var config = Object.assign({ Client: Client }, options)
-      super(config)
+      super(options, Client)
     }
   }
 }

--- a/packages/pg/test/unit/connection-pool/configuration-tests.js
+++ b/packages/pg/test/unit/connection-pool/configuration-tests.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const assert = require('assert')
+const helper = require('../test-helper')
+
+test('pool with copied settings includes password', () => {
+  const original = new helper.pg.Pool({
+    password: 'original',
+  })
+
+  const copy = new helper.pg.Pool(original.options)
+
+  assert.equal(copy.options.password, 'original')
+})


### PR DESCRIPTION
by dropping the requirement for the `password` property to be enumerable.