### PR TITLE
Allow Node to exit if the pool is idle

### DIFF
--- a/packages/pg-pool/test/idle-timeout-exit.js
+++ b/packages/pg-pool/test/idle-timeout-exit.js
@@ -1,0 +1,16 @@
+// This test is meant to be spawned from idle-timeout.js
+if (module === require.main) {
+  const allowExitOnIdle = process.env.ALLOW_EXIT_ON_IDLE === '1'
+  const Pool = require('../index')
+
+  const pool = new Pool({ idleTimeoutMillis: 200, ...(allowExitOnIdle ? { allowExitOnIdle: true } : {}) })
+  pool.query('SELECT NOW()', (err, res) => console.log('completed first'))
+  pool.on('remove', () => {
+    console.log('removed')
+    done()
+  })
+
+  setTimeout(() => {
+    pool.query('SELECT * from generate_series(0, 1000)', (err, res) => console.log('completed second'))
+  }, 50)
+}

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -577,6 +577,14 @@ class Client extends EventEmitter {
     return result
   }
 
+  ref() {
+    this.connection.ref()
+  }
+
+  unref() {
+    this.connection.unref()
+  }
+
   end(cb) {
     this._ending = true
 

--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -177,6 +177,14 @@ class Connection extends EventEmitter {
     this._send(syncBuffer)
   }
 
+  ref() {
+    this.stream.ref()
+  }
+
+  unref() {
+    this.stream.unref()
+  }
+
   end() {
     // 0x58 = 'X'
     this._ending = true


### PR DESCRIPTION
Based on the suggestion from #2078.

Unfortunately I don't yet know how to test this under Mocha, as the whole point is to let Node exit, but I did test it with the following script:

```javascript
const Pool = require('./index')

const pool = new Pool({ idleTimeoutMillis: 1000 })
pool.query('SELECT NOW()', (err, res) => console.log(res))
pool.on('remove', () => {
  console.log('removed')
  done()
})

setTimeout(() => {
  pool.query('SELECT * from generate_series(0, 1000)', (err, res) => console.log(res))
}, 500)
```

The program waits for the idle timeout during the time between the first query and the second, but exits immediately after the second query has finished running. After the second query, Node's loop is empty, and since the idle timeout and the one connected socket are unref'd, Node can exit right away.

If anyone has any suggestions on how to test this under Mocha, I'm all ears.