### PR TITLE
chore (ci): add macOS and Windows to the CI OS matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       matrix:
         node: ['8', '10', '12', '14', '16', '17']
-    name: Node ${{ matrix.node }}
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    name: Node.js ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2
       - name: Setup node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         node: ['8', '10', '12', '14', '16', '17']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     name: Node.js ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Hello.

This PR aims to add macOS and Windows to the CI OS matrix.
This way the tests will be run across the 3 major operating systems, making it easier to spot specific bugs and regressions.