### PR TITLE
Fix repository field in package.json files after packages were moved into monorepo

### DIFF
--- a/packages/pg-connection-string/package.json
+++ b/packages/pg-connection-string/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iceddev/pg-connection-string"
+    "url": "git://github.com/brianc/node-postgres.git"
   },
   "keywords": [
     "pg",

--- a/packages/pg-cursor/package.json
+++ b/packages/pg-cursor/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/brianc/node-pg-cursor.git"
+    "url": "git://github.com/brianc/node-postgres.git"
   },
   "author": "Brian M. Carlson",
   "license": "MIT",

--- a/packages/pg-pool/package.json
+++ b/packages/pg-pool/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/brianc/node-pg-pool.git"
+    "url": "git://github.com/brianc/node-postgres.git"
   },
   "keywords": [
     "pg",


### PR DESCRIPTION
Noticed this because of an automated PR for updating pg-connection-string: 2.2.0 → 2.2.1 linked me to the wrong repository.