### PR TITLE
pg: update README, remove dead badge

### DIFF
--- a/packages/pg/README.md
+++ b/packages/pg/README.md
@@ -1,7 +1,6 @@
 # node-postgres
 
 [![Build Status](https://secure.travis-ci.org/brianc/node-postgres.svg?branch=master)](http://travis-ci.org/brianc/node-postgres)
-[![Dependency Status](https://david-dm.org/brianc/node-postgres.svg?path=packages/pg)](https://david-dm.org/brianc/node-postgres?path=packages/pg)
 <span class="badge-npmversion"><a href="https://npmjs.org/package/pg" title="View this project on NPM"><img src="https://img.shields.io/npm/v/pg.svg" alt="NPM version" /></a></span>
 <span class="badge-npmdownloads"><a href="https://npmjs.org/package/pg" title="View this project on NPM"><img src="https://img.shields.io/npm/dm/pg.svg" alt="NPM downloads" /></a></span>
 


### PR DESCRIPTION
This removes the dead badge, so it after next publish to npmjs.org will not show in the readme, 

![image](https://user-images.githubusercontent.com/5888506/158022187-64690601-d034-435c-ba2b-5f4dd517f91c.png)
