### PR TITLE
Enable old commented out ssl test, add test for self-signed cert failure

### DIFF
--- a/packages/pg/test/integration/client/ssl-tests.js
+++ b/packages/pg/test/integration/client/ssl-tests.js
@@ -1,15 +1,28 @@
 'use strict'
-var pg = require(__dirname + '/../../../lib')
-var config = require(__dirname + '/test-helper').config
-test('can connect with ssl', function () {
-  return false
-  config.ssl = {
-    rejectUnauthorized: false
+const { pg, Suite } = require('./test-helper')
+const assert = require('assert')
+
+const suite = new Suite()
+
+suite.testAsync('it can connect w/ ssl', async () => {
+  const ssl = {
+    rejectUnauthorized: false,
   }
-  pg.connect(config, assert.success(function (client) {
-    return false
-    client.query('SELECT NOW()', assert.success(function () {
-      pg.end()
-    }))
-  }))
+
+  const client = new pg.Client({ ssl })
+  await client.connect()
+  assert.strictEqual(client.connection.stream.encrypted, true)
+  await client.end()
+})
+
+suite.testAsync('it rejects on self-signed cert', async () => {
+  const ssl = true
+  const client = new pg.Client({ ssl })
+  try {
+    await client.connect()
+  } catch (e) {
+    assert(e.message.includes('self signed'))
+    return
+  }
+  throw new Error('connection should have failed with self-signed cert error')
 })


### PR DESCRIPTION
Just add a few more tests.  A bit redundant, but better than dead code.