### PR TITLE
Remove double-send of ssl request packet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ package-lock.json
 dist
 .DS_Store
 .vscode/
+manually-test-on-heroku.js

--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -115,17 +115,7 @@ Connection.prototype.connect = function (port, host) {
     }
     self.stream = tls.connect(options)
     self.stream.on('error', reportStreamError)
-
-    // send SSLRequest packet
-    const buff = Buffer.alloc(8)
-    buff.writeUInt32BE(8)
-    buff.writeUInt32BE(80877103, 4)
-    if (self.stream.writable) {
-      self.stream.write(buff)
-    }
-
     self.attachListeners(self.stream)
-
     self.emit('sslconnect')
   })
 }

--- a/packages/pg/test/integration/gh-issues/2085-tests.js
+++ b/packages/pg/test/integration/gh-issues/2085-tests.js
@@ -1,0 +1,15 @@
+
+
+"use strict"
+var helper = require('./../test-helper')
+var assert = require('assert')
+
+const suite = new helper.Suite()
+
+suite.testAsync('it should connect over ssl', async () => {
+  const client = new helper.pg.Client({ ssl: 'require '})
+  await client.connect()
+  const { rows } = await client.query('SELECT NOW()')
+  assert.strictEqual(rows.length, 1)
+  await client.end()
+})

--- a/packages/pg/test/integration/gh-issues/2085-tests.js
+++ b/packages/pg/test/integration/gh-issues/2085-tests.js
@@ -7,7 +7,7 @@ var assert = require('assert')
 const suite = new helper.Suite()
 
 suite.testAsync('it should connect over ssl', async () => {
-  const client = new helper.pg.Client({ ssl: 'require '})
+  const client = new helper.pg.Client({ ssl: 'require'})
   await client.connect()
   const { rows } = await client.query('SELECT NOW()')
   assert.strictEqual(rows.length, 1)


### PR DESCRIPTION
I missed the fact that we are already sending this.  Since I don't have good test coverage for ssl [which I am planning on fixing next](https://github.com/brianc/node-postgres/issues/2009) this got missed.

I'm forcing an SSL test on travis.  This will break for me locally as I don't have SSL enabled on my local test DB. Something I will also remedy.

This fixes #2085