### PR TITLE
ConnectionOptions interface is incompatible with @types/pg definitions

### DIFF
--- a/packages/pg-connection-string/index.d.ts
+++ b/packages/pg-connection-string/index.d.ts
@@ -5,7 +5,7 @@ export interface ConnectionOptions {
   password?: string
   user?: string
   port?: string | null
-  database: string | null | undefined
+  database: string | undefined
   client_encoding?: string
   ssl?: boolean | string
 


### PR DESCRIPTION
Using pg-connection-string with @types/pg currently results in a type error like this:

    Argument of type 'ConnectionOptions' is not assignable to parameter of type 'PoolConfig'.
      Types of property 'database' are incompatible.
        Type 'string | null | undefined' is not assignable to type 'string | undefined'.
          Type 'null' is not assignable to type 'string | undefined'.ts(2345)

See clashing definition: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/08f0feedca9329fe95d23ccc64886e3db03195bf/types/pg/index.d.ts#L18