### PR TITLE
Do not return broken or closed clients to the pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 *.swp
 dist
 .DS_Store
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 node_js:
   - lts/dubnium
   - lts/erbium
-  - 13
+  - 13.6
 
 addons:
   postgresql: "10"

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -60,6 +60,18 @@ class Pool extends EventEmitter {
   constructor (options, Client) {
     super()
     this.options = Object.assign({}, options)
+
+    if (options != null && 'password' in options) {
+      // "hiding" the password so it doesn't show up in stack traces
+      // or if the client is console.logged
+      Object.defineProperty(this.options, 'password', {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: options.password
+      })
+    }
+
     this.options.max = this.options.max || this.options.poolSize || 10
     this.log = this.options.log || function () { }
     this.Client = this.options.Client || Client || require('pg').Client

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -25,29 +25,8 @@ class PendingItem {
   }
 }
 
-function throwOnRelease () {
+function throwOnDoubleRelease () {
   throw new Error('Release called on client which has already been released to the pool.')
-}
-
-function release (client, err) {
-  client.release = throwOnRelease
-  if (err || this.ending || !client._queryable || client._ending) {
-    this._remove(client)
-    this._pulseQueue()
-    return
-  }
-
-  // idle timeout
-  let tid
-  if (this.options.idleTimeoutMillis) {
-    tid = setTimeout(() => {
-      this.log('remove idle client')
-      this._remove(client)
-    }, this.options.idleTimeoutMillis)
-  }
-
-  this._idle.push(new IdleItem(client, tid))
-  this._pulseQueue()
 }
 
 function promisify (Promise, callback) {
@@ -281,7 +260,7 @@ class Pool extends EventEmitter {
 
     client.release = (err) => {
       if (released) {
-        throw new Error('Release called on client which has already been released to the pool.')
+        throwOnDoubleRelease()
       }
 
       released = true
@@ -317,7 +296,8 @@ class Pool extends EventEmitter {
   _release (client, idleListener, err) {
     client.on('error', idleListener)
 
-    if (err || this.ending) {
+    // TODO(bmc): expose a proper, public interface _queryable and _ending
+    if (err || this.ending || !client._queryable || client._ending) {
       this._remove(client)
       this._pulseQueue()
       return

--- a/packages/pg-pool/package.json
+++ b/packages/pg-pool/package.json
@@ -34,6 +34,6 @@
     "pg-cursor": "^1.3.0"
   },
   "peerDependencies": {
-    "pg": ">5.0"
+    "pg": ">=8.0"
   }
 }

--- a/packages/pg-pool/test/error-handling.js
+++ b/packages/pg-pool/test/error-handling.js
@@ -181,40 +181,6 @@ describe('pool error handling', function () {
     })
   })
 
-  describe('releasing a not queryable client', () => {
-    it('removes the client from the pool', (done) => {
-      const pool = new Pool({ max: 1 })
-      const connectionError = new Error('connection failed')
-
-      pool.once('error', () => {
-        // Ignore error on pool
-      })
-
-      pool.connect((err, client) => {
-        expect(err).to.be(undefined)
-
-        client.once('error', (err) => {
-          expect(err).to.eql(connectionError)
-
-          // Releasing the client should remove it from the pool,
-          // whether called with an error or not
-          client.release()
-
-          // Verify that the pool is still usuable and new client has been
-          // created
-          pool.query('SELECT $1::text as name', ['brianc'], (err, res) => {
-            expect(err).to.be(undefined)
-            expect(res.rows).to.eql([{ name: 'brianc' }])
-
-            pool.end(done)
-          })
-        })
-
-        client.emit('error', connectionError)
-      })
-    })
-  })
-
   describe('pool with lots of errors', () => {
     it('continues to work and provide new clients', co.wrap(function* () {
       const pool = new Pool({ max: 1 })

--- a/packages/pg-pool/test/error-handling.js
+++ b/packages/pg-pool/test/error-handling.js
@@ -181,6 +181,40 @@ describe('pool error handling', function () {
     })
   })
 
+  describe('releasing a not queryable client', () => {
+    it('removes the client from the pool', (done) => {
+      const pool = new Pool({ max: 1 })
+      const connectionError = new Error('connection failed')
+
+      pool.once('error', () => {
+        // Ignore error on pool
+      })
+
+      pool.connect((err, client) => {
+        expect(err).to.be(undefined)
+
+        client.once('error', (err) => {
+          expect(err).to.eql(connectionError)
+
+          // Releasing the client should remove it from the pool,
+          // whether called with an error or not
+          client.release()
+
+          // Verify that the pool is still usuable and new client has been
+          // created
+          pool.query('SELECT $1::text as name', ['brianc'], (err, res) => {
+            expect(err).to.be(undefined)
+            expect(res.rows).to.eql([{ name: 'brianc' }])
+
+            pool.end(done)
+          })
+        })
+
+        client.emit('error', connectionError)
+      })
+    })
+  })
+
   describe('pool with lots of errors', () => {
     it('continues to work and provide new clients', co.wrap(function* () {
       const pool = new Pool({ max: 1 })

--- a/packages/pg-pool/test/releasing-clients.js
+++ b/packages/pg-pool/test/releasing-clients.js
@@ -1,0 +1,54 @@
+const Pool = require('../')
+
+const expect = require('expect.js')
+const net = require('net')
+
+describe('releasing clients', () => {
+  it('removes a client which cannot be queried', async () => {
+    // make a pool w/ only 1 client
+    const pool = new Pool({ max: 1 })
+    expect(pool.totalCount).to.eql(0)
+    const client = await pool.connect()
+    expect(pool.totalCount).to.eql(1)
+    expect(pool.idleCount).to.eql(0)
+    // reach into the client and sever its connection
+    client.connection.end()
+
+    // wait for the client to error out
+    const err = await new Promise((resolve) => client.once('error', resolve))
+    expect(err).to.be.ok()
+    expect(pool.totalCount).to.eql(1)
+    expect(pool.idleCount).to.eql(0)
+
+    // try to return it to the pool - this removes it because its broken
+    client.release()
+    expect(pool.totalCount).to.eql(0)
+    expect(pool.idleCount).to.eql(0)
+
+    // make sure pool still works
+    const { rows } = await pool.query('SELECT NOW()')
+    expect(rows).to.have.length(1)
+    await pool.end()
+  })
+
+  it('removes a client which is ending', async () => {
+    // make a pool w/ only 1 client
+    const pool = new Pool({ max: 1 })
+    expect(pool.totalCount).to.eql(0)
+    const client = await pool.connect()
+    expect(pool.totalCount).to.eql(1)
+    expect(pool.idleCount).to.eql(0)
+    // end the client gracefully (but you shouldn't do this with pooled clients)
+    client.end()
+
+    // try to return it to the bool
+    client.release()
+    expect(pool.totalCount).to.eql(0)
+    expect(pool.idleCount).to.eql(0)
+
+    // make sure pool still works
+    const { rows } = await pool.query('SELECT NOW()')
+    expect(rows).to.have.length(1)
+    await pool.end()
+  })
+})

--- a/packages/pg/Makefile
+++ b/packages/pg/Makefile
@@ -62,6 +62,4 @@ test-pool:
 
 lint:
 	@echo "***Starting lint***"
-	node -e "process.exit(Number(process.versions.node.split('.')[0]) < 8 ? 0 : 1)" \
-	  && echo "***Skipping lint (node version too old)***" \
-	  || node_modules/.bin/eslint lib
+	node_modules/.bin/eslint lib

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -30,7 +30,16 @@ var Client = function (config) {
   this.database = this.connectionParameters.database
   this.port = this.connectionParameters.port
   this.host = this.connectionParameters.host
-  this.password = this.connectionParameters.password
+
+  // "hiding" the password so it doesn't show up in stack traces
+  // or if the client is console.logged
+  Object.defineProperty(this, 'password', {
+    configurable: true,
+    enumerable: false,
+    writable: true,
+    value: this.connectionParameters.password
+  })
+
   this.replication = this.connectionParameters.replication
 
   var c = config || {}

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -54,7 +54,16 @@ var ConnectionParameters = function (config) {
   this.database = val('database', config)
   this.port = parseInt(val('port', config), 10)
   this.host = val('host', config)
-  this.password = val('password', config)
+
+  // "hiding" the password so it doesn't show up in stack traces
+  // or if the client is console.logged
+  Object.defineProperty(this, 'password', {
+    configurable: true,
+    enumerable: false,
+    writable: true,
+    value: val('password', config)
+  })
+
   this.binary = val('binary', config)
   this.ssl = typeof config.ssl === 'undefined' ? useSsl() : config.ssl
   this.client_encoding = val('client_encoding', config)

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -52,6 +52,11 @@ var ConnectionParameters = function (config) {
 
   this.user = val('user', config)
   this.database = val('database', config)
+
+  if (this.database === undefined) {
+    this.database = this.user
+  }
+
   this.port = parseInt(val('port', config), 10)
   this.host = val('host', config)
 

--- a/packages/pg/lib/defaults.js
+++ b/packages/pg/lib/defaults.js
@@ -15,7 +15,7 @@ module.exports = {
   user: process.platform === 'win32' ? process.env.USERNAME : process.env.USER,
 
   // name of database to connect
-  database: process.platform === 'win32' ? process.env.USERNAME : process.env.USER,
+  database: undefined,
 
   // database user's password
   password: null,

--- a/packages/pg/lib/index.js
+++ b/packages/pg/lib/index.js
@@ -15,8 +15,7 @@ var Pool = require('pg-pool')
 const poolFactory = (Client) => {
   return class BoundPool extends Pool {
     constructor (options) {
-      var config = Object.assign({ Client: Client }, options)
-      super(config)
+      super(options, Client)
     }
   }
 }

--- a/packages/pg/lib/index.js
+++ b/packages/pg/lib/index.js
@@ -7,25 +7,18 @@
  * README.md file in the root directory of this source tree.
  */
 
-var util = require('util')
 var Client = require('./client')
 var defaults = require('./defaults')
 var Connection = require('./connection')
 var Pool = require('pg-pool')
-const checkConstructor = require('./compat/check-constructor')
 
 const poolFactory = (Client) => {
-  var BoundPool = function (options) {
-    // eslint-disable-next-line no-eval
-    checkConstructor('pg.Pool', 'PG-POOL-NEW', () => eval('new.target'))
-
-    var config = Object.assign({ Client: Client }, options)
-    return new Pool(config)
+  return class BoundPool extends Pool {
+    constructor (options) {
+      var config = Object.assign({ Client: Client }, options)
+      super(config)
+    }
   }
-
-  util.inherits(BoundPool, Pool)
-
-  return BoundPool
 }
 
 var PG = function (clientConstructor) {

--- a/packages/pg/lib/native/client.js
+++ b/packages/pg/lib/native/client.js
@@ -43,7 +43,15 @@ var Client = module.exports = function (config) {
   // for the time being. TODO: deprecate all this jazz
   var cp = this.connectionParameters = new ConnectionParameters(config)
   this.user = cp.user
-  this.password = cp.password
+
+  // "hiding" the password so it doesn't show up in stack traces
+  // or if the client is console.logged
+  const hiddenPassword = cp.password
+  Object.defineProperty(this, 'password', {
+    enumerable: false,
+    writable: true,
+    value: hiddenPassword
+  })
   this.database = cp.database
   this.host = cp.host
   this.port = cp.port

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -51,6 +51,6 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">= 4.5.0"
+    "node": ">= 8.0.0"
   }
 }

--- a/packages/pg/test/integration/client/configuration-tests.js
+++ b/packages/pg/test/integration/client/configuration-tests.js
@@ -14,7 +14,7 @@ for (var key in process.env) {
 suite.test('default values are used in new clients', function () {
   assert.same(pg.defaults, {
     user: process.env.USER,
-    database: process.env.USER,
+    database: undefined,
     password: null,
     port: 5432,
     rows: 0,
@@ -52,6 +52,28 @@ suite.test('modified values are passed to created clients', function () {
     port: 1234,
     host: 'blam'
   })
+})
+
+suite.test('database defaults to user when user is non-default', () => {
+  {
+    pg.defaults.database = undefined
+
+    const client = new Client({
+      user: 'foo',
+    })
+
+    assert.strictEqual(client.database, 'foo')
+  }
+
+  {
+    pg.defaults.database = 'bar'
+
+    const client = new Client({
+      user: 'foo',
+    })
+
+    assert.strictEqual(client.database, 'bar')
+  }
 })
 
 suite.test('cleanup', () => {

--- a/packages/pg/test/integration/gh-issues/1542-tests.js
+++ b/packages/pg/test/integration/gh-issues/1542-tests.js
@@ -1,0 +1,25 @@
+
+"use strict"
+const helper = require('./../test-helper')
+const assert = require('assert')
+
+const suite = new helper.Suite()
+
+suite.testAsync('BoundPool can be subclassed', async () => {
+  const Pool = helper.pg.Pool;
+  class SubPool extends Pool {
+
+  }
+  const subPool = new SubPool()
+  const client = await subPool.connect()
+  client.release()
+  await subPool.end()
+  assert(subPool instanceof helper.pg.Pool)
+})
+
+suite.test('calling pg.Pool without new throws', () => {
+  const Pool = helper.pg.Pool;
+  assert.throws(() => {
+    const pool = Pool()
+  })
+})

--- a/packages/pg/test/integration/gh-issues/1992-tests.js
+++ b/packages/pg/test/integration/gh-issues/1992-tests.js
@@ -1,0 +1,11 @@
+
+"use strict"
+const helper = require('./../test-helper')
+const assert = require('assert')
+
+const suite = new helper.Suite()
+
+suite.test('Native should not be enumerable', () => {
+  const keys = Object.keys(helper.pg)
+  assert.strictEqual(keys.indexOf('native'), -1)
+})

--- a/packages/pg/test/integration/gh-issues/2064-tests.js
+++ b/packages/pg/test/integration/gh-issues/2064-tests.js
@@ -1,0 +1,32 @@
+
+"use strict"
+const helper = require('./../test-helper')
+const assert = require('assert')
+const util = require('util')
+
+const suite = new helper.Suite()
+
+const password = 'FAIL THIS TEST'
+
+suite.test('Password should not exist in toString() output', () => {
+  const pool = new helper.pg.Pool({ password })
+  const client = new helper.pg.Client({ password })
+  assert(pool.toString().indexOf(password) === -1);
+  assert(client.toString().indexOf(password) === -1);
+})
+
+suite.test('Password should not exist in util.inspect output', () => {
+  const pool = new helper.pg.Pool({ password })
+  const client = new helper.pg.Client({ password })
+  const depth = 20;
+  assert(util.inspect(pool, { depth }).indexOf(password) === -1);
+  assert(util.inspect(client, { depth }).indexOf(password) === -1);
+})
+
+suite.test('Password should not exist in json.stringfy output', () => {
+  const pool = new helper.pg.Pool({ password })
+  const client = new helper.pg.Client({ password })
+  const depth = 20;
+  assert(JSON.stringify(pool).indexOf(password) === -1);
+  assert(JSON.stringify(client).indexOf(password) === -1);
+})

--- a/packages/pg/test/unit/connection-parameters/creation-tests.js
+++ b/packages/pg/test/unit/connection-parameters/creation-tests.js
@@ -16,8 +16,13 @@ test('ConnectionParameters construction', function () {
 })
 
 var compare = function (actual, expected, type) {
+  const expectedDatabase =
+    expected.database === undefined
+      ? expected.user
+      : expected.database
+
   assert.equal(actual.user, expected.user, type + ' user')
-  assert.equal(actual.database, expected.database, type + ' database')
+  assert.equal(actual.database, expectedDatabase, type + ' database')
   assert.equal(actual.port, expected.port, type + ' port')
   assert.equal(actual.host, expected.host, type + ' host')
   assert.equal(actual.password, expected.password, type + ' password')

--- a/packages/pg/test/unit/connection-pool/configuration-tests.js
+++ b/packages/pg/test/unit/connection-pool/configuration-tests.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const assert = require('assert')
+const helper = require('../test-helper')
+
+test('pool with copied settings includes password', () => {
+  const original = new helper.pg.Pool({
+    password: 'original',
+  })
+
+  const copy = new helper.pg.Pool(original.options)
+
+  assert.equal(copy.options.password, 'original')
+})


### PR DESCRIPTION
Building off of https://github.com/brianc/node-pg-pool/pull/119

This was slated to go into 8.0, but after working on this I'm not sure it's a breaking change...previously if you released a broken or ended client you'd basically put your app into a state where you'd crash or hit undefined behavior in the future.  Perhaps we just merge this into the existing 7.x branch so more folks can get the change sooner.  what you think @charmander?

Either way I think this closes the final thing mentioned in #2047 

The only thing really left for 8.0 is to get some proper tests in place for handling self-signed versus "real" certificates so we can check the code is doing the right thing in travis in all cases.  I need to reference the jdbc postgres repo and find how the configure all those different situations to test against them.  After that, I can write tests, make sure it works, and release 8.0.  Then the fun work of 9.0 begins. 🏃 