### PR TITLE
fix(pg-cursor): EventEmitter memory leak

### DIFF
--- a/packages/pg-cursor/index.js
+++ b/packages/pg-cursor/index.js
@@ -28,6 +28,9 @@ util.inherits(Cursor, EventEmitter)
 Cursor.prototype._ifNoData = function () {
   this.state = 'idle'
   this._shiftQueue()
+  if (this.connection) {
+    this.connection.removeListener('rowDescription', this._rowDescription)
+  }
 }
 
 Cursor.prototype._rowDescription = function () {


### PR DESCRIPTION
You will got warning `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 rowDescription listeners added to [Connection]. Use emitter.setMaxListeners() to increase limit` when use cursor for insert without returning.

This PR can fix the issue.