### PR TITLE
chore(pg-query-stream): remove through dependency

### DIFF
--- a/packages/pg-query-stream/package.json
+++ b/packages/pg-query-stream/package.json
@@ -40,7 +40,6 @@
     "pg": "^8.5.1",
     "stream-spec": "~0.3.5",
     "stream-tester": "0.0.5",
-    "through": "~2.3.4",
     "ts-node": "^8.5.4",
     "typescript": "^4.0.3"
   },

--- a/packages/pg-query-stream/test/concat.ts
+++ b/packages/pg-query-stream/test/concat.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import concat from 'concat-stream'
-import through from 'through'
+import { Transform } from 'stream'
 import helper from './helper'
 import QueryStream from '../src'
 
@@ -10,8 +10,11 @@ helper('concat', function (client) {
     const query = client.query(stream)
     query
       .pipe(
-        through(function (row) {
-          this.push(row.num)
+        new Transform({
+          transform(chunk, _, callback) {
+            callback(null, chunk.num)
+          },
+          objectMode: true,
         })
       )
       .pipe(


### PR DESCRIPTION
I was browsing through the tests for the `pg-query-stream` package to see how to wire a transform stream to the output and the dependency seemed unnecessary to me. Hence this PR is removing it and replacing it with a [stream.Transform](https://nodejs.org/docs/latest/api/stream.html#stream_new_stream_transform_options).

If you think changes like this are worthwhile I can have a look through the other packages for similar "easy" PRs to get started contributing to `pg`.