### PR TITLE
[pg-cursor] Add query_timeout parameter to test code to trigger queryCallback bug

### DIFF
--- a/packages/pg-cursor/test/index.js
+++ b/packages/pg-cursor/test/index.js
@@ -6,7 +6,9 @@ const text = 'SELECT generate_series as num FROM generate_series(0, 5)'
 
 describe('cursor', function () {
   beforeEach(function (done) {
-    const client = (this.client = new pg.Client())
+    const client = (this.client = new pg.Client({
+      query_timeout: 15000,
+    }))
     client.connect(done)
 
     this.pgCursor = function (text, values) {


### PR DESCRIPTION
There is a bug in the query callback handling (e.g. #1860 #2560) but the test code doesn't pick it up.  This change ensures that code path runs in the tests, so it will probably make the tests fail until the bug is fixed.  (I say 'probably' because the exception doesn't get thrown until after all the tests have completed successfully.)

```
/srv/its-pf1pr0gd/code/node-postgres/packages/pg-cursor/node_modules/mocha/lib/runner.js:911
    throw err;                                                               
    ^                                                                        
                                                                             
TypeError: queryCallback is not a function                                   
    at Timeout._onTimeout (/srv/its-pf1pr0gd/code/node-postgres/packages/pg-cursor/node_modules/pg/lib/client.js:532:9)
    at listOnTimeout (node:internal/timers:557:17)                           
    at processTimers (node:internal/timers:500:7)
```