### PR TITLE
Fix metadata for pg-connection-string

### DIFF
--- a/packages/pg-connection-string/package.json
+++ b/packages/pg-connection-string/package.json
@@ -22,9 +22,9 @@
   "author": "Blaine Bublitz <blaine@iceddev.com> (http://iceddev.com/)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/iceddev/pg-connection-string/issues"
+    "url": "https://github.com/brianc/node-postgres/issues"
   },
-  "homepage": "https://github.com/iceddev/pg-connection-string",
+  "homepage": "https://github.com/brianc/node-postgres/tree/master/packages/pg-connection-string",
   "devDependencies": {
     "chai": "^4.1.1",
     "coveralls": "^3.0.4",


### PR DESCRIPTION
When you visit the [pg-connection-string module on npmjs.com](https://www.npmjs.com/package/pg-connection-string) it links to the wrong place.