### PR TITLE
Use monorepo connection string

### DIFF
--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "buffer-writer": "2.0.0",
     "packet-reader": "1.0.0",
-    "pg-connection-string": "0.1.3",
+    "pg-connection-string": "^2.2.1",
     "pg-pool": "^3.1.1",
     "pg-protocol": "^1.2.2",
     "pg-types": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4596,11 +4596,6 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-pg-connection-string@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
-  integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
-
 pg-copy-streams@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/pg-copy-streams/-/pg-copy-streams-0.3.0.tgz#a4fbc2a3b788d4e9da6f77ceb35422d8d7043b7f"


### PR DESCRIPTION
This points main `pg` package at the internal `pg-connection-string` package.  Though `pg-connection-string` had a major semver bump, I verified w/ the author and by auditing the whole diff between versions there aren't actually any breaking changes in there...the author just did a semver bump when the repo ownership changed hands so its fine to release this as a non-breaking change in `pg` core.