### PR TITLE
Update pg.connect with pool.connect

### DIFF
--- a/packages/pg-query-stream/README.md
+++ b/packages/pg-query-stream/README.md
@@ -15,11 +15,12 @@ _requires pg>=2.8.1_
 
 ```js
 const pg = require('pg')
+var pool = new pg.Pool()
 const QueryStream = require('pg-query-stream')
 const JSONStream = require('JSONStream')
 
 //pipe 1,000,000 rows to stdout without blowing up your memory usage
-pg.connect((err, client, done) => {
+pool.connect((err, client, done) => {
   if (err) throw err
   const query = new QueryStream('SELECT * FROM generate_series(0, $1) num', [1000000])
   const stream = client.query(query)


### PR DESCRIPTION
pg.connect() has been deprecated.

https://node-postgres.com/guides/upgrading