### PR TITLE
Add no-verify ssl option

### DIFF
--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -25,9 +25,11 @@ var val = function (key, config, envVar) {
   return config[key] || envVar || defaults[key]
 }
 
-var useSsl = function (modeFromConfig) {
+var normalizeSSLConfig = function (modeFromConfig) {
   // if the ssl parameter passed to config is not a string, just return it
   // directly (it will be passed directly to tls.connect)
+  // this way you can pass all the ssl params in via constructor:
+  // new Client({ ssl: { minDHSize: 1024 } }) etc
   if (modeFromConfig !== undefined && typeof modeFromConfig !== 'string') {
     return modeFromConfig
   }
@@ -41,6 +43,11 @@ var useSsl = function (modeFromConfig) {
     case 'verify-ca':
     case 'verify-full':
       return true
+    // no-verify is not standard to libpq but allows specifying
+    // you require ssl but want to bypass server certificate validation.
+    // this is a very common way to connect in heroku so we support it
+    // vai both environment variables (PGSSLMODE=no-verify) as well
+    // as in connection string params ?ssl=no-verify
     case 'no-verify':
       return { rejectUnauthorized: false }
   }
@@ -77,8 +84,8 @@ var ConnectionParameters = function (config) {
   })
 
   this.binary = val('binary', config)
-  // this.ssl = typeof config.ssl === 'undefined' ? useSsl() : config.ssl
-  this.ssl = useSsl(config.ssl)
+
+  this.ssl = normalizeSSLConfig(config.ssl)
   this.client_encoding = val('client_encoding', config)
   this.replication = val('replication', config)
   // a domain socket begins with '/'

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -25,8 +25,15 @@ var val = function (key, config, envVar) {
   return config[key] || envVar || defaults[key]
 }
 
-var useSsl = function () {
-  switch (process.env.PGSSLMODE) {
+var useSsl = function (modeFromConfig) {
+  // if the ssl parameter passed to config is not a string, just return it
+  // directly (it will be passed directly to tls.connect)
+  if (modeFromConfig !== undefined && typeof modeFromConfig !== 'string') {
+    return modeFromConfig
+  }
+  const mode = modeFromConfig || process.env.PGSSLMODE
+
+  switch (mode) {
     case 'disable':
       return false
     case 'prefer':
@@ -70,7 +77,8 @@ var ConnectionParameters = function (config) {
   })
 
   this.binary = val('binary', config)
-  this.ssl = typeof config.ssl === 'undefined' ? useSsl() : config.ssl
+  // this.ssl = typeof config.ssl === 'undefined' ? useSsl() : config.ssl
+  this.ssl = useSsl(config.ssl)
   this.client_encoding = val('client_encoding', config)
   this.replication = val('replication', config)
   // a domain socket begins with '/'

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -25,17 +25,8 @@ var val = function (key, config, envVar) {
   return config[key] || envVar || defaults[key]
 }
 
-var normalizeSSLConfig = function (modeFromConfig) {
-  // if the ssl parameter passed to config is not a string, just return it
-  // directly (it will be passed directly to tls.connect)
-  // this way you can pass all the ssl params in via constructor:
-  // new Client({ ssl: { minDHSize: 1024 } }) etc
-  if (modeFromConfig !== undefined && typeof modeFromConfig !== 'string') {
-    return modeFromConfig
-  }
-  const mode = modeFromConfig || process.env.PGSSLMODE
-
-  switch (mode) {
+var readSSLConfigFromEnvironment = function () {
+  switch (process.env.PGSSLMODE) {
     case 'disable':
       return false
     case 'prefer':
@@ -43,11 +34,6 @@ var normalizeSSLConfig = function (modeFromConfig) {
     case 'verify-ca':
     case 'verify-full':
       return true
-    // no-verify is not standard to libpq but allows specifying
-    // you require ssl but want to bypass server certificate validation.
-    // this is a very common way to connect in heroku so we support it
-    // vai both environment variables (PGSSLMODE=no-verify) as well
-    // as in connection string params ?ssl=no-verify
     case 'no-verify':
       return { rejectUnauthorized: false }
   }
@@ -85,7 +71,13 @@ var ConnectionParameters = function (config) {
 
   this.binary = val('binary', config)
 
-  this.ssl = normalizeSSLConfig(config.ssl)
+  this.ssl = typeof config.ssl === 'undefined' ? readSSLConfigFromEnvironment() : config.ssl
+
+  // support passing in ssl=no-verify via connection string
+  if (this.ssl === 'no-verify') {
+    this.ssl = { rejectUnauthorized: false }
+  }
+
   this.client_encoding = val('client_encoding', config)
   this.replication = val('replication', config)
   // a domain socket begins with '/'

--- a/packages/pg/test/unit/client/configuration-tests.js
+++ b/packages/pg/test/unit/client/configuration-tests.js
@@ -44,11 +44,6 @@ test('client settings', function () {
     assert.equal(client.ssl, true)
   })
 
-  test('ssl no-verify', function () {
-    var client = new Client({ ssl: 'no-verify' })
-    assert.deepStrictEqual(client.ssl, { rejectUnauthorized: false })
-  })
-
   test('custom ssl force off', function () {
     var old = process.env.PGSSLMODE
     process.env.PGSSLMODE = 'prefer'

--- a/packages/pg/test/unit/client/configuration-tests.js
+++ b/packages/pg/test/unit/client/configuration-tests.js
@@ -1,5 +1,6 @@
 'use strict'
 require(__dirname + '/test-helper')
+var assert = require('assert')
 
 var pguser = process.env['PGUSER'] || process.env.USER
 var pgdatabase = process.env['PGDATABASE'] || process.env.USER
@@ -41,6 +42,11 @@ test('client settings', function () {
     process.env.PGSSLMODE = old
 
     assert.equal(client.ssl, true)
+  })
+
+  test('ssl no-verify', function () {
+    var client = new Client({ ssl: 'no-verify' })
+    assert.deepStrictEqual(client.ssl, { rejectUnauthorized: false })
   })
 
   test('custom ssl force off', function () {


### PR DESCRIPTION
This adds no-verify ssl option to

1) connection string parsing.  You can pass `?ssl=no-verify` on the pg connection string & it will properly use `{ rejectUnauthorized: false }` in the ssl config passed to `tls.connect`.  Connecting with connection strings is common in heroku, and without this patch the connection info cannot be entirely contained within the connection string for heroku environments.

2) environment variables.  added support for `PGSSLMODE=no-verify`.

3) manually passing `new Client({ ssl: 'no-verify' })`.  The 3rd option isn't very common, but it _will_ technically work.

This is a backwards compatible, semver minor change.

Thanks to @benhjames for takin' the lead on this one 😄 