### PR TITLE
add finish function

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -77,6 +77,7 @@ class Pool extends EventEmitter {
     this._idle = []
     this._pendingQueue = []
     this._endCallback = undefined
+    this.finishing = false
     this.ending = false
     this.ended = false
   }
@@ -91,7 +92,7 @@ class Pool extends EventEmitter {
       this.log('pulse queue ended')
       return
     }
-    if (this.ending) {
+    if (this.ending && (!this.finishing || !this._pendingQueue.length)) {
       this.log('pulse queue on ending')
       if (this._idle.length) {
         this._idle.slice().map(item => {
@@ -368,6 +369,11 @@ class Pool extends EventEmitter {
     this._endCallback = promised.callback
     this._pulseQueue()
     return promised.result
+  }
+
+  finish (cb) {
+    this.finishing = true
+    return this.end(cb)
   }
 
   get waitingCount () {


### PR DESCRIPTION
similar to `end`, `finish` closes the connections and pool but only after the queue has processed all currently pending queries, instead of cutting out pending queries like `end`