### PR TITLE
Test case for #2642 - pg-cursor .close() never returns after connection lost

### DIFF
--- a/packages/pg-cursor/test/error-handling.js
+++ b/packages/pg-cursor/test/error-handling.js
@@ -19,6 +19,24 @@ describe('error handling', function () {
       })
     })
   })
+
+  it('can continue after connection lost', function (done) {
+    const client = new pg.Client()
+    client.connect()
+    const cursor = client.query(new Cursor('SELECT NOW()'))
+    cursor.read(1, function (err) {
+      // Simulate a connection dropout by disconnecting.
+      client.end(function (err) {
+        assert.ifError(err)
+        // Try to close the cursor as if we didn't know the connection had
+        // dropped out.
+        cursor.close(function (err) {
+          assert.ifError(err)
+          done()
+        })
+      })
+    })
+  })
 })
 
 describe('read callback does not fire sync', () => {


### PR DESCRIPTION
This is a test case that reproduces the problem described in #2642.

It will of course fail, until the bug is fixed.