### PR TITLE
Attempt to handle a stream being silently killed in the background

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -121,10 +121,12 @@ class Pool extends EventEmitter {
 
       // TODO(bmc): we need a better state represetation on the client itself
       // to indicate if it's connecting, idle, running a query, closed, etc...
-      // but for now we can look at it's stream.
+      // as right now this hacky fix will only work for the JS client
+      // since the native client doesn't _have_ a connection property
+
       // remove this client, it's died in the background - this can happen
       // in aws lambdas - they go idle and the streams are closed without an error
-      if (client.connection.stream.readyState !== 'open') {
+      if (client.connection && client.connection.stream.readyState !== 'open') {
         this._remove(client)
       } else {
         const idleListener = idleItem.idleListener

--- a/packages/pg-pool/test/background-socket-terminiation.js
+++ b/packages/pg-pool/test/background-socket-terminiation.js
@@ -1,0 +1,31 @@
+'use strict'
+const net = require('net')
+const co = require('co')
+const expect = require('expect.js')
+
+const describe = require('mocha').describe
+const it = require('mocha').it
+
+const Pool = require('../')
+
+describe('a socket disconnecting in the background', () => {
+  it('should leave the pool in a usable state', async () => {
+    const pool = new Pool({ max: 1 })
+    // just run any arbitrary query
+    const client = await pool.connect()
+    await client.query('SELECT NOW()')
+    // return the client
+    client.release()
+
+    // now kill the socket in the background
+    client.connection.stream.end()
+
+    // now try to query again, it should work
+    await pool.query('SELECT NOW()')
+    await pool.query('SELECT NOW()')
+    await pool.query('SELECT NOW()')
+    await pool.query('SELECT NOW()')
+
+    await pool.end()
+  })
+})


### PR DESCRIPTION
I _think_ this will fix the issue outlined in #2112 

I just pounded out this initial version pretty quickly as I'm not 100% sure it'll fix the issue yet....as I'm not sure my test is _exactly_ replicating what's going on in lambda.  In the test I'm "cleanly" severing the connected stream to the backend which doesn't emit an error anywhere so the client/pool still thinks its okay.  

Could someone from #2112 try applying this patch to their code in lambda and see if it fixes the issue? If so I'll polish this up, write a couple more tests, and get a patch version fix out.