### PR TITLE
Add support for ?sslmode connection string param

### DIFF
--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -81,6 +81,25 @@ function parse(str) {
     config.ssl.ca = fs.readFileSync(config.sslrootcert).toString()
   }
 
+  switch (config.sslmode) {
+    case 'disable': {
+      config.ssl = false
+      break
+    }
+    case 'prefer':
+    case 'require':
+    case 'verify-ca':
+    case 'verify-full': {
+      config.ssl = config.ssl || true
+      break
+    }
+    case 'no-verify': {
+      config.ssl = config.ssl || {}
+      config.ssl.rejectUnauthorized = false
+      break
+    }
+  }
+
   return config
 }
 

--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -65,7 +65,7 @@ function parse(str) {
     config.ssl = false
   }
 
-  if (config.sslcert || config.sslkey || config.sslrootcert) {
+  if (config.sslcert || config.sslkey || config.sslrootcert || config.sslmode) {
     config.ssl = {}
   }
 
@@ -90,11 +90,9 @@ function parse(str) {
     case 'require':
     case 'verify-ca':
     case 'verify-full': {
-      config.ssl = config.ssl || true
       break
     }
     case 'no-verify': {
-      config.ssl = config.ssl || {}
       config.ssl.rejectUnauthorized = false
       break
     }

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -279,8 +279,8 @@ describe('parse', function () {
     subject.ssl.should.eql({})
   })
 
-  it("configuration parameter sslmode=require doesn't overwrite sslrootcert=/path/to/ca", function () {
-    var connectionString = 'pg:///?sslrootcert=' + __dirname + '/example.ca&sslmode=require'
+  it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca', function () {
+    var connectionString = 'pg:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require'
     var subject = parse(connectionString)
     subject.ssl.should.eql({
       ca: 'example ca\n',

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -241,6 +241,52 @@ describe('parse', function () {
     })
   })
 
+  it('configuration parameter sslmode=no-verify', function () {
+    var connectionString = 'pg:///?sslmode=no-verify'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql({
+      rejectUnauthorized: false,
+    })
+  })
+
+  it('configuration parameter sslmode=disable', function () {
+    var connectionString = 'pg:///?sslmode=disable'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql(false)
+  })
+
+  it('configuration parameter sslmode=prefer', function () {
+    var connectionString = 'pg:///?sslmode=prefer'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql(true)
+  })
+
+  it('configuration parameter sslmode=require', function () {
+    var connectionString = 'pg:///?sslmode=require'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql(true)
+  })
+
+  it('configuration parameter sslmode=verify-ca', function () {
+    var connectionString = 'pg:///?sslmode=verify-ca'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql(true)
+  })
+
+  it('configuration parameter sslmode=verify-full', function () {
+    var connectionString = 'pg:///?sslmode=verify-full'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql(true)
+  })
+
+  it("configuration parameter sslmode=require doesn't overwrite sslrootcert=/path/to/ca", function () {
+    var connectionString = 'pg:///?sslrootcert=' + __dirname + '/example.ca&sslmode=require'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql({
+      ca: 'example ca\n',
+    })
+  })
+
   it('allow other params like max, ...', function () {
     var subject = parse('pg://myhost/db?max=18&min=4')
     subject.max.should.equal('18')

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -258,25 +258,25 @@ describe('parse', function () {
   it('configuration parameter sslmode=prefer', function () {
     var connectionString = 'pg:///?sslmode=prefer'
     var subject = parse(connectionString)
-    subject.ssl.should.eql(true)
+    subject.ssl.should.eql({})
   })
 
   it('configuration parameter sslmode=require', function () {
     var connectionString = 'pg:///?sslmode=require'
     var subject = parse(connectionString)
-    subject.ssl.should.eql(true)
+    subject.ssl.should.eql({})
   })
 
   it('configuration parameter sslmode=verify-ca', function () {
     var connectionString = 'pg:///?sslmode=verify-ca'
     var subject = parse(connectionString)
-    subject.ssl.should.eql(true)
+    subject.ssl.should.eql({})
   })
 
   it('configuration parameter sslmode=verify-full', function () {
     var connectionString = 'pg:///?sslmode=verify-full'
     var subject = parse(connectionString)
-    subject.ssl.should.eql(true)
+    subject.ssl.should.eql({})
   })
 
   it("configuration parameter sslmode=require doesn't overwrite sslrootcert=/path/to/ca", function () {


### PR DESCRIPTION
Fixes #1949

If you're using connection strings, you can't use the `PGSSLMODE=no-verify` envvar because that's only used when `config.ssl` is not set. I use `?ssl=true&sslmode=no-verify&sslrootcert=/app/data/amazon-rds-ca-cert.pem` which does set `config.ssl`, so we need to also support parsing sslmode from the connection string. I've copied the logic (roughly) from:

https://github.com/brianc/node-postgres/blob/8291b233b81312ce2fbfce12ccd98ceceb53f5b9/packages/pg/lib/connection-parameters.js#L21-L32

I didn't see a CONTRIBUTING file, so I've taken a guess at the steps to make a good PR:

- [x] Added fix
- [x] Noted the GitHub issue it closes
- [x] Added test cases / 100% code coverage
- [x] Matched surrounding code style / passed linting
- [x] Sponsor @brianc :sparkling_heart: 