### PR TITLE
Fix README to separate sponsors onto separate lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,16 @@ You can also follow me [@briancarlson](https://twitter.com/briancarlson) if that
 node-postgres's continued development has been made possible in part by generous finanical support from [the community](https://github.com/brianc/node-postgres/blob/master/SPONSORS.md) and these featured sponsors:
 
 <div align="center">
-<a href="https://crate.io" target="_blank">
-  <img height="80" src="https://node-postgres.com/crate-io.png" />
-</a>
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAABCAQAAAB0m0auAAAADElEQVR42mNkIBIAAABSAAI2VLqiAAAAAElFTkSuQmCC" />
-<a href="https://www.eaze.com" target="_blank">
-  <img height="80" src="https://node-postgres.com/eaze.png" />
-</a>
+  <p>
+    <a href="https://crate.io" target="_blank">
+      <img height="80" src="https://node-postgres.com/crate-io.png" />
+    </a>
+  </p>
+  <p>
+    <a href="https://www.eaze.com" target="_blank">
+      <img height="80" src="https://node-postgres.com/eaze.png" />
+    </a>
+  </p>
 </div>
 
 If you or your company are benefiting from node-postgres and would like to help keep the project financially sustainable [please consider supporting](https://github.com/sponsors/brianc) its development.


### PR DESCRIPTION
I noticed that the sponsor links show up side to side so it looks like it's one company named "*CrateDBeaze*". This splits them out onto separate lines. Also gets rid of an inline png that wasn't actually be rendered.