### PR TITLE
feat: add connection parameter nativeConnectionString

### DIFF
--- a/packages/pg/lib/native/client.js
+++ b/packages/pg/lib/native/client.js
@@ -30,6 +30,7 @@ var Client = (module.exports = function (config) {
   // keep these on the object for legacy reasons
   // for the time being. TODO: deprecate all this jazz
   var cp = (this.connectionParameters = new ConnectionParameters(config))
+  if (config.nativeConnectionString) cp.nativeConnectionString = config.nativeConnectionString
   this.user = cp.user
 
   // "hiding" the password so it doesn't show up in stack traces
@@ -84,6 +85,7 @@ Client.prototype._connect = function (cb) {
 
   this.connectionParameters.getLibpqConnectionString(function (err, conString) {
     if (err) return cb(err)
+    if (self.connectionParameters.nativeConnectionString) conString = self.connectionParameters.nativeConnectionString
     self.native.connect(conString, function (err) {
       if (err) {
         self.native.end()


### PR DESCRIPTION
for when you want to pass connection string AS IS to pg-native
which allows the use of features present in libpq but still not
implemented in the js drivers
like multihost URI