### PR TITLE
Fix 'Error: invalid sslmode value: "true"' in native mode

### DIFF
--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -123,7 +123,11 @@ class ConnectionParameters {
     add(params, this, 'connect_timeout')
     add(params, this, 'options')
 
-    var ssl = typeof this.ssl === 'object' ? this.ssl : this.ssl ? { sslmode: this.ssl } : {}
+    var ssl = (typeof this.ssl === 'object')
+      ? this.ssl
+      : ((this.ssl && typeof this.ssl === 'string')
+        ? { sslmode: this.ssl }
+        : {})
     add(params, ssl, 'sslmode')
     add(params, ssl, 'sslca')
     add(params, ssl, 'sslkey')


### PR DESCRIPTION
When using PGSSLMODE env in native mode, an invalid database URL string
is constructed with sslmode=true/false.