### PR TITLE
fix(pg-connection-string): get closer to libpq semantics for `sslmode`

### DIFF
--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -87,11 +87,11 @@ Query parameters follow a `?` character, including the following special query p
  * `host=<host>` - sets `host` property, overriding the URL's host
  * `encoding=<encoding>` - sets the `client_encoding` property
  * `ssl=1`, `ssl=true`, `ssl=0`, `ssl=false` - sets `ssl` to true or false, accordingly
- * `sslmode=<sslmode>`
+* `sslmode=<sslmode>`
    * `sslmode=disable` - sets `ssl` to false
-   * `sslmode=no-verify`, `sslmode=prefer`, - sets `ssl` to `{ rejectUnauthorized: false }`
-   * `sslmode=require`, - sets `ssl` to `{ rejectUnauthorized: false }` unless `sslrootcert` is specified, in which case it behaves like `verify-ca`
-   * `sslmode=verify-ca` - sets `ssl` to `{ checkServerIdentity: no-op}` (verify CA, but not server identity)
+   * `sslmode=no-verify`, `sslmode=prefer` - sets `ssl` to `{ rejectUnauthorized: false }`
+   * `sslmode=require` - sets `ssl` to `{ rejectUnauthorized: false }` unless `sslrootcert` is specified, in which case it behaves like `verify-ca`
+   * `sslmode=verify-ca` - sets `ssl` to `{ checkServerIdentity: no-op }` (verify CA, but not server identity)
    * `sslmode=verify-full` - sets `ssl` to `{}` (verify CA and server identity)
  * `sslcert=<filename>` - reads data from the given file and includes the result as `ssl.cert`
  * `sslkey=<filename>` - reads data from the given file and includes the result as `ssl.key`

--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -90,7 +90,7 @@ Query parameters follow a `?` character, including the following special query p
  * `sslcompat=libpq` - use libpq semantics for `sslmode`
  * `sslmode=<sslmode>` when `sslcompat=libpq`
    * `sslmode=disable` - sets `ssl` to false
-   * `sslmode=no-verify`, `sslmode=prefer` - sets `ssl` to `{ rejectUnauthorized: false }`
+   * `sslmode=prefer` - sets `ssl` to `{ rejectUnauthorized: false }`
    * `sslmode=require` - sets `ssl` to `{ rejectUnauthorized: false }` unless `sslrootcert` is specified, in which case it behaves like `verify-ca`
    * `sslmode=verify-ca` - sets `ssl` to `{ checkServerIdentity: no-op }` (verify CA, but not server identity). This verifies the presented certificate against the effective CA, i.e. the one specified in sslrootcert or the system CA if sslrootcert was not specified.
    * `sslmode=verify-full` - sets `ssl` to `{}` (verify CA and server identity)

--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -89,8 +89,10 @@ Query parameters follow a `?` character, including the following special query p
  * `ssl=1`, `ssl=true`, `ssl=0`, `ssl=false` - sets `ssl` to true or false, accordingly
  * `sslmode=<sslmode>`
    * `sslmode=disable` - sets `ssl` to false
-   * `sslmode=no-verify` - sets `ssl` to `{ rejectUnauthorized: false }`
-   * `sslmode=prefer`, `sslmode=require`, `sslmode=verify-ca`, `sslmode=verify-full` - sets `ssl` to true
+   * `sslmode=no-verify`, `sslmode=prefer`, - sets `ssl` to `{ rejectUnauthorized: false }`
+   * `sslmode=require`, - sets `ssl` to `{ rejectUnauthorized: false }` unless `sslrootcert` is specified, in which case it behaves like `verify-ca`
+   * `sslmode=verify-ca` - sets `ssl` to `{ checkServerIdentity: no-op}` (verify CA, but not server identity)
+   * `sslmode=verify-full` - sets `ssl` to `{}` (verify CA and server identity)
  * `sslcert=<filename>` - reads data from the given file and includes the result as `ssl.cert`
  * `sslkey=<filename>` - reads data from the given file and includes the result as `ssl.key`
  * `sslrootcert=<filename>` - reads data from the given file and includes the result as `ssl.ca`

--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -87,12 +87,17 @@ Query parameters follow a `?` character, including the following special query p
  * `host=<host>` - sets `host` property, overriding the URL's host
  * `encoding=<encoding>` - sets the `client_encoding` property
  * `ssl=1`, `ssl=true`, `ssl=0`, `ssl=false` - sets `ssl` to true or false, accordingly
