### PR TITLE
Prevents bad ssl credentials from causing a crash

### DIFF
--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -85,7 +85,11 @@ class Connection extends EventEmitter {
       if (net.isIP(host) === 0) {
         options.servername = host
       }
-      self.stream = tls.connect(options)
+      try {
+        self.stream = tls.connect(options)
+      } catch (err) {
+        return self.emit('error', err)
+      }
       self.attachListeners(self.stream)
       self.stream.on('error', reportStreamError)
 

--- a/packages/pg/test/integration/gh-issues/2307-tests.js
+++ b/packages/pg/test/integration/gh-issues/2307-tests.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const pg = require('../../../lib')
+const helper = require('../test-helper')
+
+const suite = new helper.Suite()
+
+suite.test('bad ssl credentials do not cause crash', (done) => {
+  const config = {
+    ssl: {
+      ca: 'invalid_value',
+      key: 'invalid_value',
+      cert: 'invalid_value',
+    },
+  }
+
+  const client = new pg.Client(config)
+
+  client.connect((err) => {
+    assert(err)
+    client.end()
+    done()
+  })
+})


### PR DESCRIPTION
This fixes a bug in `Client.connect()` where invalid ssl credentials would cause an error that was not passed to the callback and could not be caught.

Fixes: https://github.com/brianc/node-postgres/issues/2307
Fixes: https://github.com/brianc/node-postgres/issues/2004