### PR TITLE
Add `PGSSLMODE=no-verify` support to opt-out of rejecting self-signed certs

### DIFF
--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -34,6 +34,8 @@ var useSsl = function () {
     case 'verify-ca':
     case 'verify-full':
       return true
+    case 'no-verify':
+      return { rejectUnauthorized: false }
   }
   return defaults.ssl
 }


### PR DESCRIPTION
Upgrading to `pg@8` is currently quite hard if relying on environment variables to set the SSL mode. For example, on Heroku, SSL is required, but the certs are not available. A good way to set this up traditionally is to set `PGSSLMODE=require` for app dynos, and `PGSSLMODE=false` (or not defined) for in-dyno CI (local ephemeral test databases).

However, in `pg@8` the `{ rejectUnauthorized: false }` option needs to be used, so this means consumers need to update all code to be aware of the environment it's running in. This also extends to code from third parties (e.g. migration frameworks like `db-migrate`), which would need to internally set this option to continue working. All of this means it's quite hard to upgrade.

A simple solution is to to support implementing a `PGSSLMODE=no-verify` option as suggested in this comment: https://github.com/brianc/node-postgres/issues/2009#issuecomment-615492069. This PR does exactly that! 👍 