### PR TITLE
Add more SASL validation and fix tests

### DIFF
--- a/packages/pg/lib/sasl.js
+++ b/packages/pg/lib/sasl.js
@@ -113,19 +113,19 @@ function extractVariablesFromFirstServerMessage(data) {
 }
 
 function xorBuffers(a, b) {
-  if (!Buffer.isBuffer(a)) a = Buffer.from(a)
-  if (!Buffer.isBuffer(b)) b = Buffer.from(b)
-  var res = []
-  if (a.length > b.length) {
-    for (var i = 0; i < b.length; i++) {
-      res.push(a[i] ^ b[i])
-    }
-  } else {
-    for (var j = 0; j < a.length; j++) {
-      res.push(a[j] ^ b[j])
-    }
+  if (!Buffer.isBuffer(a)) {
+    throw new TypeError('first argument must be a Buffer')
   }
-  return Buffer.from(res)
+  if (!Buffer.isBuffer(b)) {
+    throw new TypeError('second argument must be a Buffer')
+  }
+  if (a.length !== b.length) {
+    throw new Error('Buffer lengths must match')
+  }
+  if (a.length === 0) {
+    throw new Error('Buffers cannot be empty')
+  }
+  return Buffer.from(a.map((_, i) => a[i] ^ b[i]))
 }
 
 function sha256(text) {

--- a/packages/pg/lib/sasl.js
+++ b/packages/pg/lib/sasl.js
@@ -32,7 +32,7 @@ function continueSession(session, password, serverData) {
   var saltedPassword = Hi(password, saltBytes, sv.iteration)
 
   var clientKey = createHMAC(saltedPassword, 'Client Key')
-  var storedKey = crypto.createHash('sha256').update(clientKey).digest()
+  var storedKey = sha256(clientKey)
 
   var clientFirstMessageBare = 'n=*,r=' + session.clientNonce
   var serverFirstMessage = 'r=' + sv.nonce + ',s=' + sv.salt + ',i=' + sv.iteration
@@ -127,6 +127,10 @@ function xorBuffers(a, b) {
     }
   }
   return Buffer.from(res)
+}
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text).digest()
 }
 
 function createHMAC(key, msg) {

--- a/packages/pg/lib/sasl.js
+++ b/packages/pg/lib/sasl.js
@@ -25,6 +25,8 @@ function continueSession(session, password, serverData) {
 
   if (!sv.nonce.startsWith(session.clientNonce)) {
     throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: server nonce does not start with client nonce')
+  } else if (sv.nonce.length === session.clientNonce.length) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: server nonce is too short')
   }
 
   var saltBytes = Buffer.from(sv.salt, 'base64')

--- a/packages/pg/lib/sasl.js
+++ b/packages/pg/lib/sasl.js
@@ -69,6 +69,22 @@ function finalizeSession(session, serverData) {
   }
 }
 
