### PR TITLE
Add typing for pg-cursor package

### DIFF
--- a/packages/pg-cursor/index.d.ts
+++ b/packages/pg-cursor/index.d.ts
@@ -1,0 +1,17 @@
+import { QueryResult, types } from 'pg';
+
+interface CursorQueryConfig {
+  // by default rows come out as a key/value pair for each row
+  // pass the string 'array' here to receive rows as an array of values
+  rowMode?: string;
+  // custom type parsers just for this query result
+  types?: {
+    getTypeParser: typeof types.getTypeParser;
+  };
+}
+
+export class Cursor {
+  constructor(text: string, values: any[], config?: CursorQueryConfig);
+  read(rowCount: number, callback: (err: Error | null, rows: any[], result: QueryResult) => void): void;
+  close(callback: () => void): void;
+}

--- a/packages/pg-cursor/package.json
+++ b/packages/pg-cursor/package.json
@@ -3,6 +3,7 @@
   "version": "2.7.3",
   "description": "Query cursor extension for node-postgres",
   "main": "index.js",
+  "types": "index.d.ts",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
PR adds typings for the pg-cursor package. I wasn't sure where best to land these (here or DefinitelyTyped), but opted for here given the general simplicity and stability of the package, and that `pg-connection-string` has its types here.