### PR TITLE
Use _isFull instead of duplicating clients check

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -168,7 +168,7 @@ class Pool extends EventEmitter {
     const result = response.result
 
     // if we don't have to connect a new client, don't do so
-    if (this._clients.length >= this.options.max || this._idle.length) {
+    if (this._isFull() || this._idle.length) {
       // if we have idle clients schedule a pulse immediately
       if (this._idle.length) {
         process.nextTick(() => this._pulseQueue())


### PR DESCRIPTION
Noticed that options.max is compared against client count directly, but there's a method wrapping it. I can't see any reason to duplicate it? And using _isFull means I can override that for the adaptive pooling idea I'm exploring :)