+/**
+ * printable       = %x21-2B / %x2D-7E
+ *                   ;; Printable ASCII except ",".
+ *                   ;; Note that any "printable" is also
+ *                   ;; a valid "value".
+ */
+function isPrintableChars(text) {
+  if (typeof text !== 'string') {
+    throw new TypeError('SASL: text must be a string')
+  }
+  return text
+    .split('')
+    .map((_, i) => text.charCodeAt(i))
+    .every((c) => (c >= 0x21 && c <= 0x2b) || (c >= 0x2d && c <= 0x7e))
+}
+
 function parseAttributePairs(text) {
   if (typeof text !== 'string') {
     throw new TypeError('SASL: attribute pairs text must be a string')
@@ -92,6 +108,8 @@ function extractVariablesFromFirstServerMessage(data) {
   const nonce = attrPairs.get('r')
   if (!nonce) {
     throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: nonce missing')
+  } else if (!isPrintableChars(nonce)) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: nonce must only contain printable characters')
   }
   const salt = attrPairs.get('s')
   if (!salt) {

--- a/packages/pg/lib/sasl.js
+++ b/packages/pg/lib/sasl.js
@@ -62,6 +62,8 @@ function finalizeSession(session, serverData) {
   const serverSignature = attrPairs.get('v')
   if (!serverSignature) {
     throw new TypeError('SASL: server signature is missing')
+  } else if (!isBase64(serverSignature)) {
+    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature must be base64')
   }
 
   if (serverSignature !== session.serverSignature) {
@@ -83,6 +85,21 @@ function isPrintableChars(text) {
     .split('')
     .map((_, i) => text.charCodeAt(i))
     .every((c) => (c >= 0x21 && c <= 0x2b) || (c >= 0x2d && c <= 0x7e))
+}
+
+/**
+ * base64-char     = ALPHA / DIGIT / "/" / "+"
+ *
+ * base64-4        = 4base64-char
+ *
+ * base64-3        = 3base64-char "="
+ *
+ * base64-2        = 2base64-char "=="
+ *
+ * base64          = *base64-4 [base64-3 / base64-2]
+ */
+function isBase64(text) {
+  return /^(?:[a-zA-Z0-9+/]{4})*(?:[a-zA-Z0-9+/]{2}==|[a-zA-Z0-9+/]{3}=)?$/.test(text)
 }
 
 function parseAttributePairs(text) {
@@ -114,6 +131,8 @@ function extractVariablesFromFirstServerMessage(data) {
   const salt = attrPairs.get('s')
   if (!salt) {
     throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: salt missing')
+  } else if (!isBase64(salt)) {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: salt must be base64')
   }
   const iterationText = attrPairs.get('i')
   if (!iterationText) {

--- a/packages/pg/lib/sasl.js
+++ b/packages/pg/lib/sasl.js
@@ -20,6 +20,12 @@ function continueSession(session, password, serverData) {
   if (session.message !== 'SASLInitialResponse') {
     throw new Error('SASL: Last message was not SASLInitialResponse')
   }
+  if (typeof password !== 'string') {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string')
+  }
+  if (typeof serverData !== 'string') {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: serverData must be a string')
+  }
 
   const sv = parseServerFirstMessage(serverData)
 

--- a/packages/pg/lib/sasl.js
+++ b/packages/pg/lib/sasl.js
@@ -65,14 +65,11 @@ function finalizeSession(session, serverData) {
   if (session.message !== 'SASLResponse') {
     throw new Error('SASL: Last message was not SASLResponse')
   }
-
-  const attrPairs = parseAttributePairs(serverData)
-  const serverSignature = attrPairs.get('v')
-  if (!serverSignature) {
-    throw new TypeError('SASL: server signature is missing')
-  } else if (!isBase64(serverSignature)) {
-    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature must be base64')
+  if (typeof serverData !== 'string') {
+    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: serverData must be a string')
   }
+
+  const { serverSignature } = parseServerFinalMessage(serverData)
 
   if (serverSignature !== session.serverSignature) {
     throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature does not match')
@@ -154,6 +151,19 @@ function parseServerFirstMessage(data) {
     nonce,
     salt,
     iteration,
+  }
+}
+
+function parseServerFinalMessage(serverData) {
+  const attrPairs = parseAttributePairs(serverData)
+  const serverSignature = attrPairs.get('v')
+  if (!serverSignature) {
+    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature is missing')
+  } else if (!isBase64(serverSignature)) {
+    throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature must be base64')
+  }
+  return {
+    serverSignature,
   }
 }
 

--- a/packages/pg/lib/sasl.js
+++ b/packages/pg/lib/sasl.js
@@ -21,7 +21,7 @@ function continueSession(session, password, serverData) {
     throw new Error('SASL: Last message was not SASLInitialResponse')
   }
 
-  const sv = extractVariablesFromFirstServerMessage(serverData)
+  const sv = parseServerFirstMessage(serverData)
 
   if (!sv.nonce.startsWith(session.clientNonce)) {
     throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: server nonce does not start with client nonce')
@@ -121,7 +121,7 @@ function parseAttributePairs(text) {
   )
 }
 
-function extractVariablesFromFirstServerMessage(data) {
+function parseServerFirstMessage(data) {
   const attrPairs = parseAttributePairs(data)
 
   const nonce = attrPairs.get('r')

--- a/packages/pg/test/test-helper.js
+++ b/packages/pg/test/test-helper.js
@@ -111,16 +111,6 @@ assert.success = function (callback) {
   }
 }
 
-assert.throws = function (offender) {
-  try {
-    offender()
-  } catch (e) {
-    assert.ok(e instanceof Error, 'Expected ' + offender + ' to throw instances of Error')
-    return
-  }
-  assert.ok(false, 'Expected ' + offender + ' to throw exception')
-}
-
 assert.lengthIs = function (actual, expectedLength) {
   assert.equal(actual.length, expectedLength)
 }


### PR DESCRIPTION
Bunch of commits to clean up some of the SASL internals, add validation for function args, validation for data types of server responses, and some regex validation as well (e.g. base64 server responses should be valid base64). They're broken up into separate commits to make it easier to review and the final file is a bit easier to digest too.

Also removes the global `asssert.throws(...)` test helper as it was overwriting the real one in the built-in asserts module. The removed one did not actually check the error signature so it would report success for unrelated errors as long as the code block threw something (which was kind of confusing while testing this out...).

The only thing using that extra validation of the error signature was the SASL tests so it shouldn't break anything and all the tests pass with that change. The SASL tests have also been updated to add in some missing parameters. Previously they weren't supplying all the args needed to actually perform the tests so they'd have early or unrelated failures.