### PR TITLE
Make tests pass in github codespaces

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       PGUSER: user
       PGDATABASE: data
       PGHOST: db
+      # set this to true in the development environment until I can get SSL setup on the 
+      # docker postgres instance
+      PGTESTNOSSL: true
       
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/packages/pg/test/integration/client/connection-parameter-tests.js
+++ b/packages/pg/test/integration/client/connection-parameter-tests.js
@@ -1,3 +1,4 @@
+const assert = require('assert')
 const helper = require('../test-helper')
 const suite = new helper.Suite()
 const { Client } = helper.pg
@@ -8,6 +9,7 @@ suite.test('it sends options', async () => {
   })
   await client.connect()
   const { rows } = await client.query('SHOW default_transaction_isolation')
-  console.log(rows)
+  assert.strictEqual(rows.length, 1)
+  assert.strictEqual(rows[0].default_transaction_isolation, 'serializable')
   await client.end()
 })

--- a/packages/pg/test/integration/client/promise-api-tests.js
+++ b/packages/pg/test/integration/client/promise-api-tests.js
@@ -20,7 +20,7 @@ suite.test('valid connection completes promise', () => {
 })
 
 suite.test('invalid connection rejects promise', (done) => {
-  const client = new pg.Client({ host: 'alksdjflaskdfj' })
+  const client = new pg.Client({ host: 'alksdjflaskdfj', port: 1234 })
   return client.connect().catch((e) => {
     assert(e instanceof Error)
     done()

--- a/packages/pg/test/integration/gh-issues/2079-tests.js
+++ b/packages/pg/test/integration/gh-issues/2079-tests.js
@@ -41,7 +41,6 @@ suite.test('SSL connection error allows event loop to exit', (done) => {
   })
 })
 
-
 suite.test('Non "S" response code allows event loop to exit', (done) => {
   const port = makeTerminatingBackend('X')
   const client = new helper.pg.Client({ ssl: 'require', host: 'localhost', port })

--- a/packages/pg/test/integration/gh-issues/2079-tests.js
+++ b/packages/pg/test/integration/gh-issues/2079-tests.js
@@ -32,7 +32,7 @@ let makeTerminatingBackend = (byte) => {
 
 suite.test('SSL connection error allows event loop to exit', (done) => {
   const port = makeTerminatingBackend('N')
-  const client = new helper.pg.Client({ ssl: 'require', port })
+  const client = new helper.pg.Client({ ssl: 'require', port, host: 'localhost' })
   // since there was a connection error the client's socket should be closed
   // and the event loop will have no refs and exit cleanly
   client.connect((err) => {
@@ -41,9 +41,10 @@ suite.test('SSL connection error allows event loop to exit', (done) => {
   })
 })
 
+
 suite.test('Non "S" response code allows event loop to exit', (done) => {
   const port = makeTerminatingBackend('X')
-  const client = new helper.pg.Client({ ssl: 'require', port })
+  const client = new helper.pg.Client({ ssl: 'require', host: 'localhost', port })
   // since there was a connection error the client's socket should be closed
   // and the event loop will have no refs and exit cleanly
   client.connect((err) => {


### PR DESCRIPTION
There were a few tests which didn't specify a host or port which wasn't working well inside the codespaces docker environment.  Added host & port where required.  Also noticed one test wasn't actually _testing_, it was just `console.log`-ing its output, so I added proper assertions there.  Finally set `PGTESTNOSSL: true` in the codespaces environment until I can get the postgres docker container configured w/ SSL...which I will do l8r.

Now I can much more easily work on my windows machine via the vscode codespaces [addon](https://docs.github.com/en/free-pro-team@latest/github/developing-online-with-codespaces/using-codespaces-in-visual-studio-code) or in a browser on the go.  Nifty.  Also, this should make doing quick contributions easier as no one needs to set up an environment, just create a codespace for this repo and it will "just work" ™️ 