### PR TITLE
Implement handleEmptyQuery for pg-query-stream.

### DIFF
--- a/packages/pg-query-stream/index.js
+++ b/packages/pg-query-stream/index.js
@@ -15,6 +15,7 @@ class PgQueryStream extends Readable {
     this.handleCommandComplete = this.cursor.handleCommandComplete.bind(this.cursor)
     this.handleReadyForQuery = this.cursor.handleReadyForQuery.bind(this.cursor)
     this.handleError = this.cursor.handleError.bind(this.cursor)
+    this.handleEmptyQuery = this.cursor.handleEmptyQuery.bind(this.cursor)
   }
 
   submit(connection) {

--- a/packages/pg-query-stream/test/empty-query.js
+++ b/packages/pg-query-stream/test/empty-query.js
@@ -1,0 +1,20 @@
+const assert = require('assert')
+const helper = require('./helper')
+const QueryStream = require('../')
+
+helper('empty-query', function (client) {
+  it('handles empty query', function(done) {
+    const stream = new QueryStream('-- this is a comment', [])
+    const query = client.query(stream)
+    query.on('end', function () {
+      // nothing should happen for empty query
+      done();
+    }).on('data', function () {
+      // noop to kick off reading
+    })
+  })
+
+  it('continues to function after stream', function (done) {
+    client.query('SELECT NOW()', done)
+  })
+})


### PR DESCRIPTION
`handleEmptyQuery()` wasn't implemented for pg-query-stream.