### PR TITLE
Fix context (this) in _checkPgPass.

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -215,7 +215,7 @@ class Client extends EventEmitter {
     } else if (this.password !== null) {
       cb()
     } else {
-      pgPass(this.connectionParameters, function (pass) {
+      pgPass(this.connectionParameters, (pass) => {
         if (undefined !== pass) {
           this.connectionParameters.password = this.password = pass
         }


### PR DESCRIPTION
In the specific scenario in which I was testing (`this.password` is `null`, and perhaps there are other factors at play) the following error is thrown:
> Cannot read property 'connectionParameters' of undefined