### PR TITLE
Fix the dns resolution of multiple hosts

### DIFF
--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -1,6 +1,8 @@
 'use strict'
 
-var dns = require('dns')
+var { promisify } = require('util')
+
+var dnsLookup = promisify(require('dns').lookup)
 
 var defaults = require('./defaults')
 
@@ -150,11 +152,15 @@ class ConnectionParameters {
     if (this.client_encoding) {
       params.push('client_encoding=' + quoteParamValue(this.client_encoding))
     }
-    dns.lookup(this.host, function (err, address) {
-      if (err) return cb(err, null)
-      params.push('hostaddr=' + quoteParamValue(address))
-      return cb(null, params.join(' '))
-    })
+    Promise.all(this.host.split(',').map((host) => dnsLookup(host))).then(
+      (results) => {
+        params.push('hostaddr=' + quoteParamValue(results.map(({ address }) => address).join(',')))
+        cb(null, params.join(' '))
+      },
+      (err) => {
+        cb(err, null)
+      }
+    )
   }
 }
 

--- a/packages/pg/test/unit/connection-parameters/creation-tests.js
+++ b/packages/pg/test/unit/connection-parameters/creation-tests.js
@@ -177,7 +177,7 @@ test('libpq connection string building', function () {
       user: 'brian',
       password: 'asdf',
       port: 5432,
-      host: 'localhost',
+      host: 'localhost,localhost',
     }
     var subject = new ConnectionParameters(config)
     subject.getLibpqConnectionString(
@@ -185,7 +185,7 @@ test('libpq connection string building', function () {
         assert(!err)
         var parts = constring.split(' ')
         checkForPart(parts, "user='brian'")
-        checkForPart(parts, "hostaddr='127.0.0.1'")
+        checkForPart(parts, "hostaddr='127.0.0.1,127.0.0.1'")
       })
     )
   })
@@ -195,7 +195,7 @@ test('libpq connection string building', function () {
       user: 'brian',
       password: 'asf',
       port: 5432,
-      host: 'asdlfkjasldfkksfd#!$!!!!..com',
+      host: 'localhost,invalid',
     }
     var subject = new ConnectionParameters(config)
     subject.getLibpqConnectionString(


### PR DESCRIPTION
This fix allows to use native client with multi-host configuration:
```js
const { native: { Client } } = require('pg');

const client = new Client({
  user: 'user',
  host: 'foo,bar,baz',
  database: 'db',
});
client.connect().then(() => {
  client.query('SELECT 1', console.log);
});
```
This is workaround for #1470 

I have a couple of questions though:
1. Do we need this dns resolution at all? In which cases libpq cannot resolve host by itself?
2. To make better tests of dns errors I need to patch `dns.resolve`. Can I just add `jest` to dependecies? Or `node-postgres` unit tests have to be written without mocking?
