### PR TITLE
Call callback when end called on unconnected client

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -563,10 +563,10 @@ Client.prototype.end = function (cb) {
   }
 
   if (cb) {
-    this.connection.stream.once('close', cb)
+    this.connection.once('end', cb)
   } else {
     return new this._Promise((resolve) => {
-      this.connection.stream.once('close', resolve)
+      this.connection.once('end', resolve)
     })
   }
 }

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -546,7 +546,7 @@ Client.prototype.end = function (cb) {
   this._ending = true
 
   // if we have never connected, then end is a noop, callback immediately
-  if (this.connection.stream.pending && !this.connection.stream.connecting) {
+  if (this.connection.stream.readyState === 'closed') {
     if (cb) {
       cb()
     } else {

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -550,7 +550,7 @@ Client.prototype.end = function (cb) {
     if (cb) {
       cb()
     } else {
-      return Promise.resolve()
+      return this._Promise.resolve()
     }
   }
 

--- a/packages/pg/test/integration/gh-issues/2108-tests.js
+++ b/packages/pg/test/integration/gh-issues/2108-tests.js
@@ -1,0 +1,13 @@
+"use strict"
+var helper = require('./../test-helper')
+const suite = new helper.Suite()
+
+suite.test('Closing an unconnected client calls callback', (done) => {
+  const client = new helper.pg.Client()
+  client.end(done)
+})
+
+suite.testAsync('Closing an unconnected client resolves promise', () => {
+  const client = new helper.pg.Client()
+  return client.end()
+})


### PR DESCRIPTION
Closes #2108

Previously the callback would never fire if one didn't first connect the client.  This fixes the issue & brings the behavior in line w/ the native client.