### PR TITLE
[WIP][POC] Use pipelining mode

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -498,6 +498,10 @@ class Client extends EventEmitter {
       }
       this.blocked = query.blocking
       this.sentQueryQueue.push(query)
+      if (query.name) {
+        console.log(`we store that ${query.name} has been submitted`)
+        this.connection.submittedNamedStatements[query.name] = query.text
+      }
     }
 
     if (this.readyForQuery === true) {

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -56,8 +56,8 @@ class Client extends EventEmitter {
 
     // Client.sentQueryQueue is the queue of queries that have been sent on the wire
     this.sentQueryQueue = []
-    // Client.sendImmediately can be set to false to restore the previous behavior
-    this.sendImmediately = true
+    // Client.pipelining can be set to true to enable experimental pipelining mode
+    this.pipelining = false
 
     this.binary = c.binary || defaults.binary
     this.processID = null
@@ -484,7 +484,7 @@ class Client extends EventEmitter {
       return
     }
 
-    while ((this.sendImmediately && !this.blocked) || (this.activeQuery === null && this.sentQueryQueue.length === 0)) {
+    while ((this.pipelining && !this.blocked) || (this.activeQuery === null && this.sentQueryQueue.length === 0)) {
       var query = this.queryQueue.shift()
       if (!query) break
 

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -53,6 +53,12 @@ class Client extends EventEmitter {
         encoding: this.connectionParameters.client_encoding || 'utf8',
       })
     this.queryQueue = []
+
+    // Client.sentQueryQueue is the queue of queries that have been sent on the wire
+    this.sentQueryQueue = []
+    // Client.sendImmediately can be set to false to restore the previous behavior
+    this.sendImmediately = true
+
     this.binary = c.binary || defaults.binary
     this.processID = null
     this.secretKey = null
@@ -286,6 +292,7 @@ class Client extends EventEmitter {
     const { activeQuery } = this
     this.activeQuery = null
     this.readyForQuery = true
+    this.handshakeDone = true
     if (activeQuery) {
       activeQuery.handleReadyForQuery(this.connection)
     }
@@ -472,20 +479,32 @@ class Client extends EventEmitter {
   }
 
   _pulseQueryQueue() {
+
+    if (!this.handshakeDone) {
+      return
+    }
+
+    while ((this.sendImmediately && !this.blocked) || (this.activeQuery === null && this.sentQueryQueue.length === 0)) {
+      var query = this.queryQueue.shift()
+      if (!query) break
+
+      const queryError = query.submit(this.connection)
+      if (queryError) {
+        process.nextTick(() => {
+          this.activeQuery.handleError(queryError, this.connection)
+          this.readyForQuery = true
+          this._pulseQueryQueue()
+        })
+      }
+      this.blocked = query.blocking
+      this.sentQueryQueue.push(query)
+    }
+
     if (this.readyForQuery === true) {
-      this.activeQuery = this.queryQueue.shift()
+      this.activeQuery = this.sentQueryQueue.shift()
       if (this.activeQuery) {
         this.readyForQuery = false
         this.hasExecuted = true
-
-        const queryError = this.activeQuery.submit(this.connection)
-        if (queryError) {
-          process.nextTick(() => {
-            this.activeQuery.handleError(queryError, this.connection)
-            this.readyForQuery = true
-            this._pulseQueryQueue()
-          })
-        }
       } else if (this.hasExecuted) {
         this.activeQuery = null
         this.emit('drain')

--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -19,6 +19,8 @@ class Connection extends EventEmitter {
     this._keepAliveInitialDelayMillis = config.keepAliveInitialDelayMillis
     this.lastBuffer = false
     this.parsedStatements = {}
+    // to track preparation of statements submitted to server
+    this.submittedNamedStatements = {}
     this.ssl = config.ssl || false
     this._ending = false
     this._emitMessage = false

--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -160,6 +160,12 @@ class Query extends EventEmitter {
   }
 
   hasBeenParsed(connection) {
+    if (connection.submittedNamedStatements[this.name]) {
+      console.log(`-----------------------------------`)
+      console.log(`query.hasBeenParsed :  This statement has already been prepared`)
+      console.log(`-----------------------------------`)
+      return true
+    }
     return this.name && connection.parsedStatements[this.name]
   }
 

--- a/packages/pg/test/unit/client/simple-query-tests.js
+++ b/packages/pg/test/unit/client/simple-query-tests.js
@@ -60,6 +60,38 @@ test('executing query', function () {
     })
   })
 
+  test("multiple in the queue, pipelining mode", function () {
+    var client = helper.client()
+    client.pipelining = true
+    var connection = client.connection
+    var queries = connection.queries
+    client.query('one')
+    client.query('two')
+    client.query('three')
+    assert.empty(queries)
+
+    test("after one ready for query", function () {
+      connection.emit('readyForQuery')
+      assert.lengthIs(queries, 3)
+      assert.equal(queries[0], "one")
+    })
+
+    test('after two ready for query', function () {
+      connection.emit('readyForQuery')
+      assert.lengthIs(queries, 3)
+    })
+
+    test("after a bunch more", function () {
+      connection.emit('readyForQuery')
+      connection.emit('readyForQuery')
+      connection.emit('readyForQuery')
+      assert.lengthIs(queries, 3)
+      assert.equal(queries[0], "one")
+      assert.equal(queries[1], 'two')
+      assert.equal(queries[2], 'three')
+    })
+  })
+
   test('query event binding and flow', function () {
     var client = helper.client()
     var con = client.connection


### PR DESCRIPTION
Work in progress to adress #2646  
Base on the previous work of @jusou here https://github.com/brianc/node-postgres/pull/662, thx to him !

### Principle

In current behaviour of node-postgres, a query is not sent to the database until the previous query has completed and the associated result received.
With this PR, pipelining mode can be enabled, it allows the client to send all of the queries to the server up front, minimizing time spent by one side waiting for the other to finish sending data.

Important : pipelining has nothing to do with query execution concurrency/parallelism. With or without pipelining mode, the PostgreSQL server is executing the queries sequentially (while using parallelism capabilities if enabled), pipelining just allows both sides of the connection to work concurrently when possible, and to minimize round-trip time.  

The higher the latency is between the driver and the posgres serveur and the number of requests sent, the higher the performance gain will be.

### API changes 
- new property `client.pipelining` can be set to true to enable pipelining mode (default false)
```js
const client = await pg.connect()
client.pipelining = true
```

### Implementation  
 
- [ ] add tests
   - [ ] add unit tests 
       - [x] queries ready to emit
       - [ ] other ?
   - [ ]  add integration tests
       - [ ] TBD     
- [ ] currently it adress only js driver, not native one (I know nothing about the native driver, so I doubt I will be able to adress that)
- [ ] prepared statements are broken (probably because of race conditions in parsing), need to be fixed  
- [x] the default behaviour has to be defined (probably optout until we are sure it's safe) **false by default in this PR**
- [x] allow to optin (or optout, depending on the default) at the pool/client level **client.pipelining = true** 

While it's not finished, we are currently testing it with our product, with massive usage of queries (50 tasks in parallel sending each thousands of queries) and it seems to work (except of prepared statements).

I'm of course open to suggestions/review but I'm very busy nowadays thus don't be frustrated if I don't answer to remarks in a decent delay.

#### More details concerning the issue with the prepared statements broken in the PR : 

If we send immediatly 2 queries with the same named Foo,  we got the error `Prepared statement Foo already exists` 

Looks like the driver try to prepare the statement twice, probably because the event `parseComplete` has not been received yet for the 1st query, when the 2nd query is sent.

I'm a bit confused about how to find the proper place to fix it.
First I thought that it would be simple to debounce the parsing in https://github.com/brianc/node-postgres/blob/21ccd4f1b6e66774bbf24aecfccdbfe7c9b49238/packages/pg/lib/query.js#L36
by checking if connection.preparedStatements[this.name] exists  
but then I realized this check is already performed here :  
 https://github.com/brianc/node-postgres/blob/21ccd4f1b6e66774bbf24aecfccdbfe7c9b49238/packages/pg/lib/query.js#L192
so I don't truly understand why this error occurs 🤔   

If someone can help/give some hints, it would be useful !

#### Perf gain in our use case (⚠️  YMMV)

In our real application (payroll processing) :  
165 tasks, concurrency  between 1 and 40 :   
distributed on 4 clients  
each task is sending thousands of DML queries, mostly SELECT  

gain : 1 second (no gain expected because of no concurrency)
concurrency 1 w/o pipeline : 2m28s
concurrency 1 with pipeline : 2m27s

gain : 18 seconds
concurrency 5 w/o pipeline : 2m20s
concurrency 5 with pipeline : 2m02s

 gain : 25 seconds (test n°2 : 26 seconds)
concurrency 20 w/o pipeline : 2m22s (test 2 : 2m24s)
concurrency 20 with pipeline : 1m57s (test 2 : 1m58s)

gain : 27 seconds (test n°2 : 28 seconds)
concurrency 40 w/o pipeline : 2m20s (test 2 2m27s)
concurrency 40 with pipeline : 1m53s (test 2 1m59s

#### Conclusion : 
Very interesting gain of 20% with concurrency 40 (our default in production) 
It's also important to note that we have disabled prepared statements with pipelining mode due to the bug, so 
the gain is perhaps even greater (by <5% more I would say).