### PR TITLE
Add ParameterDescription message to pg-protocol

### DIFF
--- a/packages/pg-protocol/src/inbound-parser.test.ts
+++ b/packages/pg-protocol/src/inbound-parser.test.ts
@@ -144,6 +144,35 @@ var expectedTwoRowMessage = {
   ],
 }
 
+var emptyParameterDescriptionBuffer = new BufferList()
+  .addInt16(0) // number of parameters
+  .join(true, 't')
+
+var oneParameterDescBuf = buffers.parameterDescription([1111])
+
+var twoParameterDescBuf = buffers.parameterDescription([2222, 3333])
+
+var expectedEmptyParameterDescriptionMessage = {
+  name: 'parameterDescription',
+  length: 6,
+  parameterCount: 0,
+  dataTypeIDs: [],
+}
+
+var expectedOneParameterMessage = {
+  name: 'parameterDescription',
+  length: 10,
+  parameterCount: 1,
+  dataTypeIDs: [1111],
+}
+
+var expectedTwoParameterMessage = {
+  name: 'parameterDescription',
+  length: 14,
+  parameterCount: 2,
+  dataTypeIDs: [2222, 3333],
+}
+
 var testForMessage = function (buffer: Buffer, expectedMessage: any) {
   it('recieves and parses ' + expectedMessage.name, async () => {
     const messages = await parseBuffers([buffer])
@@ -243,6 +272,12 @@ describe('PgPacketStream', function () {
     testForMessage(emptyRowDescriptionBuffer, expectedEmptyRowDescriptionMessage)
     testForMessage(oneRowDescBuff, expectedOneRowMessage)
     testForMessage(twoRowBuf, expectedTwoRowMessage)
+  })
+
+  describe('parameterDescription messages', function () {
+    testForMessage(emptyParameterDescriptionBuffer, expectedEmptyParameterDescriptionMessage)
+    testForMessage(oneParameterDescBuf, expectedOneParameterMessage)
+    testForMessage(twoParameterDescBuf, expectedTwoParameterMessage)
   })
 
   describe('parsing rows', function () {

--- a/packages/pg-protocol/src/messages.ts
+++ b/packages/pg-protocol/src/messages.ts
@@ -11,6 +11,7 @@ export type MessageName =
   | 'copyDone'
   | 'copyData'
   | 'rowDescription'
+  | 'parameterDescription'
   | 'parameterStatus'
   | 'backendKeyData'
   | 'notification'
@@ -149,6 +150,14 @@ export class RowDescriptionMessage {
   public readonly fields: Field[]
   constructor(public readonly length: number, public readonly fieldCount: number) {
     this.fields = new Array(this.fieldCount)
+  }
+}
+
+export class ParameterDescriptionMessage {
+  public readonly name: MessageName = 'parameterDescription'
+  public readonly dataTypeIDs: number[]
+  constructor(public readonly length: number, public readonly parameterCount: number) {
+    this.dataTypeIDs = new Array(this.parameterCount)
   }
 }
 

--- a/packages/pg-protocol/src/testing/test-buffers.ts
+++ b/packages/pg-protocol/src/testing/test-buffers.ts
@@ -62,6 +62,16 @@ const buffers = {
     return buf.join(true, 'T')
   },
 
+  parameterDescription: function (dataTypeIDs: number[]) {
+    dataTypeIDs = dataTypeIDs || []
+    var buf = new BufferList()
+    buf.addInt16(dataTypeIDs.length)
+    dataTypeIDs.forEach(function (dataTypeID) {
+      buf.addInt32(dataTypeID)
+    })
+    return buf.join(true, 't')
+  },
+
   dataRow: function (columns: any[]) {
     columns = columns || []
     var buf = new BufferList()


### PR DESCRIPTION
The PostgreSQL server replies with a series of messages, including a ParameterDescription message, when the description of a prepared statement is requested. This pull request implements parsing this message type according to the documentation of the PostgreSQL protocol (see https://www.postgresql.org/docs/12/protocol-message-formats.html).