### PR TITLE
Remove broken test

### DIFF
--- a/packages/pg-pool/test/error-handling.js
+++ b/packages/pg-pool/test/error-handling.js
@@ -65,18 +65,6 @@ describe('pool error handling', function () {
     })
   })
 
-  describe('calling connect after end', () => {
-    it('should return an error', function* () {
-      const pool = new Pool()
-      const res = yield pool.query('SELECT $1::text as name', ['hi'])
-      expect(res.rows[0].name).to.equal('hi')
-      const wait = pool.end()
-      pool.query('select now()')
-      yield wait
-      expect(() => pool.query('select now()')).to.reject()
-    })
-  })
-
   describe('using an ended pool', () => {
     it('rejects all additional promises', (done) => {
       const pool = new Pool()


### PR DESCRIPTION
It’s missing `co.wrap`, so it doesn’t actually run (Mocha does nothing with the paused generator). The test group that follows it, “using an ended pool”, covers the same thing anyway.