-* `sslmode=<sslmode>`
+ * `sslcompat=libpq` - use libpq semantics for `sslmode`
+ * `sslmode=<sslmode>` when `sslcompat=libpq`
    * `sslmode=disable` - sets `ssl` to false
    * `sslmode=no-verify`, `sslmode=prefer` - sets `ssl` to `{ rejectUnauthorized: false }`
    * `sslmode=require` - sets `ssl` to `{ rejectUnauthorized: false }` unless `sslrootcert` is specified, in which case it behaves like `verify-ca`
    * `sslmode=verify-ca` - sets `ssl` to `{ checkServerIdentity: no-op }` (verify CA, but not server identity)
    * `sslmode=verify-full` - sets `ssl` to `{}` (verify CA and server identity)
+ * `sslmode=<sslmode>` when `sslcompat` is not set
+   * `sslmode=disable` - sets `ssl` to false
+   * `sslmode=no-verify` - sets `ssl` to `{ rejectUnauthorized: false }`
+   * `sslmode=prefer`, `sslmode=require`, `sslmode=verify-ca`, `sslmode=verify-full` - sets `ssl` to true
  * `sslcert=<filename>` - reads data from the given file and includes the result as `ssl.cert`
  * `sslkey=<filename>` - reads data from the given file and includes the result as `ssl.key`
  * `sslrootcert=<filename>` - reads data from the given file and includes the result as `ssl.ca`

--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -87,7 +87,7 @@ Query parameters follow a `?` character, including the following special query p
  * `host=<host>` - sets `host` property, overriding the URL's host
  * `encoding=<encoding>` - sets the `client_encoding` property
  * `ssl=1`, `ssl=true`, `ssl=0`, `ssl=false` - sets `ssl` to true or false, accordingly
- * `sslcompat=libpq` - use libpq semantics for `sslmode`
+ * `uselibpqcompat=true` - use libpq semantics
  * `sslmode=<sslmode>` when `sslcompat` is not set
    * `sslmode=disable` - sets `ssl` to false
    * `sslmode=no-verify` - sets `ssl` to `{ rejectUnauthorized: false }`

--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -96,7 +96,7 @@ Query parameters follow a `?` character, including the following special query p
    * `sslmode=disable` - sets `ssl` to false
    * `sslmode=prefer` - sets `ssl` to `{ rejectUnauthorized: false }`
    * `sslmode=require` - sets `ssl` to `{ rejectUnauthorized: false }` unless `sslrootcert` is specified, in which case it behaves like `verify-ca`
-   * `sslmode=verify-ca` - sets `ssl` to `{ checkServerIdentity: no-op }` (verify CA, but not server identity). This verifies the presented certificate against the effective CA, i.e. the one specified in sslrootcert or the system CA if sslrootcert was not specified.
+   * `sslmode=verify-ca` - sets `ssl` to `{ checkServerIdentity: no-op }` (verify CA, but not server identity). This verifies the presented certificate against the effective CA specified in sslrootcert.
    * `sslmode=verify-full` - sets `ssl` to `{}` (verify CA and server identity)
  * `sslcert=<filename>` - reads data from the given file and includes the result as `ssl.cert`
  * `sslkey=<filename>` - reads data from the given file and includes the result as `ssl.key`

--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -92,7 +92,7 @@ Query parameters follow a `?` character, including the following special query p
    * `sslmode=disable` - sets `ssl` to false
    * `sslmode=no-verify`, `sslmode=prefer` - sets `ssl` to `{ rejectUnauthorized: false }`
    * `sslmode=require` - sets `ssl` to `{ rejectUnauthorized: false }` unless `sslrootcert` is specified, in which case it behaves like `verify-ca`
-   * `sslmode=verify-ca` - sets `ssl` to `{ checkServerIdentity: no-op }` (verify CA, but not server identity)
+   * `sslmode=verify-ca` - sets `ssl` to `{ checkServerIdentity: no-op }` (verify CA, but not server identity). This verifies the presented certificate against the effective CA, i.e. the one specified in sslrootcert or the system CA if sslrootcert was not specified.
    * `sslmode=verify-full` - sets `ssl` to `{}` (verify CA and server identity)
  * `sslmode=<sslmode>` when `sslcompat` is not set
    * `sslmode=disable` - sets `ssl` to false

