### PR TITLE
Implement a `PoolError` with dedicated codes

### DIFF
--- a/packages/pg-pool/README.md
+++ b/packages/pg-pool/README.md
@@ -331,6 +331,20 @@ var bluebirdPool = new Pool({
 
 __please note:__ in node `<=0.12.x` the pool will throw if you do not provide a promise constructor in one of the two ways mentioned above.  In node `>=4.0.0` the pool will use the native promise implementation by default; however, the two methods above still allow you to "bring your own."
 
+## error management
+
+Errors throwed by the pool are instances of `PoolError`. Each `PoolError` has a message (short description of the exception) and a structured code composed of 5 characters string starting with letter `Z`.
+The following table list the existing `PoolError`s and their code:
+
+| Code  | Message                                                                  |
+| ----- | ------------------------------------------------------------------------ |
+| Z0001 | Cannot use a pool after calling end on the pool                          |
+| Z0002 | Passing a function as the first parameter to pool.query is not supported |
+| Z0003 | Release called on client which has already been released to the pool     |
+| Z0004 | Called end on pool more than once                                        |
+| Z0005 | Timeout exceeded when trying to connect                                  |
+| Z0009 | Unexpected condition                                                     |
+
 ## maxUses and read-replica autoscaling (e.g. AWS Aurora)
 
 The maxUses config option can help an application instance rebalance load against a replica set that has been auto-scaled after the connection pool is already full of healthy connections.

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -24,7 +24,7 @@ class PendingItem {
 }
 
 function throwOnDoubleRelease() {
-  throw new Error('Release called on client which has already been released to the pool.')
+  throw new PoolError('Release called on client which has already been released to the pool.', 'Z0003')
 }
 
 function promisify(Promise, callback) {
@@ -56,6 +56,15 @@ function makeIdleListener(pool, client) {
     // the client has already been closed & purged and is unusable
     pool.emit('error', err, client)
   }
+}
+
+class PoolError extends Error {
+    // A PoolError is an error throwed during a Pool process. Each type of error contains a specific "code".
+    // Please document in README file the error codes.
+    constructor(message, code) {
+        super(message)
+        this.code = code
+    }
 }
 
 class Pool extends EventEmitter {
@@ -143,7 +152,7 @@ class Pool extends EventEmitter {
     if (!this._isFull()) {
       return this.newClient(pendingItem)
     }
-    throw new Error('unexpected condition')
+    throw new PoolError('unexpected condition', 'Z0009')
   }
 
   _remove(client) {
@@ -160,7 +169,7 @@ class Pool extends EventEmitter {
 
   connect(cb) {
     if (this.ending) {
-      const err = new Error('Cannot use a pool after calling end on the pool')
+      const err = new PoolError('Cannot use a pool after calling end on the pool', 'Z0001')
       return cb ? cb(err) : this.Promise.reject(err)
     }
 
@@ -192,7 +201,7 @@ class Pool extends EventEmitter {
         // we're going to call it with a timeout error
         removeWhere(this._pendingQueue, (i) => i.callback === queueCallback)
         pendingItem.timedOut = true
-        response.callback(new Error('timeout exceeded when trying to connect'))
+        response.callback(new PoolError('timeout exceeded when trying to connect', 'Z0005'))
       }, this.options.connectionTimeoutMillis)
 
       this._pendingQueue.push(pendingItem)
@@ -334,7 +343,7 @@ class Pool extends EventEmitter {
     if (typeof text === 'function') {
       const response = promisify(this.Promise, text)
       setImmediate(function () {
-        return response.callback(new Error('Passing a function as the first parameter to pool.query is not supported'))
+        return response.callback(new PoolError('Passing a function as the first parameter to pool.query is not supported', 'Z0002'))
       })
       return response.result
     }
@@ -385,7 +394,7 @@ class Pool extends EventEmitter {
   end(cb) {
     this.log('ending')
     if (this.ending) {
-      const err = new Error('Called end on pool more than once')
+      const err = new PoolError('Called end on pool more than once', 'Z0004')
       return cb ? cb(err) : this.Promise.reject(err)
     }
     this.ending = true
@@ -408,3 +417,5 @@ class Pool extends EventEmitter {
   }
 }
 module.exports = Pool
+module.exports.Pool = Pool
+module.exports.PoolError = PoolError


### PR DESCRIPTION
Previously the Pool was throwing built-in JS `Error`. It's therefore difficult to identify each kind of error.
This patch allow the developer to identify each type of error raised by the Pool with a `PoolError`.

Each `PoolError` has its own code and a message (original message for backward compatibility).

Codes and errors are documented in README file.