### PR TITLE
Catch errors client throws in pool

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -375,20 +375,24 @@ class Pool extends EventEmitter {
 
       client.once('error', onError)
       this.log('dispatching query')
-      client.query(text, values, (err, res) => {
-        this.log('query dispatched')
-        client.removeListener('error', onError)
-        if (clientReleased) {
-          return
-        }
-        clientReleased = true
-        client.release(err)
-        if (err) {
-          return cb(err)
-        } else {
-          return cb(undefined, res)
-        }
-      })
+      try {
+        client.query(text, values, (err, res) => {
+          this.log('query dispatched')
+          client.removeListener('error', onError)
+          if (clientReleased) {
+            return
+          }
+          clientReleased = true
+          client.release(err)
+          if (err) {
+            return cb(err)
+          } else {
+            return cb(undefined, res)
+          }
+        })
+      } catch (err) {
+        return cb(err)
+      }
     })
     return response.result
   }

--- a/packages/pg-pool/test/error-handling.js
+++ b/packages/pg-pool/test/error-handling.js
@@ -37,6 +37,17 @@ describe('pool error handling', function () {
     })
   })
 
+  it('Catches errors in client.query', async function () {
+    await expect((new Pool()).query(null)).to.throwError()
+    await expect(async () => {
+      try {
+        await (new Pool()).query(null)
+      } catch (e) {
+        console.log(e)
+      }
+    }).not.to.throwError()
+  })
+
   describe('calling release more than once', () => {
     it(
       'should throw each time',


### PR DESCRIPTION
Old behavior: if you do something like

```js
try {
  await (new Pool()).query(null);
} catch (error) {
  console.log(error);
}
```

you get an uncaught exception. If you have a server that generates text to pass in to query the pool, it will crash your server.

New behavior: This change catches the error thrown at https://github.com/zlotnika/node-postgres/blob/master/packages/pg/lib/client.js#L505 and treats it the same as it does with any other. This way, a query of `null` works similarly to a query of `'over 9000'` or `new Date()` or whatever other not-so-SQL-y thing you come up with.

An alternate solution would be to call the callback with an error in the client instead of throwing an error. I personally prefer throw-catching.