### PR TITLE
Fix double-sync crash on postgres 9.x

### DIFF
--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -31,7 +31,6 @@ class Query extends EventEmitter {
     this.isPreparedStatement = false
     this._canceledDueToError = false
     this._promise = null
-    this._hasSentSync = false
   }
 
   requiresPreparation() {

--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -136,11 +136,12 @@ class Query extends EventEmitter {
     this.emit('end', this._results)
   }
 
-  // in postgres 9.6 the backend sends both a command complete and error response
-  // to a query which has timed out on rare, random occasions.  If we send sync twice we will receive
-  // to 'readyForQuery' events.  I think this might be a bug in postgres 9.6, but I'm not sure...
+  // In postgres 9.x & 10.x the backend sends both a CommandComplete and ErrorResponse
+  // to the same query when it times out due to a statement_timeout on rare, random occasions.  If we send sync twice we will receive
+  // to ReadyForQuery messages .  I hink this might be a race condition in some versions of postgres, but I'm not sure...
   // the docs here: https://www.postgresql.org/docs/9.6/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
-  // say "Therefore, an Execute phase is always terminated by the appearance of exactly one of these messages: CommandComplete, EmptyQueryResponse (if the portal was created from an empty query string), ErrorResponse, or PortalSuspended."
+  // say "Therefore, an Execute phase is always terminated by the appearance of exactly one of these messages:
+  // CommandComplete, EmptyQueryResponse (if the portal was created from an empty query string), ErrorResponse, or PortalSuspended."
   maybeSync(connection) {
     if (this.isPreparedStatement && !this._hasSentSync) {
       this._hasSentSync = true

--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -142,7 +142,7 @@ class Query extends EventEmitter {
   // the docs here: https://www.postgresql.org/docs/9.6/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
   // say "Therefore, an Execute phase is always terminated by the appearance of exactly one of these messages: CommandComplete, EmptyQueryResponse (if the portal was created from an empty query string), ErrorResponse, or PortalSuspended."
   maybeSync(connection) {
-    if (this.isPreparedStatement) {
+    if (this.isPreparedStatement && !this._hasSentSync) {
       this._hasSentSync = true
       connection.sync()
     }

--- a/packages/pg/test/integration/client/prepared-statement-tests.js
+++ b/packages/pg/test/integration/client/prepared-statement-tests.js
@@ -174,5 +174,15 @@ var suite = new helper.Suite()
     checkForResults(query)
   })
 
+  suite.testAsync('with no data response and rows', async function () {
+    const result = await client.query({
+      name: 'some insert',
+      text: '',
+      values: [],
+      rows: 1,
+    })
+    assert.equal(result.rows.length, 0)
+  })
+
   suite.test('cleanup', () => client.end())
 })()

--- a/packages/pg/test/integration/gh-issues/1105-tests.js
+++ b/packages/pg/test/integration/gh-issues/1105-tests.js
@@ -6,7 +6,7 @@ suite.testAsync('timeout causing query crashes', async () => {
   const client = new helper.Client()
   await client.connect()
   await client.query('CREATE TEMP TABLE foobar( name TEXT NOT NULL, id SERIAL)')
-  client.query('BEGIN')
+  await client.query('BEGIN')
   await client.query("SET LOCAL statement_timeout TO '1ms'")
   let count = 0
   while (count++ < 5000) {

--- a/packages/pg/test/integration/gh-issues/1105-tests.js
+++ b/packages/pg/test/integration/gh-issues/1105-tests.js
@@ -1,0 +1,20 @@
+const pg = require('../../../lib')
+const helper = require('../test-helper')
+const suite = new helper.Suite()
+
+suite.testAsync('timeout causing query crashes', async () => {
+  const client = new helper.Client()
+  await client.connect()
+  await client.query('CREATE TEMP TABLE foobar( name TEXT NOT NULL, id SERIAL)')
+  client.query('BEGIN')
+  await client.query("SET LOCAL statement_timeout TO '1ms'")
+  let count = 0
+  while (count++ < 5000) {
+    try {
+      await client.query('INSERT INTO foobar(name) VALUES ($1)', [Math.random() * 1000 + ''])
+    } catch (e) {
+      await client.query('ROLLBACK')
+    }
+  }
+  await client.end()
+})

--- a/packages/pg/test/integration/gh-issues/2085-tests.js
+++ b/packages/pg/test/integration/gh-issues/2085-tests.js
@@ -4,6 +4,10 @@ var assert = require('assert')
 
 const suite = new helper.Suite()
 
+if (process.env.PGTESTNOSSL) {
+  return
+}
+
 suite.testAsync('it should connect over ssl', async () => {
   const ssl = helper.args.native
     ? 'require'

--- a/packages/pg/test/integration/gh-issues/2085-tests.js
+++ b/packages/pg/test/integration/gh-issues/2085-tests.js
@@ -4,6 +4,8 @@ var assert = require('assert')
 
 const suite = new helper.Suite()
 
+// allow skipping of this test via env var for
+// local testing when you don't have SSL set up
 if (process.env.PGTESTNOSSL) {
   return
 }


### PR DESCRIPTION
An attempt to fix #1105

It looks like in rare, random occasions postgres 9.x is sending both `ErrorResponse` __and__ `CommandComplete` when a query times out.  In an attempt to fix this, I have changed the query to only send a `sync` on an error message if it hasn't already sent a sync.  Judging from the docs this should never happen, and indeed on newer versions of postgres the bug is not reproducible...but lots of folks still run postgres 9.x in production.  I'm not super fond of this fix as it feels like it's working around a possible race condition in postgres 9.x so I'd love some additional eyes & ideas on this one.  Also, want to run the test suite and make sure everything passes in the whole test matrix on travis.

One option is to put this behind some environment variable like `PGSKIPDOUBLESYNC` or something and allow people to opt in to this change.  I'm worried about a (according to the docs, not possible) circumstance where we receive two messages requiring a sync and we only send one sync back.