### PR TITLE
Fix error in TS client packages with '--isolatedModules':

### DIFF
--- a/packages/pg-protocol/src/messages.ts
+++ b/packages/pg-protocol/src/messages.ts
@@ -1,6 +1,6 @@
 export type Mode = 'text' | 'binary'
 
-export const enum MessageName {
+export enum MessageName {
   parseComplete = 'parseComplete',
   bindComplete = 'bindComplete',
   closeComplete = 'closeComplete',


### PR DESCRIPTION
`error TS2748: Cannot access ambient const enums when the '--isolatedModules' flag is provided.`