### PR TITLE
Little typo fix, and add GitHub Sponsors

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,4 +1,4 @@
-node-postgres is made possible by the helpful contributors from the community well as the following generous supporters on [Patreon](https://www.patreon.com/node_postgres).
+node-postgres is made possible by the helpful contributors from the community as well as the following generous supporters on [GitHub Sponsors](https://github.com/sponsors/brianc) and [Patreon](https://www.patreon.com/node_postgres).
 
 # Leaders
 


### PR DESCRIPTION
Since I believe GitHub Sponsors is your preferred way to donate now, maybe you want to totally get rid of the mention of Patreon, or mention that GitHub Sponsors is preferred?