--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -88,18 +88,21 @@ Query parameters follow a `?` character, including the following special query p
  * `encoding=<encoding>` - sets the `client_encoding` property
  * `ssl=1`, `ssl=true`, `ssl=0`, `ssl=false` - sets `ssl` to true or false, accordingly
  * `sslcompat=libpq` - use libpq semantics for `sslmode`
+ * `sslmode=<sslmode>` when `sslcompat` is not set
+   * `sslmode=disable` - sets `ssl` to false
+   * `sslmode=no-verify` - sets `ssl` to `{ rejectUnauthorized: false }`
+   * `sslmode=prefer`, `sslmode=require`, `sslmode=verify-ca`, `sslmode=verify-full` - sets `ssl` to true
  * `sslmode=<sslmode>` when `sslcompat=libpq`
    * `sslmode=disable` - sets `ssl` to false
    * `sslmode=prefer` - sets `ssl` to `{ rejectUnauthorized: false }`
    * `sslmode=require` - sets `ssl` to `{ rejectUnauthorized: false }` unless `sslrootcert` is specified, in which case it behaves like `verify-ca`
    * `sslmode=verify-ca` - sets `ssl` to `{ checkServerIdentity: no-op }` (verify CA, but not server identity). This verifies the presented certificate against the effective CA, i.e. the one specified in sslrootcert or the system CA if sslrootcert was not specified.
    * `sslmode=verify-full` - sets `ssl` to `{}` (verify CA and server identity)
- * `sslmode=<sslmode>` when `sslcompat` is not set
-   * `sslmode=disable` - sets `ssl` to false
-   * `sslmode=no-verify` - sets `ssl` to `{ rejectUnauthorized: false }`
-   * `sslmode=prefer`, `sslmode=require`, `sslmode=verify-ca`, `sslmode=verify-full` - sets `ssl` to true
  * `sslcert=<filename>` - reads data from the given file and includes the result as `ssl.cert`
  * `sslkey=<filename>` - reads data from the given file and includes the result as `ssl.key`
  * `sslrootcert=<filename>` - reads data from the given file and includes the result as `ssl.ca`
 
 A bare relative URL, such as `salesdata`, will indicate a database name while leaving other properties empty.
+
+> [!CAUTION]
+> Choosing an sslmode other than verify-full has serious security implications. Please read https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS to understand the trade-offs.

--- a/packages/pg-connection-string/index.d.ts
+++ b/packages/pg-connection-string/index.d.ts
@@ -1,6 +1,11 @@
 import { ClientConfig } from 'pg'
 
