### PR TITLE
Replace uses of private/undocumented `readyState` API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ node_js:
   # if 13.8 still has this problem when it comes down I'll talk to the node team about the change
   # in the mean time...peg to 13.6 
   - 13.6
+  - 14
 
 addons:
   postgresql: "10"

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -566,7 +566,7 @@ Client.prototype.end = function (cb) {
   this._ending = true
 
   // if we have never connected, then end is a noop, callback immediately
-  if (this.connection.stream.readyState === 'closed') {
+  if (!this.connection._connecting) {
     if (cb) {
       cb()
     } else {

--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -50,13 +50,10 @@ util.inherits(Connection, EventEmitter)
 Connection.prototype.connect = function (port, host) {
   var self = this
 
-  if (this.stream.readyState === 'closed') {
-    this.stream.connect(port, host)
-  } else if (this.stream.readyState === 'open') {
-    this.emit('connect')
-  }
+  this._connecting = true
+  this.stream.connect(port, host)
 
-  this.stream.on('connect', function () {
+  this.stream.once('connect', function () {
     if (self._keepAlive) {
       self.stream.setKeepAlive(true, self._keepAliveInitialDelayMillis)
     }
@@ -316,7 +313,7 @@ Connection.prototype.end = function () {
   // 0x58 = 'X'
   this.writer.add(emptyBuffer)
   this._ending = true
-  if (!this.stream.writable) {
+  if (!this._connecting || !this.stream.writable) {
     this.stream.end()
     return
   }

--- a/packages/pg/test/unit/client/stream-and-query-error-interaction-tests.js
+++ b/packages/pg/test/unit/client/stream-and-query-error-interaction-tests.js
@@ -5,6 +5,9 @@ var Client = require(__dirname + '/../../../lib/client')
 
 test('emits end when not in query', function () {
   var stream = new (require('events').EventEmitter)()
+  stream.connect = function () {
+    // NOOP
+  }
   stream.write = function () {
     // NOOP
   }

--- a/packages/pg/test/unit/connection/inbound-parser-tests.js
+++ b/packages/pg/test/unit/connection/inbound-parser-tests.js
@@ -399,7 +399,6 @@ test('Connection', function () {
 test('split buffer, single message parsing', function () {
   var fullBuffer = buffers.dataRow([null, 'bang', 'zug zug', null, '!'])
   var stream = new MemoryStream()
-  stream.readyState = 'open'
   var client = new Connection({
     stream: stream,
   })

--- a/packages/pg/test/unit/connection/outbound-sending-tests.js
+++ b/packages/pg/test/unit/connection/outbound-sending-tests.js
@@ -5,6 +5,7 @@ var stream = new MemoryStream()
 var con = new Connection({
   stream: stream,
 })
+con._connecting = true
 
 assert.received = function (stream, buffer) {
   assert.lengthIs(stream.packets, 1)

--- a/packages/pg/test/unit/connection/startup-tests.js
+++ b/packages/pg/test/unit/connection/startup-tests.js
@@ -7,10 +7,9 @@ test('connection can take existing stream', function () {
   assert.equal(con.stream, stream)
 })
 
-test('using closed stream', function () {
+test('using any stream', function () {
   var makeStream = function () {
     var stream = new MemoryStream()
-    stream.readyState = 'closed'
     stream.connect = function (port, host) {
       this.connectCalled = true
       this.port = port
@@ -63,22 +62,5 @@ test('using closed stream', function () {
     setTimeout(function () {
       assert.equal(res, true)
     })
-  })
-})
-
-test('using opened stream', function () {
-  var stream = new MemoryStream()
-  stream.readyState = 'open'
-  stream.connect = function () {
-    assert.ok(false, 'Should not call open')
-  }
-  var con = new Connection({ stream: stream })
-  test('does not call open', function () {
-    var hit = false
-    con.once('connect', function () {
-      hit = true
-    })
-    con.connect()
-    assert.ok(hit)
   })
 })

--- a/packages/pg/test/unit/test-helper.js
+++ b/packages/pg/test/unit/test-helper.js
@@ -13,6 +13,10 @@ helper.sys.inherits(MemoryStream, EventEmitter)
 
 var p = MemoryStream.prototype
 
+p.connect = function () {
+  // NOOP
+}
+
 p.write = function (packet, cb) {
   this.packets.push(packet)
   if (cb) {
@@ -30,7 +34,6 @@ p.writable = true
 
 const createClient = function () {
   var stream = new MemoryStream()
-  stream.readyState = 'open'
   var client = new Client({
     connection: new Connection({ stream: stream }),
   })


### PR DESCRIPTION
The `readyState` of a newly-created `net.Socket` changed from `'closed'` to `'open'` in Node 14.0.0, so this makes the JS driver work on Node 14.

`Connection` now always calls `connect` on its `stream` when `connect` is called on it.

#2170