### PR TITLE
type(pg-connection-string): fix typings in ConnectionOptions

### DIFF
--- a/packages/pg-connection-string/index.d.ts
+++ b/packages/pg-connection-string/index.d.ts
@@ -7,9 +7,19 @@ export interface ConnectionOptions {
   port?: string | null
   database: string | null | undefined
   client_encoding?: string
-  ssl?: boolean | string
+  ssl?:
+    | string
+    | boolean
+    | {
+        cert: string
+        key: string
+        ca: string
+      }
 
   application_name?: string
   fallback_application_name?: string
   options?: string
+  schema?: string
+
+  [key: string]: any
 }


### PR DESCRIPTION
- The `ssl` option can be either boolean or its own type consisting of cert, key, and ca.
- Because as [the documentation here](https://www.npmjs.com/package/pg-connection-string) says, any other query params should be preserved intact as well as types so I added `[key: string]: any` in `ConnectionOptions`.

Because without this I had to cast the result parsed as any type, or add `{ schema?: string }` in everywhere with such conditions that require `schema`, I think this PR will help those in need.
