### PR TITLE
pg: Re-export DatabaseError from 'pg-protocol'

### DIFF
--- a/packages/pg/lib/index.js
+++ b/packages/pg/lib/index.js
@@ -4,6 +4,7 @@ var Client = require('./client')
 var defaults = require('./defaults')
 var Connection = require('./connection')
 var Pool = require('pg-pool')
+const { DatabaseError } = require('pg-protocol')
 
 const poolFactory = (Client) => {
   return class BoundPool extends Pool {
@@ -21,6 +22,7 @@ var PG = function (clientConstructor) {
   this._pools = []
   this.Connection = Connection
   this.types = require('pg-types')
+  this.DatabaseError = DatabaseError
 }
 
 if (typeof process.env.NODE_PG_FORCE_NATIVE !== 'undefined') {

--- a/packages/pg/test/integration/client/error-handling-tests.js
+++ b/packages/pg/test/integration/client/error-handling-tests.js
@@ -5,6 +5,7 @@ var util = require('util')
 
 var pg = helper.pg
 const Client = pg.Client
+const DatabaseError = pg.DatabaseError
 
 var createErorrClient = function () {
   var client = helper.client()
@@ -140,6 +141,9 @@ suite.test('when a query is binding', function (done) {
   )
 
   assert.emits(query, 'error', function (err) {
+    if (!helper.config.native) {
+      assert(err instanceof DatabaseError);
+    }
     assert.equal(err.severity, 'ERROR')
     ensureFuture(client, done)
   })
@@ -213,6 +217,9 @@ suite.test('within a simple query', (done) => {
   var query = client.query(new pg.Query("select eeeee from yodas_dsflsd where pixistix = 'zoiks!!!'"))
 
   assert.emits(query, 'error', function (error) {
+    if (!helper.config.native) {
+      assert(error instanceof DatabaseError);
+    }
     assert.equal(error.severity, 'ERROR')
     done()
   })

--- a/packages/pg/test/integration/client/error-handling-tests.js
+++ b/packages/pg/test/integration/client/error-handling-tests.js
@@ -142,7 +142,7 @@ suite.test('when a query is binding', function (done) {
 
   assert.emits(query, 'error', function (err) {
     if (!helper.config.native) {
-      assert(err instanceof DatabaseError);
+      assert(err instanceof DatabaseError)
     }
     assert.equal(err.severity, 'ERROR')
     ensureFuture(client, done)
@@ -218,7 +218,7 @@ suite.test('within a simple query', (done) => {
 
   assert.emits(query, 'error', function (error) {
     if (!helper.config.native) {
-      assert(error instanceof DatabaseError);
+      assert(error instanceof DatabaseError)
     }
     assert.equal(error.severity, 'ERROR')
     done()

--- a/packages/pg/test/integration/client/query-error-handling-tests.js
+++ b/packages/pg/test/integration/client/query-error-handling-tests.js
@@ -2,6 +2,7 @@
 var helper = require('./test-helper')
 var util = require('util')
 var Query = helper.pg.Query
+var DatabaseError = helper.pg.DatabaseError;
 
 test('error during query execution', function () {
   var client = new Client(helper.args)
@@ -74,6 +75,9 @@ test('9.3 column error fields', function () {
 
           client.query('CREATE TEMP TABLE column_err_test(a int NOT NULL)')
           client.query('INSERT INTO column_err_test(a) VALUES (NULL)', function (err) {
+            if (!helper.config.native) {
+              assert(err instanceof DatabaseError);
+            }
             assert.equal(err.severity, 'ERROR')
             assert.equal(err.code, '23502')
             assert.equal(err.table, 'column_err_test')
@@ -102,6 +106,9 @@ test('9.3 constraint error fields', function () {
           client.query('CREATE TEMP TABLE constraint_err_test(a int PRIMARY KEY)')
           client.query('INSERT INTO constraint_err_test(a) VALUES (1)')
           client.query('INSERT INTO constraint_err_test(a) VALUES (1)', function (err) {
+            if (!helper.config.native) {
+              assert(err instanceof DatabaseError);
+            }
             assert.equal(err.severity, 'ERROR')
             assert.equal(err.code, '23505')
             assert.equal(err.table, 'constraint_err_test')

--- a/packages/pg/test/integration/client/query-error-handling-tests.js
+++ b/packages/pg/test/integration/client/query-error-handling-tests.js
@@ -2,7 +2,7 @@
 var helper = require('./test-helper')
 var util = require('util')
 var Query = helper.pg.Query
-var DatabaseError = helper.pg.DatabaseError;
+var DatabaseError = helper.pg.DatabaseError
 
 test('error during query execution', function () {
   var client = new Client(helper.args)
@@ -76,7 +76,7 @@ test('9.3 column error fields', function () {
           client.query('CREATE TEMP TABLE column_err_test(a int NOT NULL)')
           client.query('INSERT INTO column_err_test(a) VALUES (NULL)', function (err) {
             if (!helper.config.native) {
-              assert(err instanceof DatabaseError);
+              assert(err instanceof DatabaseError)
             }
             assert.equal(err.severity, 'ERROR')
             assert.equal(err.code, '23502')
@@ -107,7 +107,7 @@ test('9.3 constraint error fields', function () {
           client.query('INSERT INTO constraint_err_test(a) VALUES (1)')
           client.query('INSERT INTO constraint_err_test(a) VALUES (1)', function (err) {
             if (!helper.config.native) {
-              assert(err instanceof DatabaseError);
+              assert(err instanceof DatabaseError)
             }
             assert.equal(err.severity, 'ERROR')
             assert.equal(err.code, '23505')


### PR DESCRIPTION
Before, users would have to import DatabaseError from 'pg-protocol'.  If
there are multiple versions of 'pg-protocol', you might end up using the
wrong one.

Closes #2378