### PR TITLE
Bump min version of pg-native

### DIFF
--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -35,7 +35,7 @@
     "pg-copy-streams": "0.3.0"
   },
   "peerDependencies": {
-    "pg-native": ">=2.0.0"
+    "pg-native": ">=3.0.1"
   },
   "peerDependenciesMeta": {
     "pg-native": {


### PR DESCRIPTION
Fixes #2786 

Pull requests for reference:
https://github.com/brianc/node-pg-native/pull/108
https://github.com/brianc/node-libpq/pull/86

This shouldn't actually affect anything in this library as there's no way to get an array into the offending parameters variable in node-libpq from this library directly anyway AFAICT, but still...I take any security issue extremely seriously (and even stopped working today to fix this).  Please LMK if there are other issues related to this.

A note for anyone on how to upgrade:
You technically don't even need to install a new version of `pg`.  Just make sure you install `pg-native@3.0.1` if you're using the native bindings. e.g. `yarn add pg-native@3.0.1` etc...