### PR TITLE
Security: Don't leak SSL key to logs, by making non-enumerable

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -76,7 +76,6 @@ class Pool extends EventEmitter {
     if (options != null && options.ssl && options.ssl.key) {
       // "hiding" the ssl->key so it doesn't show up in stack traces
       // or if the client is console.logged
-      this.options.ssl.key = options.ssl.key
       Object.defineProperty(this.options.ssl, 'key', {
         enumerable: false,
       })

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -73,6 +73,14 @@ class Pool extends EventEmitter {
         value: options.password,
       })
     }
+    if (options != null && options.ssl && options.ssl.key) {
+      // "hiding" the ssl->key so it doesn't show up in stack traces
+      // or if the client is console.logged
+      this.options.ssl.key = options.ssl.key
+      Object.defineProperty(this.options.ssl, 'key', {
+        enumerable: false,
+      })
+    }
 
     this.options.max = this.options.max || this.options.poolSize || 10
     this.options.maxUses = this.options.maxUses || Infinity

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -57,6 +57,15 @@ class Client extends EventEmitter {
     this.processID = null
     this.secretKey = null
     this.ssl = this.connectionParameters.ssl || false
+    // As with Password, make SSL->Key (the private key) non-enumerable.
+    // It won't show up in stack traces
+    // or if the client is console.logged
+    if (this.ssl && this.ssl.key) {
+      Object.defineProperty(this.ssl, 'key', {
+        enumerable: false,
+      })
+    }
+
     this._connectionTimeoutMillis = c.connectionTimeoutMillis || 0
   }
 

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -84,6 +84,11 @@ class ConnectionParameters {
     if (this.ssl === 'no-verify') {
       this.ssl = { rejectUnauthorized: false }
     }
+    if (this.ssl && this.ssl.key) {
+      Object.defineProperty(this.ssl, 'key', {
+        enumerable: false,
+      })
+    }
 
     this.client_encoding = val('client_encoding', config)
     this.replication = val('replication', config)

--- a/packages/pg/test/integration/gh-issues/2303-tests.js
+++ b/packages/pg/test/integration/gh-issues/2303-tests.js
@@ -1,0 +1,47 @@
+'use strict'
+const helper = require('./../test-helper')
+const assert = require('assert')
+const util = require('util')
+
+const suite = new helper.Suite()
+
+const secret_value = 'FAIL THIS TEST'
+
+suite.test('SSL Key should not exist in toString() output', () => {
+  const pool = new helper.pg.Pool({ ssl: { key: secret_value } })
+  const client = new helper.pg.Client({ ssl: { key: secret_value } })
+  assert(pool.toString().indexOf(secret_value) === -1)
+  assert(client.toString().indexOf(secret_value) === -1)
+})
+
+suite.test('SSL Key should not exist in util.inspect output', () => {
+  const pool = new helper.pg.Pool({ ssl: { key: secret_value } })
+  const client = new helper.pg.Client({ ssl: { key: secret_value } })
+  const depth = 20
+  assert(util.inspect(pool, { depth }).indexOf(secret_value) === -1)
+  assert(util.inspect(client, { depth }).indexOf(secret_value) === -1)
+})
+
+suite.test('SSL Key should not exist in json.stringfy output', () => {
+  const pool = new helper.pg.Pool({ ssl: { key: secret_value } })
+  const client = new helper.pg.Client({ ssl: { key: secret_value } })
+  const depth = 20
+  assert(JSON.stringify(pool).indexOf(secret_value) === -1)
+  assert(JSON.stringify(client).indexOf(secret_value) === -1)
+})
+
+suite.test('SSL Key should exist for direct access', () => {
+  const pool = new helper.pg.Pool({ ssl: { key: secret_value } })
+  const client = new helper.pg.Client({ ssl: { key: secret_value } })
+  assert(pool.options.ssl.key === secret_value)
+  assert(client.connectionParameters.ssl.key === secret_value)
+})
+
+suite.test('SSL Key should exist for direct access even when non-enumerable custom config', () => {
+  const config = { ssl: { key: secret_value } }
+  Object.defineProperty(config.ssl, 'key', { enumerable: false })
+  const pool = new helper.pg.Pool(config)
+  const client = new helper.pg.Client(config)
+  assert(pool.options.ssl.key === secret_value)
+  assert(client.connectionParameters.ssl.key === secret_value)
+})


### PR DESCRIPTION
## Problem-space

* `password` already has this set, but was a little long considering we only want to override default of one property
* `ssl.key` was showing up in tracebacks

This came up locally when disconnecting a client after connection, but before close

```
Emitted 'error' event on BoundPool instance at:
    at Client.idleListener (C:\Users\lewis\projects\nodejs-app\node_modules\pg-pool\index.js:57:10)
    at Client.emit (events.js:321:20)
    at connectedErrorHandler (C:\Users\lewis\projects\nodejs-app\node_modules\pg\lib\client.js:221:10)
    at Connection.<anonymous> (C:\Users\lewis\projects\nodejs-app\node_modules\pg\lib\client.js:289:9)
    at Object.onceWrapper (events.js:427:28)
    [... lines matching original stack trace ...]
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  client: Client {
```

with

```
key: '-----BEGIN RSA PRIVATE KEY-----\n' +
        'MIIEpAIBAAKCAQEAxAnztpOXj+6OuEONaUkpW2CPxCOoKyuzlsF5PTcjETHGgSN+\n' +
        ...
        'qq/1uRgkxeakQ9gl9sXL94+ALu8bHKFVReZbSsdYEcdJwdEH5F/4HA==\n' +
        '-----END RSA PRIVATE KEY-----\n'
```

Secrets in logs are not great.

## Temporary fix

Without this code, you can already make the key non-enumerable. This just passes that responsibility into the library so that it does not impact users who don't know about this.