### PR TITLE
Only call queryCallback if it's valid

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -546,7 +546,7 @@ class Client extends EventEmitter {
 
       query.callback = (err, res) => {
         clearTimeout(readTimeoutTimer)
-        queryCallback(err, res)
+        if (queryCallback) queryCallback(err, res)
       }
     }
 


### PR DESCRIPTION
If `query()` is called with a single object parameter (such as the example code in the [node-pg-copy-streams README](https://github.com/brianc/node-pg-copy-streams)) then there is no callback function available.  However if the query times out, the timeout function will try to call the handler anyway.

This small fix ensures the user callback will only be called if one was supplied.  It fixes the error:

    TypeError: queryCallback is not a function
        at Timeout._onTimeout (node_modules/pg/lib/client.js:532:9)
