### PR TITLE
Allows for the sockets that are passed through to not be overridden

### DIFF
--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -35,8 +35,13 @@ class Connection extends EventEmitter {
     var self = this
 
     this._connecting = true
-    this.stream.setNoDelay(true)
-    this.stream.connect(port, host)
+    //Check if stream is open (e.g passing socket from SOCKS proxy)
+    if (!this.stream.readable && !this.stream.writeable) {
+      this.stream.setNoDelay(true)
+      this.stream.connect(port, host)
+    } else {
+      process.nextTick(() => self.emit('connect'))
+    }
 
     this.stream.once('connect', function () {
       if (self._keepAlive) {


### PR DESCRIPTION
This re-adds in functionality that was broken in #2171 with regards to passing existing sockets into pg. This was causing things like SOCKS proxies to fail.

Checks to see if the base `Stream.duplex` is read/writable since using something like `connecting` is unreliable. Sad Node v14 got rid of `.readyState` but such is life. 

NOTE: I had to also add in a `process.nextTick()` to allow for something like https://www.npmjs.com/package/socks to properly allow for all the events to fire in order. I'm pretty sure this is going to be controversial, but it was the only way it seams to make sure everything fires in order and as expected.  