### PR TITLE
Support types/getTypeParser in query method for pg-native

### DIFF
--- a/packages/pg/lib/native/query.js
+++ b/packages/pg/lib/native/query.js
@@ -13,6 +13,7 @@ var NativeQuery = (module.exports = function (config, values, callback) {
   this.callback = config.callback
   this.state = 'new'
   this._arrayMode = config.rowMode === 'array'
+  this.types = config.types;
 
   // if the 'row' event is listened for
   // then emit them as they come in
@@ -87,9 +88,17 @@ NativeQuery.prototype.submit = function (client) {
   var self = this
   this.native = client.native
   client.native.arrayMode = this._arrayMode
+  var savedTypes;
+  if (this.types) {
+    savedTypes = client.native._types;
+    client.native._types = this.types;
+  }
 
   var after = function (err, rows, results) {
     client.native.arrayMode = false
+    if (savedTypes) {
+      client.native._types = savedTypes;
+    }
     setImmediate(function () {
       self.emit('_done')
     })


### PR DESCRIPTION
This fixes #2686

This is a simple fix that gets the job done. I've done the same thing that is done with `_arrayMode`: update the value on the `client.native` and then change it back when we are done.