### PR TITLE
Fix and enable pool `verify` option test

### DIFF
--- a/packages/pg-pool/test/verify.js
+++ b/packages/pg-pool/test/verify.js
@@ -7,10 +7,9 @@ const it = require('mocha').it
 const Pool = require('../')
 
 describe('verify', () => {
-  it('verifies a client with a callback', false, (done) => {
+  it('verifies a client with a callback', (done) => {
     const pool = new Pool({
       verify: (client, cb) => {
-        client.release()
         cb(new Error('nope'))
       },
     })


### PR DESCRIPTION
by not double-releasing.