### PR TITLE
Run build before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
     "pretest": "yarn build",
+    "prepublish": "yarn build",
     "lint": "eslint '*/**/*.{js,ts,tsx}'"
   },
   "devDependencies": {


### PR DESCRIPTION
The module was ported to typescript but build wasn't running as a pre-release step so the dist folder didn't exist on publish. Fixes #2408