### PR TITLE
Add Cursor to index.js's module.exports

### DIFF
--- a/packages/pg/lib/index.js
+++ b/packages/pg/lib/index.js
@@ -23,6 +23,14 @@ var PG = function (clientConstructor) {
   this.Connection = Connection
   this.types = require('pg-types')
   this.DatabaseError = DatabaseError
+
+  try {
+    this.Cursor = require('pg-cursor')
+  } catch (err) {
+    if (err.code !== 'MODULE_NOT_FOUND') {
+      throw err
+    }
+  }
 }
 
 if (typeof process.env.NODE_PG_FORCE_NATIVE !== 'undefined') {


### PR DESCRIPTION
Even though the documentation refers to it as [pg.Cursor](https://node-postgres.com/api/cursor) it isn't actually defined in the library's index.js.

I don't completely get the argument why it wasn't added in the first place, but I am going to guess that it's because not everyone uses Cursors. I thought this would be an alright compromise between that.

One downside with this change, is the somewhat unexpected behaviour one might experience if they try to use `pg.Cursor` without `pg-cursor` installed. Best way to fix that downside is to simply add `pg-cursor` to the dependencies, and include it like Pool, but this might be unwanted?