### PR TITLE
Add ability to cancel active query

### DIFF
--- a/packages/pg/lib/native/client.js
+++ b/packages/pg/lib/native/client.js
@@ -286,6 +286,12 @@ Client.prototype.cancel = function (query) {
   }
 }
 
+Client.prototype.cancelActiveQuery = function () {
+  return new Promise((resolve, reject) => {
+    this.native.cancel((err) => err ? reject(err) : resolve())
+  })
+}
+
 Client.prototype.setTypeParser = function (oid, format, parseFn) {
   return this._types.setTypeParser(oid, format, parseFn)
 }

--- a/packages/pg/test/integration/client/cancel-tests.js
+++ b/packages/pg/test/integration/client/cancel-tests.js
@@ -1,0 +1,25 @@
+"use strict"
+var helper = require('./../test-helper')
+var assert = require('assert')
+
+const suite = new helper.Suite()
+
+suite.testAsync('All queries should return a result array', async () => {
+  const pool = new helper.pg.Pool()
+  const client = await pool.connect()
+  const cancledPromise = client.query('SELECT pg_sleep(100000)')
+    .then(() => {
+      throw new Error('this should not resolve because query is cancled')
+    })
+    .catch(err => {
+      return err
+    })
+  await client.cancelActiveQuery()
+  const err = await cancledPromise
+  assert(err instanceof Error)
+  // make sure client is still usable
+  const { rows } = await client.query('SELECT 1 as "foo"')
+  assert.strictEqual(rows.length, 1)
+  assert.deepStrictEqual(rows[0], { foo: 1 })
+  await client.end()
+})


### PR DESCRIPTION
This is a proof of concept to cancel active executing query on a client.  It behaves the same way with native bindings and pure JS in that it opens a new connection, bypasses all startup messaging, and dispatches the cancel call [as described here](https://www.postgresql.org/docs/9.3/protocol-flow.html#AEN100004).  Whether the backend is able to cancel the query or not it will terminate the connection which requested cancelation w/o any other messages.  