### PR TITLE
Refactor pg-pool to avoid potential memory leak

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -252,16 +252,7 @@ class Pool extends EventEmitter {
 
     this.emit('acquire', client)
 
-    let released = false
-
-    client.release = (err) => {
-      if (released) {
-        throwOnDoubleRelease()
-      }
-
-      released = true
-      this._release(client, idleListener, err)
-    }
+    client.release = this._releaseOnce(client, idleListener)
 
     client.removeListener('error', idleListener)
 
@@ -284,6 +275,20 @@ class Pool extends EventEmitter {
       } else {
         client.release()
       }
+    }
+  }
+
+  // returns a function that wraps _release and throws if called more than once
+  _releaseOnce(client, idleListener) {
+    let released = false
+
+    return (err) => {
+      if (released) {
+        throwOnDoubleRelease()
+      }
+
+      released = true
+      this._release(client, idleListener, err)
     }
   }
 


### PR DESCRIPTION
When a connection is allocated from pg-pool, `_acquireClient` creates a lambda function that wraps `Pool._release`. The way this is currently implemented leads to potential memory leak since the lambda's closure captures a bigger scope than necessay and retains a reference to `pendingItem` which in turn references a Promise.

Normally it is not a problem that a Promise has a longer lifetime than necessary, but when used together with libraries such as [cls-hooked](https://www.npmjs.com/package/cls-hooked) that rely on async_hooks to generate a Continuation Local Storage where you can store a database connection you get a memory leak:
* The Promise is referenced by the Client
* The Client is referenced by the CLS
* CLS is waiting for the Promise to be garbage collected before releasing the Client

(I am not actually using cls-hooked but an in-house-developed package that is very similar.)

As a user of these libraries I can make sure to manually remove the Client object from CLS when it is no longer required, but I thought it would be a good idea to also refactor pg-pool.

DevTools pointed me to [line 245 of pg-pool/index.js](https://github.com/brianc/node-postgres/blob/pg-pool%402.0.9/packages/pg-pool/index.js#L245):
![DevTools view of the memory leak](https://user-images.githubusercontent.com/643284/79326233-cafdf000-7f12-11ea-9f84-f15d34215252.png)

This PR comes without tests. I cannot think of a way to test this without `node --expose-gc` and even then I think such a test would be flaky.