### PR TITLE
Support lock_timeout

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -403,6 +403,9 @@ class Client extends EventEmitter {
     if (params.statement_timeout) {
       data.statement_timeout = String(parseInt(params.statement_timeout, 10))
     }
+    if (params.lock_timeout) {
+      data.lock_timeout = String(parseInt(params.lock_timeout, 10))
+    }
     if (params.idle_in_transaction_session_timeout) {
       data.idle_in_transaction_session_timeout = String(parseInt(params.idle_in_transaction_session_timeout, 10))
     }

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -103,6 +103,7 @@ class ConnectionParameters {
     this.application_name = val('application_name', config, 'PGAPPNAME')
     this.fallback_application_name = val('fallback_application_name', config, false)
     this.statement_timeout = val('statement_timeout', config, false)
+    this.lock_timeout = val('lock_timeout', config, false)
     this.idle_in_transaction_session_timeout = val('idle_in_transaction_session_timeout', config, false)
     this.query_timeout = val('query_timeout', config, false)
 

--- a/packages/pg/lib/defaults.js
+++ b/packages/pg/lib/defaults.js
@@ -54,6 +54,10 @@ module.exports = {
   // false=unlimited
   statement_timeout: false,
 
+  // Abort any statement that waits longer than the specified duration in milliseconds while attempting to acquire a lock.
+  // false=unlimited
+  lock_timeout: false,
+
   // Terminate any session with an open transaction that has been idle for longer than the specified duration in milliseconds
   // false=unlimited
   idle_in_transaction_session_timeout: false,

--- a/packages/pg/test/unit/connection-parameters/creation-tests.js
+++ b/packages/pg/test/unit/connection-parameters/creation-tests.js
@@ -28,6 +28,7 @@ var compare = function (actual, expected, type) {
   assert.equal(actual.password, expected.password, type + ' password')
   assert.equal(actual.binary, expected.binary, type + ' binary')
   assert.equal(actual.statement_timeout, expected.statement_timeout, type + ' statement_timeout')
+  assert.equal(actual.lock_timeout, expected.lock_timeout, type + ' lock_timeout')
   assert.equal(actual.options, expected.options, type + ' options')
   assert.equal(
     actual.idle_in_transaction_session_timeout,
@@ -51,6 +52,7 @@ suite.test('ConnectionParameters initializing from defaults with connectionStrin
     host: 'foo.bar.net',
     binary: defaults.binary,
     statement_timeout: false,
+    lock_timeout: false,
     idle_in_transaction_session_timeout: false,
     options: '-c geqo=off',
   }
@@ -78,6 +80,7 @@ suite.test('ConnectionParameters initializing from config', function () {
       asdf: 'blah',
     },
     statement_timeout: 15000,
+    lock_timeout: 15000,
     idle_in_transaction_session_timeout: 15000,
     options: '-c geqo=off',
   }


### PR DESCRIPTION
Allow passing `lock_timeout` in connection params.

https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT