### PR TITLE
Do not return broken clients to the pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
 node_js:
   - lts/dubnium
   - lts/erbium
+  # node 13.7 seems to have changed behavior of async iterators exiting early on streams
+  # if 13.8 still has this problem when it comes down I'll talk to the node team about the change
+  # in the mean time...peg to 13.6 
   - 13.6
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 node_js:
   - lts/dubnium
   - lts/erbium
-  - 13
+  - 13.6
 
 addons:
   postgresql: "10"

--- a/packages/pg-pool/test/error-handling.js
+++ b/packages/pg-pool/test/error-handling.js
@@ -181,40 +181,6 @@ describe('pool error handling', function () {
     })
   })
 
-  describe('releasing a not queryable client', () => {
-    it('removes the client from the pool', (done) => {
-      const pool = new Pool({ max: 1 })
-      const connectionError = new Error('connection failed')
-
-      pool.once('error', () => {
-        // Ignore error on pool
-      })
-
-      pool.connect((err, client) => {
-        expect(err).to.be(undefined)
-
-        client.once('error', (err) => {
-          expect(err).to.eql(connectionError)
-
-          // Releasing the client should remove it from the pool,
-          // whether called with an error or not
-          client.release()
-
-          // Verify that the pool is still usuable and new client has been
-          // created
-          pool.query('SELECT $1::text as name', ['brianc'], (err, res) => {
-            expect(err).to.be(undefined)
-            expect(res.rows).to.eql([{ name: 'brianc' }])
-
-            pool.end(done)
-          })
-        })
-
-        client.emit('error', connectionError)
-      })
-    })
-  })
-
   describe('pool with lots of errors', () => {
     it('continues to work and provide new clients', co.wrap(function* () {
       const pool = new Pool({ max: 1 })

--- a/packages/pg-pool/test/error-handling.js
+++ b/packages/pg-pool/test/error-handling.js
@@ -181,6 +181,40 @@ describe('pool error handling', function () {
     })
   })
 
+  describe('releasing a not queryable client', () => {
+    it('removes the client from the pool', (done) => {
+      const pool = new Pool({ max: 1 })
+      const connectionError = new Error('connection failed')
+
+      pool.once('error', () => {
+        // Ignore error on pool
+      })
+
+      pool.connect((err, client) => {
+        expect(err).to.be(undefined)
+
+        client.once('error', (err) => {
+          expect(err).to.eql(connectionError)
+
+          // Releasing the client should remove it from the pool,
+          // whether called with an error or not
+          client.release()
+
+          // Verify that the pool is still usuable and new client has been
+          // created
+          pool.query('SELECT $1::text as name', ['brianc'], (err, res) => {
+            expect(err).to.be(undefined)
+            expect(res.rows).to.eql([{ name: 'brianc' }])
+
+            pool.end(done)
+          })
+        })
+
+        client.emit('error', connectionError)
+      })
+    })
+  })
+
   describe('pool with lots of errors', () => {
     it('continues to work and provide new clients', co.wrap(function* () {
       const pool = new Pool({ max: 1 })

--- a/packages/pg-pool/test/releasing-clients.js
+++ b/packages/pg-pool/test/releasing-clients.js
@@ -1,0 +1,54 @@
+const Pool = require('../')
+
+const expect = require('expect.js')
+const net = require('net')
+
+describe('releasing clients', () => {
+  it('removes a client which cannot be queried', async () => {
+    // make a pool w/ only 1 client
+    const pool = new Pool({ max: 1 })
+    expect(pool.totalCount).to.eql(0)
+    const client = await pool.connect()
+    expect(pool.totalCount).to.eql(1)
+    expect(pool.idleCount).to.eql(0)
+    // reach into the client and sever its connection
+    client.connection.end()
+
+    // wait for the client to error out
+    const err = await new Promise((resolve) => client.once('error', resolve))
+    expect(err).to.be.ok()
+    expect(pool.totalCount).to.eql(1)
+    expect(pool.idleCount).to.eql(0)
+
+    // try to return it to the pool - this removes it because its broken
+    client.release()
+    expect(pool.totalCount).to.eql(0)
+    expect(pool.idleCount).to.eql(0)
+
+    // make sure pool still works
+    const { rows } = await pool.query('SELECT NOW()')
+    expect(rows).to.have.length(1)
+    await pool.end()
+  })
+
+  it('removes a client which is ending', async () => {
+    // make a pool w/ only 1 client
+    const pool = new Pool({ max: 1 })
+    expect(pool.totalCount).to.eql(0)
+    const client = await pool.connect()
+    expect(pool.totalCount).to.eql(1)
+    expect(pool.idleCount).to.eql(0)
+    // end the client gracefully (but you shouldn't do this with pooled clients)
+    client.end()
+
+    // try to return it to the bool
+    client.release()
+    expect(pool.totalCount).to.eql(0)
+    expect(pool.idleCount).to.eql(0)
+
+    // make sure pool still works
+    const { rows } = await pool.query('SELECT NOW()')
+    expect(rows).to.have.length(1)
+    await pool.end()
+  })
+})

--- a/packages/pg-pool/test/releasing-clients.js
+++ b/packages/pg-pool/test/releasing-clients.js
@@ -41,7 +41,7 @@ describe('releasing clients', () => {
     // end the client gracefully (but you shouldn't do this with pooled clients)
     client.end()
 
-    // try to return it to the bool
+    // try to return it to the pool
     client.release()
     expect(pool.totalCount).to.eql(0)
     expect(pool.idleCount).to.eql(0)


### PR DESCRIPTION
This is the exact same as #2081 except it targets master, so this closes #2081 since this is not a backwards incompatible change: the old behavior was simply to put your pool into an unusable or unknown state and eventually perhaps crash your app sometime in the future when you go to use the broken client later which is...never what you want.