### PR TITLE
Update package.json

### DIFF
--- a/packages/pg-query-stream/package.json
+++ b/packages/pg-query-stream/package.json
@@ -42,6 +42,9 @@
     "ts-node": "^8.5.4",
     "typescript": "^4.0.3"
   },
+  "peerDependencies": {
+    "pg": "^8"
+  },
   "dependencies": {
     "pg-cursor": "^2.7.4"
   }


### PR DESCRIPTION
Installing `pg-query-stream` using `yarn@v3` causes the following error:

```
/workspace/.pnp.cjs:42329
      Error.captureStackTrace(firstError);
            ^

Error: pg-cursor tried to access pg (a peer dependency) but it isn't provided by its ancestors; this makes the require call ambiguous and unsound.

Required package: pg (via "pg/lib/result.js")
Required by: pg-cursor@virtual:b15c8e58b2b8594a0187b88c869a498d86e8516db99b3d1eb03c094d7c7a1382793a82b929ca663d905d880350406f40122bf7227483202673f134928631ae7c#npm:2.7.4 (via /workspace/.yarn/__virtual__/pg-cursor-virtual-9bc4494085/0/cache/pg-cursor-npm-2.7.4-599c8a9a52-f150287f88.zip/node_modules/pg-cursor/)

Ancestor breaking the chain: pg-query-stream@npm:4.2.4


Require stack:
- /workspace/.yarn/__virtual__/pg-cursor-virtual-9bc4494085/0/cache/pg-cursor-npm-2.7.4-599c8a9a52-f150287f88.zip/node_modules/pg-cursor/index.js
- /workspace/.yarn/cache/pg-query-stream-npm-4.2.4-b15c8e58b2-635fdf986a.zip/node_modules/pg-query-stream/dist/index.js
- /workspace/index.js
    at Function.require$$0.Module._resolveFilename (/workspace/.pnp.cjs:42329:13)
    at Function.require$$0.Module._load (/workspace/.pnp.cjs:42183:42)
    at Module.require (node:internal/modules/cjs/loader:1028:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/workspace/.yarn/__virtual__/pg-cursor-virtual-9bc4494085/0/cache/pg-cursor-npm-2.7.4-599c8a9a52-f150287f88.zip/node_modules/pg-cursor/index.js:2:16)
    at Module._compile (node:internal/modules/cjs/loader:1126:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1180:10)
    at Object.require$$0.Module._extensions..js (/workspace/.pnp.cjs:42373:33)
    at Module.load (node:internal/modules/cjs/loader:1004:32)
    at Function.require$$0.Module._load (/workspace/.pnp.cjs:42213:14)

```

This change makes it explicit that `pg-query-stream` has a (peer) dependency on `pg`.