### PR TITLE
chore (ci): trigger a CI run on PR events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Hello.

This PR aims to add the ability to trigger a CI run on Pull Request events.

_NB: there is an integrated GitHub Action security mechanism that require a manual authorization for 1st time contributors to prevent any CI abuse ^^_