### PR TITLE
Public export of DatabaseError

### DIFF
--- a/packages/pg-protocol/src/index.ts
+++ b/packages/pg-protocol/src/index.ts
@@ -1,4 +1,4 @@
-import { BackendMessage } from './messages'
+import { BackendMessage, DatabaseError } from './messages'
 import { serialize } from './serializer'
 import { Parser, MessageCallback } from './parser'
 
@@ -8,4 +8,4 @@ export function parse(stream: NodeJS.ReadableStream, callback: MessageCallback):
   return new Promise((resolve) => stream.on('end', () => resolve()))
 }
 
-export { serialize }
+export { serialize, DatabaseError }


### PR DESCRIPTION
## Description

When handling errors from this package it would be better to have the errors publicly exported

## Change Summary

- Updated root exports of 'pg-protocol' to include DatabaseError

Ref: #2340