### PR TITLE
add support for user lookup function

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -114,16 +114,28 @@ class Client extends EventEmitter {
     }
 
     // once connection is established send startup message
-    con.on('connect', function () {
+    con.on('connect', async function () {
       if (self.ssl) {
         con.requestSsl()
       } else {
-        con.startup(self.getStartupConf())
+        try {
+          const conf = await self.getStartupConf()
+          con.startup(conf)
+        }
+        catch(err) {
+          con.stream.destroy(err)
+        }
       }
     })
 
-    con.on('sslconnect', function () {
-      con.startup(self.getStartupConf())
+    con.on('sslconnect', async function () {
+      try {
+        const conf = await self.getStartupConf()
+        con.startup(conf)
+      }
+      catch(err) {
+        con.stream.destroy(err)
+      }
     })
 
     this._attachListeners(con)
@@ -385,11 +397,26 @@ class Client extends EventEmitter {
     this.emit('notice', msg)
   }
 
-  getStartupConf() {
+  async getStartupConf() {
     var params = this.connectionParameters
 
+    var user = params.user
+    if (typeof this.user === 'function') {
+      user = await this.user()
+
+      if (user !== undefined) {
+        if (typeof user !== 'string') {
+          throw new TypeError('User must be a string')
+          return
+        }
+        this.connectionParameters.user = this.user = user
+      } else {
+        this.connectionParameters.user = this.user = null
+      }
+    }
+
     var data = {
-      user: params.user,
+      user: user,
       database: params.database,
     }
 

--- a/packages/pg/test/integration/connection/dynamic-password-tests.js
+++ b/packages/pg/test/integration/connection/dynamic-password-tests.js
@@ -6,9 +6,10 @@ const pg = require('../../../lib/index')
 const Client = pg.Client
 
 const password = process.env.PGPASSWORD || null
+const user = process.env.PGUSER || null
 const sleep = (millis) => new Promise((resolve) => setTimeout(resolve, millis))
 
-if (!password) {
+if ((!password) || (!user)) {
   // skip these tests; no password will be requested
   return
 }
@@ -113,6 +114,111 @@ suite.testAsync('Password function must return a string', () => {
     })
     .then(() => {
       assert.ok(wasCalled, 'Our password function should have been called')
+      assert.ok(wasThrown, 'Our error should have been thrown')
+      return client.end()
+    })
+})
+
+suite.testAsync('Get user from a sync function', () => {
+  let wasCalled = false
+  function getUser() {
+    wasCalled = true
+    return user
+  }
+  const client = new Client({
+    user: getUser
+  })
+  return client.connect().then( async () => {
+    assert.ok(wasCalled, 'Our user function should have been called')
+    return client.end()
+  })
+})
+
+suite.testAsync('Throw error from user sync function', () => {
+  let wasCalled = false
+  const myError = new Error('Oops!')
+  function getUser() {
+    wasCalled = true
+    throw myError
+  }
+  const client = new Client({
+    user: getUser,
+  })
+  let wasThrown = false
+  return client
+    .connect()
+    .catch((err) => {
+      assert.equal(err, myError, 'Our sync error should have been thrown')
+      wasThrown = true
+    })
+    .then(() => {
+      assert.ok(wasCalled, 'Our user function should have been called')
+      assert.ok(wasThrown, 'Our error should have been thrown')
+      return client.end()
+    })
+})
+
+suite.testAsync('Get user from a function asynchronously', () => {
+  let wasCalled = false
+  function getUser() {
+    wasCalled = true
+    return sleep(100).then(() => user)
+  }
+  const client = new Client({
+    user: getUser,
+  })
+  return client.connect().then(() => {
+    assert.ok(wasCalled, 'Our user function should have been called')
+    return client.end()
+  })
+})
+
+suite.testAsync('Throw error from async user function', () => {
+  let wasCalled = false
+  const myError = new Error('Oops!')
+  function getUser() {
+    wasCalled = true
+    return sleep(100).then(() => {
+      throw myError
+    })
+  }
+  const client = new Client({
+    user: getUser,
+  })
+  let wasThrown = false
+  return client
+    .connect()
+    .catch((err) => {
+      assert.equal(err, myError, 'Our async error should have been thrown')
+      wasThrown = true
+    })
+    .then(() => {
+      assert.ok(wasCalled, 'Our user function should have been called')
+      assert.ok(wasThrown, 'Our error should have been thrown')
+      return client.end()
+    })
+})
+
+suite.testAsync('User function must return a string', () => {
+  let wasCalled = false
+  function getUser() {
+    wasCalled = true
+    // Return a user that is not a string
+    return 12345
+  }
+  const client = new Client({
+    user: getUser,
+  })
+  let wasThrown = false
+  return client
+    .connect()
+    .catch((err) => {
+      assert.ok(err instanceof TypeError, 'A TypeError should have been thrown')
+      assert.equal(err.message, 'User must be a string')
+      wasThrown = true
+    })
+    .then(() => {
+      assert.ok(wasCalled, 'Our user function should have been called')
       assert.ok(wasThrown, 'Our error should have been thrown')
       return client.end()
     })


### PR DESCRIPTION
Similar to the dynamic lookup of a password, this PR makes it possible to support a lookup of the user as well. This is needed for AWS RDS rotation where the username is (can, in some rotation schemes) rotated as well.