### PR TITLE
[pg-protocol] patch out the const enum in messages.d.ts

### DIFF
--- a/packages/pg-protocol/package.json
+++ b/packages/pg-protocol/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "test": "mocha dist/**/*.test.js",
-    "build": "tsc",
+    "build": "tsc && node script/remove-public-const-enum.js",
     "build:watch": "tsc --watch",
     "prepublish": "yarn build",
     "pretest": "yarn build"

--- a/packages/pg-protocol/script/remove-public-const-enum.js
+++ b/packages/pg-protocol/script/remove-public-const-enum.js
@@ -1,0 +1,93 @@
+// This task would be better served by recast or something like that.
+// https://github.com/travellocal/babel-plugin-declare-const-enum is a good starting point for that.
+
+const fs = require('fs')
+const path = require('path')
+
+const filepath = path.join(__dirname, '../dist/messages.d.ts')
+const backuppath = path.join(__dirname, '../dist/messages.const-enum.d.ts')
+/** @type {string} */
+let srcpath
+// use the filepath if it's newer
+try {
+  const backupStat = fs.statSync(backuppath)
+  const fileStat = fs.statSync(filepath)
+  srcpath = fileStat.mtimeMs > backupStat.mtimeMs ? filepath : backuppath
+} catch (err) {
+  if (err.code !== 'ENOENT') {
+    throw err
+  }
+  srcpath = filepath
+}
+const src = fs.readFileSync(srcpath, 'utf8')
+if (srcpath === filepath) {
+  fs.writeFileSync(backuppath, src, 'utf8')
+}
+
+/** @type {({startIndex: number, endIndex: number, content: string})[]} */
+let replacements = []
+
+// find the const enum declarations
+const startRe = /(^|\n)export declare const enum ([A-Za-z][A-Za-z0-9]+) \{\n*/g
+const endRe = /\n\}/g
+
+const constEnums = {}
+
+/** @type {RegExpExecArray | null} */
+let match
+while ((match = startRe.exec(src))) {
+  const startIndex = match.index
+  const name = match[2]
+  const contentStartIndex = (endRe.lastIndex = startRe.lastIndex)
+  const end = endRe.exec(src)
+  if (!end) break
+  const contentEndIndex = end.index
+  const endIndex = (startRe.lastIndex = endRe.lastIndex)
+
+  // collect the members of the const enum
+  const constEnumContent = src.slice(contentStartIndex, contentEndIndex)
+  const itemRe = /\b([A-Za-z][A-Za-z0-9]+)\s*=\s*(.+),/g
+  const lastRe = /\b([A-Za-z][A-Za-z0-9]+)\s*=\s*(.+)/g
+
+  const enumItems = (constEnums[name] = {})
+  const enumValueLiterals = []
+
+  /** @type {RegExpExecArray | null} */
+  let itemMatch
+  while ((itemMatch = itemRe.exec(constEnumContent))) {
+    enumValueLiterals.push((enumItems[itemMatch[1]] = itemMatch[2]))
+    lastRe.lastIndex = itemRe.lastIndex
+  }
+  itemMatch = lastRe.exec(constEnumContent)
+  if (itemMatch) {
+    enumValueLiterals.push((enumItems[itemMatch[1]] = itemMatch[2]))
+  }
+
+  replacements.push({
+    startIndex,
+    endIndex,
+    content: `${match[1]}export type ${name} =\n${enumValueLiterals.map((s) => `    | ${s}`).join('\n')};`,
+  })
+}
+
+if (replacements.length > 0) {
+  // replace the const enum declarations with a literal type union
+  let out = replacements
+    .sort((a, b) => a.startIndex - b.startIndex)
+    .reduce((out, { endIndex, content }, i, r) => {
+      const next = r[i + 1]
+      return out + content + src.slice(endIndex, next && next.startIndex)
+    }, src.slice(0, replacements[0].startIndex))
+
+  // replace references to the enum with the literals
+  for (const enumName of Object.keys(constEnums)) {
+    const enumItems = constEnums[enumName]
+    const re = new RegExp(`\\b${enumName}\\.(${Object.keys(enumItems).join('|')})\\b`, 'g')
+
+    out = out.replace(re, (s, enumItemName) => enumItems[enumItemName])
+  }
+
+  fs.writeFileSync(filepath, out, 'utf8')
+  const now = new Date()
+  fs.utimesSync(backuppath, now, now)
+}


### PR DESCRIPTION
Alternative fix to #2473

This is the diff it generates to the typedefs:

```patch
--- dist/messages.const-enum.d.ts	2021-03-11 15:16:01.000000000 -0800
+++ dist/messages.d.ts	2021-03-11 15:16:01.000000000 -0800
@@ -1,33 +1,32 @@
 /// <reference types="node" />
 export declare type Mode = 'text' | 'binary';
-export declare const enum MessageName {
-    parseComplete = "parseComplete",
-    bindComplete = "bindComplete",
-    closeComplete = "closeComplete",
-    noData = "noData",
-    portalSuspended = "portalSuspended",
-    replicationStart = "replicationStart",
-    emptyQuery = "emptyQuery",
-    copyDone = "copyDone",
-    copyData = "copyData",
-    rowDescription = "rowDescription",
-    parameterStatus = "parameterStatus",
-    backendKeyData = "backendKeyData",
-    notification = "notification",
-    readyForQuery = "readyForQuery",
-    commandComplete = "commandComplete",
-    dataRow = "dataRow",
-    copyInResponse = "copyInResponse",
-    copyOutResponse = "copyOutResponse",
-    authenticationOk = "authenticationOk",
-    authenticationMD5Password = "authenticationMD5Password",
-    authenticationCleartextPassword = "authenticationCleartextPassword",
-    authenticationSASL = "authenticationSASL",
-    authenticationSASLContinue = "authenticationSASLContinue",
-    authenticationSASLFinal = "authenticationSASLFinal",
-    error = "error",
-    notice = "notice"
-}
+export type MessageName =
+    | "parseComplete"
+    | "bindComplete"
+    | "closeComplete"
+    | "noData"
+    | "portalSuspended"
+    | "replicationStart"
+    | "emptyQuery"
+    | "copyDone"
+    | "copyData"
+    | "rowDescription"
+    | "parameterStatus"
+    | "backendKeyData"
+    | "notification"
+    | "readyForQuery"
+    | "commandComplete"
+    | "dataRow"
+    | "copyInResponse"
+    | "copyOutResponse"
+    | "authenticationOk"
+    | "authenticationMD5Password"
+    | "authenticationCleartextPassword"
+    | "authenticationSASL"
+    | "authenticationSASLContinue"
+    | "authenticationSASLFinal"
+    | "error"
+    | "notice";
 export interface BackendMessage {
     name: MessageName;
     length: number;
@@ -83,7 +82,7 @@
 export declare class CopyDataMessage {
     readonly length: number;
     readonly chunk: Buffer;
-    readonly name = MessageName.copyData;
+    readonly name = "copyData";
     constructor(length: number, chunk: Buffer);
 }
 export declare class CopyResponse {
@@ -161,7 +160,7 @@
     readonly length: number;
     readonly message: string | undefined;
     constructor(length: number, message: string | undefined);
-    readonly name = MessageName.notice;
+    readonly name = "notice";
     severity: string | undefined;
     code: string | undefined;
     detail: string | undefined;
```