### PR TITLE
Replace semver with optional peer dependencies

### DIFF
--- a/packages/pg/lib/native/client.js
+++ b/packages/pg/lib/native/client.js
@@ -3,15 +3,10 @@
 // eslint-disable-next-line
 var Native = require('pg-native')
 var TypeOverrides = require('../type-overrides')
-var semver = require('semver')
 var pkg = require('../../package.json')
-var assert = require('assert')
 var EventEmitter = require('events').EventEmitter
 var util = require('util')
 var ConnectionParameters = require('../connection-parameters')
-
-var msg = 'Version >= ' + pkg.minNativeVersion + ' of pg-native required.'
-assert(semver.gte(Native.version, pkg.minNativeVersion), msg)
 
 var NativeQuery = require('./query')
 

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -25,8 +25,7 @@
     "pg-pool": "^3.2.1",
     "pg-protocol": "^1.2.5",
     "pg-types": "^2.1.0",
-    "pgpass": "1.x",
-    "semver": "4.3.2"
+    "pgpass": "1.x"
   },
   "devDependencies": {
     "async": "0.9.0",
@@ -34,7 +33,14 @@
     "co": "4.6.0",
     "pg-copy-streams": "0.3.0"
   },
-  "minNativeVersion": "2.0.0",
+  "peerDependencies": {
+    "pg-native": ">=2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "pg-native": {
+      "optional": true
+    }
+  },
   "scripts": {
     "test": "make test-all"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5077,11 +5077,6 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
-  integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
-
 semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"


### PR DESCRIPTION
See example https://github.com/sindresorhus/gulp-chown/blob/bb74168c957b3a94f122aafcecf7ebc87088ec46/package.json#L42-L49

This feature is supported by both npm and yarn.