-export function parse(connectionString: string): ConnectionOptions
+export function parse(connectionString: string, options: Options): ConnectionOptions
+
+export interface Options {
+  // Use libpq semantics when interpreting the connection string
+  useLibpqCompat?: boolean
+}
 
 export interface ConnectionOptions {
   host: string | null

--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -107,6 +107,11 @@ function parse(str) {
         break
       }
       case 'verify-ca': {
+        if (!config.ssl.ca) {
+          throw new Error(
+            'SECURITY WARNING: Using sslmode=verify-ca requires specifying a CA with sslrootcert. If a public CA is used, verify-ca allows connections to a server that somebody else may have registered with the CA, making you vulnerable to Man-in-the-Middle attacks. Either specify a custom CA certificate with sslrootcert parameter or use sslmode=verify-full for proper security.'
+          )
+        }
         config.ssl.checkServerIdentity = function () {}
         break
       }

--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -87,11 +87,11 @@ function parse(str, options = {}) {
     config.ssl.ca = fs.readFileSync(config.sslrootcert).toString()
   }
 
-  if (options.useLibpqCompat && config.sslcompat) {
-    throw new Error('Both useLibpqCompat and sslcompat are set. Please use only one of them.')
+  if (options.useLibpqCompat && config.uselibpqcompat) {
+    throw new Error('Both useLibpqCompat and uselibpqcompat are set. Please use only one of them.')
   }
 
-  if (config.sslcompat === 'libpq' || options.useLibpqCompat) {
+  if (config.uselibpqcompat === 'true' || options.useLibpqCompat) {
     switch (config.sslmode) {
       case 'disable': {
         config.ssl = false

--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -93,13 +93,24 @@ function parse(str) {
       break
     }
     case 'prefer':
-    case 'require':
-    case 'verify-ca':
-    case 'verify-full': {
-      break
-    }
     case 'no-verify': {
       config.ssl.rejectUnauthorized = false
+      break
+    }
+    case 'require': {
+      if (config.sslrootcert) {
+        // If a root CA is specified, behavior of `sslmode=require` will be the same as that of `verify-ca`
+        config.ssl.checkServerIdentity = function () {}
+      } else {
+        config.ssl.rejectUnauthorized = false
+      }
+      break
+    }
+    case 'verify-ca': {
+      config.ssl.checkServerIdentity = function () {}
+      break
+    }
+    case 'verify-full': {
       break
     }
   }

--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -93,8 +93,7 @@ function parse(str) {
         config.ssl = false
         break
       }
-      case 'prefer':
-      case 'no-verify': {
+      case 'prefer': {
         config.ssl.rejectUnauthorized = false
         break
       }

--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -87,31 +87,50 @@ function parse(str) {
     config.ssl.ca = fs.readFileSync(config.sslrootcert).toString()
   }
 
-  switch (config.sslmode) {
-    case 'disable': {
-      config.ssl = false
-      break
-    }
-    case 'prefer':
-    case 'no-verify': {
-      config.ssl.rejectUnauthorized = false
-      break
-    }
-    case 'require': {
-      if (config.sslrootcert) {
-        // If a root CA is specified, behavior of `sslmode=require` will be the same as that of `verify-ca`
-        config.ssl.checkServerIdentity = function () {}
-      } else {
-        config.ssl.rejectUnauthorized = false
+  if (config.sslcompat === 'libpq') {
+    switch (config.sslmode) {
+      case 'disable': {
+        config.ssl = false
+        break
       }
-      break
+      case 'prefer':
+      case 'no-verify': {
+        config.ssl.rejectUnauthorized = false
+        break
+      }
+      case 'require': {
+        if (config.sslrootcert) {
+          // If a root CA is specified, behavior of `sslmode=require` will be the same as that of `verify-ca`
+          config.ssl.checkServerIdentity = function () {}
+        } else {
+          config.ssl.rejectUnauthorized = false
+        }
+        break
+      }
+      case 'verify-ca': {
+        config.ssl.checkServerIdentity = function () {}
+        break
+      }
+      case 'verify-full': {
+        break
+      }
     }
-    case 'verify-ca': {
-      config.ssl.checkServerIdentity = function () {}
-      break
-    }
-    case 'verify-full': {
-      break
+  } else {
+    switch (config.sslmode) {
+      case 'disable': {
+        config.ssl = false
+        break
+      }
+      case 'prefer':
+      case 'require':
+      case 'verify-ca':
+      case 'verify-full': {
+        break
+      }
+      case 'no-verify': {
+        config.ssl.rejectUnauthorized = false
+        break
+      }
     }
   }
 

--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -5,7 +5,7 @@
 //MIT License
 
 //parses a connection string
-function parse(str) {
+function parse(str, options = {}) {
   //unix socket
   if (str.charAt(0) === '/') {
     const config = str.split(' ')
@@ -87,7 +87,11 @@ function parse(str) {
     config.ssl.ca = fs.readFileSync(config.sslrootcert).toString()
   }
 
-  if (config.sslcompat === 'libpq') {
+  if (options.useLibpqCompat && config.sslcompat) {
+    throw new Error('Both useLibpqCompat and sslcompat are set. Please use only one of them.')
+  }
+
+  if (config.sslcompat === 'libpq' || options.useLibpqCompat) {
     switch (config.sslmode) {
       case 'disable': {
         config.ssl = false

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -275,7 +275,7 @@ describe('parse', function () {
     var connectionString = 'pg:///?sslmode=verify-ca'
     var subject = parse(connectionString)
     subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
-    expect(subject.ssl.checkServerIdentity()).be.undefined
+    expect(subject.ssl.checkServerIdentity()).to.be.undefined
   })
 
   it('configuration parameter sslmode=verify-full', function () {
@@ -289,7 +289,7 @@ describe('parse', function () {
     var subject = parse(connectionString)
     subject.ssl.should.have.property('ca', 'example ca\n')
     subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
-    expect(subject.ssl.checkServerIdentity()).be.undefined
+    expect(subject.ssl.checkServerIdentity()).to.be.undefined
   })
 
   it('allow other params like max, ...', function () {

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -258,19 +258,24 @@ describe('parse', function () {
   it('configuration parameter sslmode=prefer', function () {
     var connectionString = 'pg:///?sslmode=prefer'
     var subject = parse(connectionString)
-    subject.ssl.should.eql({})
+    subject.ssl.should.eql({
+      rejectUnauthorized: false,
+    })
   })
 
   it('configuration parameter sslmode=require', function () {
     var connectionString = 'pg:///?sslmode=require'
     var subject = parse(connectionString)
-    subject.ssl.should.eql({})
+    subject.ssl.should.eql({
+      rejectUnauthorized: false,
+    })
   })
 
   it('configuration parameter sslmode=verify-ca', function () {
     var connectionString = 'pg:///?sslmode=verify-ca'
     var subject = parse(connectionString)
-    subject.ssl.should.eql({})
+    subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
+    expect(subject.ssl.checkServerIdentity()).be.undefined
   })
 
   it('configuration parameter sslmode=verify-full', function () {
@@ -282,9 +287,9 @@ describe('parse', function () {
   it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca', function () {
     var connectionString = 'pg:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require'
     var subject = parse(connectionString)
-    subject.ssl.should.eql({
-      ca: 'example ca\n',
-    })
+    subject.ssl.should.have.property('ca', 'example ca\n')
+    subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
+    expect(subject.ssl.checkServerIdentity()).be.undefined
   })
 
   it('allow other params like max, ...', function () {

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -338,6 +338,63 @@ describe('parse', function () {
     expect(subject.ssl.checkServerIdentity()).be.undefined
   })
 
+  it('configuration parameter sslmode=disable with useLibpqCompat option', function () {
+    var connectionString = 'pg:///?sslmode=disable'
+    var subject = parse(connectionString, { useLibpqCompat: true })
+    subject.ssl.should.eql(false)
+  })
+
+  it('configuration parameter sslmode=prefer with useLibpqCompat option', function () {
+    var connectionString = 'pg:///?sslmode=prefer'
+    var subject = parse(connectionString, { useLibpqCompat: true })
+    subject.ssl.should.eql({
+      rejectUnauthorized: false,
+    })
+  })
+
+  it('configuration parameter sslmode=require with useLibpqCompat option', function () {
+    var connectionString = 'pg:///?sslmode=require'
+    var subject = parse(connectionString, { useLibpqCompat: true })
+    subject.ssl.should.eql({
+      rejectUnauthorized: false,
+    })
+  })
+
+  it('configuration parameter sslmode=verify-ca with useLibpqCompat option', function () {
+    var connectionString = 'pg:///?sslmode=verify-ca'
+    expect(function () {
+      parse(connectionString, { useLibpqCompat: true })
+    }).to.throw()
+  })
+
+  it('configuration parameter sslmode=verify-ca and sslrootcert with useLibpqCompat option', function () {
+    var connectionString = 'pg:///?sslmode=verify-ca&sslrootcert=' + __dirname + '/example.ca'
+    var subject = parse(connectionString, { useLibpqCompat: true })
+    subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
+    expect(subject.ssl.checkServerIdentity()).be.undefined
+  })
+
+  it('configuration parameter sslmode=verify-full with useLibpqCompat option', function () {
+    var connectionString = 'pg:///?sslmode=verify-full'
+    var subject = parse(connectionString, { useLibpqCompat: true })
+    subject.ssl.should.eql({})
+  })
+
+  it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca with useLibpqCompat option', function () {
+    var connectionString = 'pg:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require'
+    var subject = parse(connectionString, { useLibpqCompat: true })
+    subject.ssl.should.have.property('ca', 'example ca\n')
+    subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
+    expect(subject.ssl.checkServerIdentity()).be.undefined
+  })
+
+  it('does not allow sslcompat query parameter and useLibpqCompat option at the same time', function () {
+    var connectionString = 'pg:///?sslcompat=libpq'
+    expect(function () {
+      parse(connectionString, { useLibpqCompat: true })
+    }).to.throw()
+  })
+
   it('allow other params like max, ...', function () {
     var subject = parse('pg://myhost/db?max=18&min=4')
     subject.max.should.equal('18')

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -288,50 +288,51 @@ describe('parse', function () {
     })
   })
 
-  it('configuration parameter sslmode=disable with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=disable&sslcompat=libpq'
+  it('configuration parameter sslmode=disable with uselibpqcompat query param', function () {
+    var connectionString = 'pg:///?sslmode=disable&uselibpqcompat=true'
     var subject = parse(connectionString)
     subject.ssl.should.eql(false)
   })
 
-  it('configuration parameter sslmode=prefer with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=prefer&sslcompat=libpq'
+  it('configuration parameter sslmode=prefer with uselibpqcompat query param', function () {
+    var connectionString = 'pg:///?sslmode=prefer&uselibpqcompat=true'
     var subject = parse(connectionString)
     subject.ssl.should.eql({
       rejectUnauthorized: false,
     })
   })
 
-  it('configuration parameter sslmode=require with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=require&sslcompat=libpq'
+  it('configuration parameter sslmode=require with uselibpqcompat query param', function () {
+    var connectionString = 'pg:///?sslmode=require&uselibpqcompat=true'
     var subject = parse(connectionString)
     subject.ssl.should.eql({
       rejectUnauthorized: false,
     })
   })
 
-  it('configuration parameter sslmode=verify-ca with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=verify-ca&sslcompat=libpq'
+  it('configuration parameter sslmode=verify-ca with uselibpqcompat query param', function () {
+    var connectionString = 'pg:///?sslmode=verify-ca&uselibpqcompat=true'
     expect(function () {
       parse(connectionString)
     }).to.throw()
   })
 
-  it('configuration parameter sslmode=verify-ca and sslrootcert with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=verify-ca&sslcompat=libpq&sslrootcert=' + __dirname + '/example.ca'
+  it('configuration parameter sslmode=verify-ca and sslrootcert with uselibpqcompat query param', function () {
+    var connectionString = 'pg:///?sslmode=verify-ca&uselibpqcompat=true&sslrootcert=' + __dirname + '/example.ca'
     var subject = parse(connectionString)
     subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
     expect(subject.ssl.checkServerIdentity()).be.undefined
   })
 
-  it('configuration parameter sslmode=verify-full with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=verify-full&sslcompat=libpq'
+  it('configuration parameter sslmode=verify-full with uselibpqcompat query param', function () {
+    var connectionString = 'pg:///?sslmode=verify-full&uselibpqcompat=true'
     var subject = parse(connectionString)
     subject.ssl.should.eql({})
   })
 
-  it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca with libpq compatibility', function () {
-    var connectionString = 'pg:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require&sslcompat=libpq'
+  it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca with uselibpqcompat query param', function () {
+    var connectionString =
+      'pg:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require&uselibpqcompat=true'
     var subject = parse(connectionString)
     subject.ssl.should.have.property('ca', 'example ca\n')
     subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
@@ -389,7 +390,7 @@ describe('parse', function () {
   })
 
   it('does not allow sslcompat query parameter and useLibpqCompat option at the same time', function () {
-    var connectionString = 'pg:///?sslcompat=libpq'
+    var connectionString = 'pg:///?uselibpqcompat=true'
     expect(function () {
       parse(connectionString, { useLibpqCompat: true })
     }).to.throw()

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -256,50 +256,22 @@ describe('parse', function () {
     subject.ssl.should.eql(false)
   })
 
-  it('configuration parameter sslmode=prefer with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=prefer&sslcompat=libpq'
+  it('configuration parameter sslmode=prefer', function () {
+    var connectionString = 'pg:///?sslmode=prefer'
     var subject = parse(connectionString)
-    subject.ssl.should.eql({
-      rejectUnauthorized: false,
-    })
+    subject.ssl.should.eql({})
   })
 
-  it('configuration parameter sslmode=require with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=require&sslcompat=libpq'
+  it('configuration parameter sslmode=require', function () {
+    var connectionString = 'pg:///?sslmode=require'
     var subject = parse(connectionString)
-    subject.ssl.should.eql({
-      rejectUnauthorized: false,
-    })
+    subject.ssl.should.eql({})
   })
 
-  it('configuration parameter sslmode=verify-ca with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=verify-ca&sslcompat=libpq'
+  it('configuration parameter sslmode=verify-ca', function () {
+    var connectionString = 'pg:///?sslmode=verify-ca'
     var subject = parse(connectionString)
-    subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
-    expect(subject.ssl.checkServerIdentity()).to.be.undefined
-  })
-
-  it('configuration parameter sslmode=prefer with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=prefer&sslcompat=libpq'
-    var subject = parse(connectionString)
-    subject.ssl.should.eql({
-      rejectUnauthorized: false,
-    })
-  })
-
-  it('configuration parameter sslmode=require with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=require&sslcompat=libpq'
-    var subject = parse(connectionString)
-    subject.ssl.should.eql({
-      rejectUnauthorized: false,
-    })
-  })
-
-  it('configuration parameter sslmode=verify-ca with libpq compatibility', function () {
-    var connectionString = 'pg:///?sslmode=verify-ca&sslcompat=libpq'
-    var subject = parse(connectionString)
-    subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
-    expect(subject.ssl.checkServerIdentity()).be.undefined
+    subject.ssl.should.eql({})
   })
 
   it('configuration parameter sslmode=verify-full', function () {
@@ -314,6 +286,48 @@ describe('parse', function () {
     subject.ssl.should.eql({
       ca: 'example ca\n',
     })
+  })
+
+  it('configuration parameter sslmode=disable with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=disable&sslcompat=libpq'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql(false)
+  })
+
+  it('configuration parameter sslmode=prefer with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=prefer&sslcompat=libpq'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql({
+      rejectUnauthorized: false,
+    })
+  })
+
+  it('configuration parameter sslmode=require with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=require&sslcompat=libpq'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql({
+      rejectUnauthorized: false,
+    })
+  })
+
+  it('configuration parameter sslmode=verify-ca with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=verify-ca&sslcompat=libpq'
+    expect(function () {
+      parse(connectionString)
+    }).to.throw()
+  })
+
+  it('configuration parameter sslmode=verify-ca and sslrootcert with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=verify-ca&sslcompat=libpq&sslrootcert=' + __dirname + '/example.ca'
+    var subject = parse(connectionString)
+    subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
+    expect(subject.ssl.checkServerIdentity()).be.undefined
+  })
+
+  it('configuration parameter sslmode=verify-full with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=verify-full&sslcompat=libpq'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql({})
   })
 
   it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca with libpq compatibility', function () {

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var chai = require('chai')
+var expect = chai.expect
 chai.should()
 
 var parse = require('../').parse
@@ -255,27 +256,50 @@ describe('parse', function () {
     subject.ssl.should.eql(false)
   })
 
-  it('configuration parameter sslmode=prefer', function () {
-    var connectionString = 'pg:///?sslmode=prefer'
+  it('configuration parameter sslmode=prefer with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=prefer&sslcompat=libpq'
     var subject = parse(connectionString)
     subject.ssl.should.eql({
       rejectUnauthorized: false,
     })
   })
 
-  it('configuration parameter sslmode=require', function () {
-    var connectionString = 'pg:///?sslmode=require'
+  it('configuration parameter sslmode=require with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=require&sslcompat=libpq'
     var subject = parse(connectionString)
     subject.ssl.should.eql({
       rejectUnauthorized: false,
     })
   })
 
-  it('configuration parameter sslmode=verify-ca', function () {
-    var connectionString = 'pg:///?sslmode=verify-ca'
+  it('configuration parameter sslmode=verify-ca with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=verify-ca&sslcompat=libpq'
     var subject = parse(connectionString)
     subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
     expect(subject.ssl.checkServerIdentity()).to.be.undefined
+  })
+
+  it('configuration parameter sslmode=prefer with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=prefer&sslcompat=libpq'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql({
+      rejectUnauthorized: false,
+    })
+  })
+
+  it('configuration parameter sslmode=require with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=require&sslcompat=libpq'
+    var subject = parse(connectionString)
+    subject.ssl.should.eql({
+      rejectUnauthorized: false,
+    })
+  })
+
+  it('configuration parameter sslmode=verify-ca with libpq compatibility', function () {
+    var connectionString = 'pg:///?sslmode=verify-ca&sslcompat=libpq'
+    var subject = parse(connectionString)
+    subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
+    expect(subject.ssl.checkServerIdentity()).be.undefined
   })
 
   it('configuration parameter sslmode=verify-full', function () {
@@ -287,9 +311,17 @@ describe('parse', function () {
   it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca', function () {
     var connectionString = 'pg:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require'
     var subject = parse(connectionString)
+    subject.ssl.should.eql({
+      ca: 'example ca\n',
+    })
+  })
+
+  it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca with libpq compatibility', function () {
+    var connectionString = 'pg:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require&sslcompat=libpq'
+    var subject = parse(connectionString)
     subject.ssl.should.have.property('ca', 'example ca\n')
     subject.ssl.should.have.property('checkServerIdentity').that.is.a('function')
-    expect(subject.ssl.checkServerIdentity()).to.be.undefined
+    expect(subject.ssl.checkServerIdentity()).be.undefined
   })
 
   it('allow other params like max, ...', function () {


### PR DESCRIPTION
## Summary

We have found that the handling of the `sslmode` connection string parameter is inconsistent with other PG libraries and with the reference [libpq documentation](https://www.postgresql.org/docs/12/libpq-connect.html#LIBPQ-CONNSTRING). This PR proposes some changes to `sslmode` behavior that are more aligned with libpq.

## Detailed `sslmode` behavior

Here is the list of all `sslmode` values and their expected behavior with this PR:

#### `sslmode=verify-full`
Require an SSL connection and verify the CA and server identity.
No changes in this PR.

#### `sslmode=verify-ca` *(changed)*
Require an SSL connection and verify the CA, but not the server identity. This is achieved by setting `ssl.checkServerIdentity` to a no-op function (see [docs](https://nodejs.org/api/tls.html#tlscheckserveridentityhostname-cert)). Previously, this mode behaved like `verify-full` but that was not consistent with the libpq implementation. SECURITY WARNING: Using `sslmode=verify-ca` requires specifying a CA with `sslrootcert`. If a public CA is used, `verify-ca` allows connections to a server that somebody else may have registered with the CA, making you vulnerable to Man-in-the-Middle attacks.

#### `sslmode=require` *(changed)*
If a root CA is provided via the `sslrootcert` parameter of the connection string, it behaves like `verify-ca`. Otherwise, require an SSL connection but do not verify CA and server identity (`ssl.rejectUnauthorized` is set to `false`).
Previously, this mode behaved like `verify-full` but that was not consistent with the libpq implementation.

#### `sslmode=no-verify`
Require an SSL connection but do not verify CA and server identity (`ssl.rejectUnauthorized` is set to `false`).
No changes in this PR. Note: this mode is not documented in libpq and does not appear to be broadly supported in other libraries, but has been kept as-is for the sake of backwards-compatibility. One option could be to mark it as deprecated since `sslmode=require` could be an alternative, but doing so might have little value for this project.

#### `sslmode=prefer` *(changed)*
Require an SSL connection but do not verify CA and server identity (`ssl.rejectUnauthorized` is set to `false`). Previously, this mode behaved like `verify-full` but that was not consistent with the libpq implementation.
In reality, this mode should be even less strict and support a fallback logic from SSL to non-SSL connection if SSL is not accepted by the server. Implementing a fallback logic seems to be more complex to solve and I did not dare touch this, but this could eventually be addressed if users of this library deem this mode valuable.

#### `sslmode=allow`
Not supported by this library.
No changes in this PR. For this mode also, there could be an opportunity to implement a fallback logic from non-SSL to SSL, but I did not dare touch this and I don't have data that suggests that this might be valuable for this project.

#### `sslmode=disable`
Only try a non-SSL connection.
No changes in this PR

An important note is that this PR potentially introduces **semver breaking changes**, in particular because it relaxes the security constraints of some `sslmode` values:

- `sslmode=prefer` is less strict, users should switch to `sslmode=verify-full` to keep parity.
- `sslmode=require` is less strict, users should switch to `sslmode=verify-full` to keep parity.
- `sslmode=verify-ca` is less strict, users should switch to `sslmode=verify-full` to keep parity.

## Prior discussions about `sslmode`

I believe this PR addresses concerns raised in these two GH issues in the past:
https://github.com/brianc/node-postgres/issues/2281
https://github.com/brianc/node-postgres/issues/2009

In particular, there has been [one case](https://github.com/brianc/node-postgres/issues/2281#issuecomment-1015824739) where the `sslmode=verify-ca` is currently too strict when connecting through AWS RDS Proxy, but the work-around of using `sslmode=no-verify` would disable CA verification completely.

## Other languages/libraries and their support for `sslmode`

Just as a reference, these two libraries are also trying to be more or less consistent with libpq:
- [Golang - pq](https://pkg.go.dev/github.com/lib/pq#hdr-Connection_String_Parameters)
  - Supports `disable`, `require`, `verify-ca` and`verify-full` only.
- [PostgreSQL JDBC Driver](https://jdbc.postgresql.org/documentation/head/ssl-client.html)
  - Supports all 6 modes.

---

Thanks for considering this change and please let me know how I can polish this further for acceptance 🙏 