### PR TITLE
Support options connection parameter

### DIFF
--- a/packages/pg-connection-string/index.d.ts
+++ b/packages/pg-connection-string/index.d.ts
@@ -11,4 +11,5 @@ export interface ConnectionOptions {
 
   application_name?: string
   fallback_application_name?: string
+  options?: string
 }

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -188,10 +188,10 @@ describe('parse', function () {
     subject.fallback_application_name.should.equal('TheAppFallback')
   })
 
-  it('configuration parameter fallback_application_name', function () {
-    var connectionString = 'pg:///?fallback_application_name=TheAppFallback'
+  it('configuration parameter options', function () {
+    var connectionString = 'pg:///?options=-c geqo=off'
     var subject = parse(connectionString)
-    subject.fallback_application_name.should.equal('TheAppFallback')
+    subject.options.should.equal('-c geqo=off')
   })
 
   it('configuration parameter ssl=true', function () {

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -391,6 +391,9 @@ Client.prototype.getStartupConf = function () {
   if (params.idle_in_transaction_session_timeout) {
     data.idle_in_transaction_session_timeout = String(parseInt(params.idle_in_transaction_session_timeout, 10))
   }
+  if (params.options) {
+    data.options = params.options
+  }
 
   return data
 }

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -70,6 +70,7 @@ var ConnectionParameters = function (config) {
   })
 
   this.binary = val('binary', config)
+  this.options = val('options', config)
 
   this.ssl = typeof config.ssl === 'undefined' ? readSSLConfigFromEnvironment() : config.ssl
 
@@ -126,6 +127,7 @@ ConnectionParameters.prototype.getLibpqConnectionString = function (cb) {
   add(params, this, 'application_name')
   add(params, this, 'fallback_application_name')
   add(params, this, 'connect_timeout')
+  add(params, this, 'options')
 
   var ssl = typeof this.ssl === 'object' ? this.ssl : this.ssl ? { sslmode: this.ssl } : {}
   add(params, ssl, 'sslmode')

--- a/packages/pg/lib/defaults.js
+++ b/packages/pg/lib/defaults.js
@@ -53,6 +53,8 @@ module.exports = {
 
   fallback_application_name: undefined,
 
+  options: undefined,
+
   parseInputDatesAsUTC: false,
 
   // max milliseconds any query using this connection will execute for before timing out in error.

--- a/packages/pg/test/unit/connection-parameters/creation-tests.js
+++ b/packages/pg/test/unit/connection-parameters/creation-tests.js
@@ -25,6 +25,7 @@ var compare = function (actual, expected, type) {
   assert.equal(actual.password, expected.password, type + ' password')
   assert.equal(actual.binary, expected.binary, type + ' binary')
   assert.equal(actual.statement_timeout, expected.statement_timeout, type + ' statement_timeout')
+  assert.equal(actual.options, expected.options, type + ' options')
   assert.equal(
     actual.idle_in_transaction_session_timeout,
     expected.idle_in_transaction_session_timeout,
@@ -48,12 +49,14 @@ test('ConnectionParameters initializing from defaults with connectionString set'
     binary: defaults.binary,
     statement_timeout: false,
     idle_in_transaction_session_timeout: false,
+    options: '-c geqo=off',
   }
 
   var original_value = defaults.connectionString
   // Just changing this here doesn't actually work because it's no longer in scope when viewed inside of
   // of ConnectionParameters() so we have to pass in the defaults explicitly to test it
-  defaults.connectionString = 'postgres://brians-are-the-best:mypassword@foo.bar.net:7777/scoobysnacks'
+  defaults.connectionString =
+    'postgres://brians-are-the-best:mypassword@foo.bar.net:7777/scoobysnacks?options=-c geqo=off'
   var subject = new ConnectionParameters(defaults)
   defaults.connectionString = original_value
   compare(subject, config, 'defaults-connectionString')
@@ -73,6 +76,7 @@ test('ConnectionParameters initializing from config', function () {
     },
     statement_timeout: 15000,
     idle_in_transaction_session_timeout: 15000,
+    options: '-c geqo=off',
   }
   var subject = new ConnectionParameters(config)
   compare(subject, config, 'config')


### PR DESCRIPTION
This supports the connection parameter documented here:
https://www.postgresql.org/docs/9.1/libpq-connect.html#LIBPQ-CONNECT-OPTIONS

fixes #2214