### PR TITLE
Add some SCRAM tests and enable them on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     # Run tests/paths that require password authentication
     - node_js: lts/erbium
       env:
-        - CC=clang CXX=clang++ npm_config_clang=1 PGUSER=postgres PGDATABASE=postgres PGPASSWORD=test-password
+        - CC=clang CXX=clang++ npm_config_clang=1 PGUSER=postgres PGDATABASE=postgres PGPASSWORD=test-password SCRAM_TEST_PGUSER=scram_test SCRAM_TEST_PGPASSWORD=test4scram
       before_script: |
         sudo -u postgres sed -i \
           -e '/^local/ s/trust$/peer/' \
@@ -36,6 +36,9 @@ matrix:
         sudo -u postgres psql -c "ALTER ROLE postgres PASSWORD 'test-password'; SELECT pg_reload_conf()"
         yarn build
         node packages/pg/script/create-test-tables.js postgresql:///
+        sudo -u postgres -- psql \
+          -c "SET password_encryption = 'scram-sha-256'" \
+          -c "CREATE ROLE scram_test login password 'test4scram'"
 
     - node_js: lts/carbon
       addons:

--- a/packages/pg/test/integration/client/sasl-scram-tests.js
+++ b/packages/pg/test/integration/client/sasl-scram-tests.js
@@ -1,41 +1,75 @@
 'use strict'
-var helper = require(__dirname + '/../test-helper')
-var pg = helper.pg
+const helper = require('./../test-helper')
+const pg = helper.pg
+const suite = new helper.Suite()
+const { native } = helper.args
 
-var suite = new helper.Suite()
+/**
+ * This test only executes if the env variables SCRAM_TEST_PGUSER and
+ * SCRAM_TEST_PGPASSWORD are defined. You can override additional values
+ * for the host, port and database with other SCRAM_TEST_ prefixed vars.
+ * If the variables are not defined the test will be skipped.
+ *
+ * SQL to create test role:
+ *
+ *     SET password_encryption = 'scram-sha-256';
+ *     CREATE ROLE scram_test login password 'test4scram';
+ *
+ * Add the following entries to pg_hba.conf:
+ *
+ *     host   all   scram_test   ::1/128    scram-sha-256
+ *     host   all    scram_test   0.0.0.0/0   scram-sha-256
+ *
+ * Then run this file with after exporting:
+ *
+ *     SCRAM_TEST_PGUSER=scram_test
+ *     SCRAM_TEST_PGPASSWORD=test4scram
+ */
 
-/*
-SQL to create test role:
+// Base config for SCRAM tests
+const config = {
+  user: process.env.SCRAM_TEST_PGUSER,
+  password: process.env.SCRAM_TEST_PGPASSWORD,
+  host: process.env.SCRAM_TEST_PGHOST, // optional
+  port: process.env.SCRAM_TEST_PGPORT, // optional
+  database: process.env.SCRAM_TEST_PGDATABASE, // optional
+}
 
-set password_encryption = 'scram-sha-256';
-create role npgtest login password 'test';
+if (native) {
+  suite.testAsync('skipping SCRAM tests (on native)', () => {})
+  return
+}
+if (!config.user || !config.password) {
+  suite.testAsync('skipping SCRAM tests (missing env)', () => {})
+  return
+}
 
-pg_hba:
-host    all             npgtest             ::1/128            scram-sha-256
-host    all             npgtest             0.0.0.0/0            scram-sha-256
-
-
-*/
-/*
-suite.test('can connect using sasl/scram', function () {
-	var connectionString = 'pg://npgtest:test@localhost/postgres'
-	const pool = new pg.Pool({ connectionString: connectionString })
-	pool.connect(
-		assert.calls(function (err, client, done) {
-			assert.ifError(err, 'should have connected')
-			done()
-		})
-	)
+suite.testAsync('can connect using sasl/scram', async () => {
+  const client = new pg.Client(config)
+  let usingSasl = false
+  client.connection.once('authenticationSASL', () => {
+    usingSasl = true
+  })
+  await client.connect()
+  assert.ok(usingSasl, 'Should be using SASL for authentication')
+  await client.end()
 })
 
-suite.test('sasl/scram fails when password is wrong', function () {
-	var connectionString = 'pg://npgtest:bad@localhost/postgres'
-	const pool = new pg.Pool({ connectionString: connectionString })
-	pool.connect(
-		assert.calls(function (err, client, done) {
-			assert.ok(err, 'should have a connection error')
-			done()
-		})
-	)
+suite.testAsync('sasl/scram fails when password is wrong', async () => {
+  const client = new pg.Client({
+    ...config,
+    password: config.password + 'append-something-to-make-it-bad',
+  })
+  let usingSasl = false
+  client.connection.once('authenticationSASL', () => {
+    usingSasl = true
+  })
+  await assert.rejects(
+    () => client.connect(),
+    {
+      code: '28P01',
+    },
+    'Error code should be for a password error'
+  )
+  assert.ok(usingSasl, 'Should be using SASL for authentication')
 })
-*/


### PR DESCRIPTION
First commit adds another test helper. Engines is node 8+ so async all the way!

Second commit adds a test for SCRAM auth. It's disabled by default. To run the test export SCRAM_TEST_PGUSER and SCRAM_TEST_PGPASSWORD env vars. The rest of the vars will inherit from the default PG% config.

Third commit enables the SCRAM test in it's own matrix build. Could probably clean this up later to piggy back on an existing combo but for now I didn't want to break anything. Also, to check if we're actually using SCRAM it adds listeners to the underlying connection so test only runs on pure-JS for now.