### PR TITLE
Making package compatible with ESM

### DIFF
--- a/packages/pg/lib/index.js
+++ b/packages/pg/lib/index.js
@@ -14,21 +14,23 @@ const poolFactory = (Client) => {
   }
 }
 
-var PG = function (clientConstructor) {
-  this.defaults = defaults
-  this.Client = clientConstructor
-  this.Query = this.Client.Query
-  this.Pool = poolFactory(this.Client)
-  this._pools = []
-  this.Connection = Connection
-  this.types = require('pg-types')
-  this.DatabaseError = DatabaseError
+module.exports = {
+  defaults: defaults,
+  _pools: [],
+  Connection: Connection,
+  types: require('pg-types'),
+  DatabaseError: DatabaseError,
 }
 
 if (typeof process.env.NODE_PG_FORCE_NATIVE !== 'undefined') {
-  module.exports = new PG(require('./native'))
+  var nativeClient = require('./native')
+  module.exports.Client = nativeClient
+  module.exports.Query = nativeClient.Query
+  module.exports.Pool = poolFactory(nativeClient)
 } else {
-  module.exports = new PG(Client)
+  module.exports.Client = Client
+  module.exports.Query = Client.Query
+  module.exports.Pool = poolFactory(Client)
 
   // lazy require native module...the native module may not have installed
   Object.defineProperty(module.exports, 'native', {


### PR DESCRIPTION
In recent version of node, node is using [cjs-module-lexer](https://github.com/guybedford/cjs-module-lexer) to try to detect names of exports in CJS modules. It is doing static analysis so it cannot detect everything. Previously this package was using a function which throw things off, but I do not there was much benefit of having that, or am I missing something? I simplified it into a simple object and now node can import it as a ESM module. Tested with node v16.0.0. E.g.:

```
import { Client } from 'pg';
```