### PR TITLE
Split message properties from error and notice objects

### DIFF
--- a/packages/pg-packet-stream/src/messages.ts
+++ b/packages/pg-packet-stream/src/messages.ts
@@ -25,7 +25,7 @@ export const enum MessageName {
   authenticationSASL = 'authenticationSASL',
   authenticationSASLContinue = 'authenticationSASLContinue',
   authenticationSASLFinal = 'authenticationSASLFinal',
-  error = 'error',
+  errorMessage = 'errorMessage',
   notice = 'notice',
 }
 
@@ -74,7 +74,8 @@ export const copyDone: BackendMessage = {
   length: 4,
 }
 
-export class DatabaseError extends Error {
+interface ErrorFields {
+  public message: string | undefined;
   public severity: string | undefined;
   public code: string | undefined;
   public detail: string | undefined;
@@ -91,8 +92,26 @@ export class DatabaseError extends Error {
   public file: string | undefined;
   public line: string | undefined;
   public routine: string | undefined;
-  constructor(message: string, public readonly length: number, public readonly name: MessageName) {
-    super(message)
+}
+
+export class DatabaseError extends Error {
+}
+
+export interface DatabaseError extends Error, ErrorFields {
+}
+
+export class Notice extends ErrorFields {
+}
+
+export class ErrorMessage {
+  public readonly name = MessageName.errorMessage;
+  constructor(public readonly length: number, public readonly error: DatabaseError) {
+  }
+}
+
+export class NoticeMessage {
+  public readonly name = MessageName.notice;
+  constructor(public readonly length: number, public readonly notice: Notice) {
   }
 }
 

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -205,6 +205,10 @@ Client.prototype._connect = function (callback) {
     this.emit('error', err)
   }
 
+  const connectingErrorMessageHandler = (msg) => {
+    connectingErrorHandler(msg.error)
+  }
+
   const connectedErrorHandler = (err) => {
     this._queryable = false
     this._errorAllQueries(err)
@@ -215,16 +219,16 @@ Client.prototype._connect = function (callback) {
     const activeQuery = this.activeQuery
 
     if (!activeQuery) {
-      connectedErrorHandler(msg)
+      connectedErrorHandler(msg.error)
       return
     }
 
     this.activeQuery = null
-    activeQuery.handleError(msg, con)
+    activeQuery.handleError(msg.error, con)
   }
 
   con.on('error', connectingErrorHandler)
-  con.on('errorMessage', connectingErrorHandler)
+  con.on('errorMessage', connectingErrorMessageHandler)
 
   // hook up query handling events to connection
   // after the connection initially becomes ready for queries
@@ -233,7 +237,7 @@ Client.prototype._connect = function (callback) {
     self._connected = true
     self._attachListeners(con)
     con.removeListener('error', connectingErrorHandler)
-    con.removeListener('errorMessage', connectingErrorHandler)
+    con.removeListener('errorMessage', connectingErrorMessageHandler)
     con.on('error', connectedErrorHandler)
     con.on('errorMessage', connectedErrorMessageHandler)
     clearTimeout(connectionTimeoutHandle)
@@ -288,7 +292,7 @@ Client.prototype._connect = function (callback) {
   })
 
   con.on('notice', function (msg) {
-    self.emit('notice', msg)
+    self.emit('notice', msg.notice)
   })
 }
 

--- a/packages/pg/lib/connection-fast.js
+++ b/packages/pg/lib/connection-fast.js
@@ -113,11 +113,10 @@ Connection.prototype.attachListeners = function (stream) {
   const packetStream = new PacketStream.PgPacketStream({ mode })
   this.stream.pipe(packetStream)
   packetStream.on('data', (msg) => {
-    var eventName = msg.name === 'error' ? 'errorMessage' : msg.name
     if (self._emitMessage) {
       self.emit('message', msg)
     }
-    self.emit(eventName, msg)
+    self.emit(msg.name, msg)
   })
   stream.on('end', function () {
     self.emit('end')

--- a/packages/pg/test/integration/client/notice-tests.js
+++ b/packages/pg/test/integration/client/notice-tests.js
@@ -57,7 +57,6 @@ $$;
     assert.ok(notice != null)
     // notice messages should not be error instances
     assert(notice instanceof Error === false)
-    assert.strictEqual(notice.name, 'notice')
     assert.strictEqual(notice.message, 'hello, world!')
     assert.strictEqual(notice.detail, 'this is a test')
     assert.strictEqual(notice.code, '23505')


### PR DESCRIPTION
This avoids exposing an unusual `name` on errors and the oddly isolated `length` on both objects and removes the special handling of the “error” message name.

The TypeScript probably still needs some work.