### PR TITLE
Fix error handling test

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -13,6 +13,9 @@ node-postgres is made possible by the helpful contributors from the community as
 - [simpleanalytics](https://simpleanalytics.com/)
 - [n8n.io](https://n8n.io/)
 - [mpirik](https://github.com/mpirik)
+- [@BLUE-DEVIL1134](https://github.com/BLUE-DEVIL1134)
+- [bubble.io](https://bubble.io/)
+- GitHub[https://github.com/github]
 
 # Supporters
 

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -417,11 +417,11 @@ class Pool extends EventEmitter {
           client.release(err)
           if (err) {
             return cb(err)
-          } else {
-            return cb(undefined, res)
           }
+          return cb(undefined, res)
         })
       } catch (err) {
+        client.release(err)
         return cb(err)
       }
     })

--- a/packages/pg-pool/test/error-handling.js
+++ b/packages/pg-pool/test/error-handling.js
@@ -38,14 +38,15 @@ describe('pool error handling', function () {
   })
 
   it('Catches errors in client.query', async function () {
-    await expect((new Pool()).query(null)).to.throwError()
-    await expect(async () => {
-      try {
-        await (new Pool()).query(null)
-      } catch (e) {
-        console.log(e)
-      }
-    }).not.to.throwError()
+    let caught = false
+    const pool = new Pool()
+    try {
+      await pool.query(null)
+    } catch (e) {
+      caught = true
+    }
+    pool.end()
+    expect(caught).to.be(true)
   })
 
   describe('calling release more than once', () => {


### PR DESCRIPTION
#2569 introduced a bug in the test. The test never passed but because travis-ci lovingly broke the integration we had a long time ago the tests weren't run in CI until I merged.  So, this fixes the tests & does a better job cleaning up the query in an errored state.