### PR TITLE
Add config.query_timeout for query()

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -510,7 +510,7 @@ class Client extends EventEmitter {
         query.callback = query.callback || values
       }
     } else {
-      readTimeout = this.connectionParameters.query_timeout
+      readTimeout = config.query_timeout || this.connectionParameters.query_timeout
       query = new Query(config, values, callback)
       if (!query.callback) {
         result = new this._Promise((resolve, reject) => {


### PR DESCRIPTION
```js
client.query('select pg_sleep(10)', {query_timeout: 5})
  .then(...)
  .catch(error => { e.message == 'Query read timeout' })
```

Solve #2652