### PR TITLE
Fix most SSL negotiation packet tests being ignored

### DIFF
--- a/packages/pg/test/unit/connection/error-tests.js
+++ b/packages/pg/test/unit/connection/error-tests.js
@@ -58,8 +58,7 @@ var SSLNegotiationPacketTests = [
   },
 ]
 
-for (var i = 0; i < SSLNegotiationPacketTests.length; i++) {
-  var tc = SSLNegotiationPacketTests[i]
+for (const tc of SSLNegotiationPacketTests) {
   suite.test(tc.testName, function (done) {
     // our fake postgres server
     var socket


### PR DESCRIPTION
`tc` was only one variable and the tests are asynchronous, so every test was writing 'E'.