### PR TITLE
util in connection not used

### DIFF
--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -2,7 +2,6 @@
 
 var net = require('net')
 var EventEmitter = require('events').EventEmitter
-var util = require('util')
 
 const { parse, serialize } = require('pg-protocol')
 


### PR DESCRIPTION
Removing `require('util')` that is not used.