### PR TITLE
Exposing TypeOverrides from the library's root

### DIFF
--- a/packages/pg/lib/index.js
+++ b/packages/pg/lib/index.js
@@ -3,6 +3,7 @@
 var Client = require('./client')
 var defaults = require('./defaults')
 var Connection = require('./connection')
+var TypeOverrides = require('./type-overrides')
 var Pool = require('pg-pool')
 
 const poolFactory = (Client) => {
@@ -20,6 +21,7 @@ var PG = function (clientConstructor) {
   this.Pool = poolFactory(this.Client)
   this._pools = []
   this.Connection = Connection
+  this.TypeOverrides = TypeOverrides
   this.types = require('pg-types')
 }
 


### PR DESCRIPTION
`TypeOverrides` is too important not to expose it. It should be available from the root.

It is essential part of custom type parsing, for which singleton `types` is exposed, while `TypeOverrides` is not.

One of the big issues the current implementation has - impossible to properly declare the type in TypeScript, since it is a class, which we have to use as `any` interface instead (it's awkward).

Related: #1838, #2363