### PR TITLE
stream-use-after-error: failing test case

### DIFF
--- a/packages/pg-query-stream/src/index.ts
+++ b/packages/pg-query-stream/src/index.ts
@@ -45,7 +45,8 @@ class QueryStream extends Readable implements Submittable {
   }
 
   public _destroy(_err: Error, cb: Function) {
-    this.cursor.close((err?: Error) => {
+    this.cursor.close(async (err?: Error) => {
+      if(process.env.WAIT_AFTER_CLOSE === '2') await new Promise(resolve => setTimeout(resolve, 100));
       cb(err || _err)
     })
   }

--- a/packages/pg-query-stream/test/close.ts
+++ b/packages/pg-query-stream/test/close.ts
@@ -106,6 +106,8 @@ if (process.version.startsWith('v8.')) {
       await assert.rejects(() => pool.query('SELECT TRUE'), { message: 'timeout exceeded when trying to connect' });
 
       await stream.destroy();
+      if(process.env.WAIT_AFTER_CLOSE) await new Promise(resolve => setTimeout(resolve, 100));
+
       await client.release();
 
       const res2 = await pool.query('SELECT TRUE');

--- a/packages/pg-query-stream/test/close.ts
+++ b/packages/pg-query-stream/test/close.ts
@@ -106,7 +106,11 @@ if (process.version.startsWith('v8.')) {
       await assert.rejects(() => pool.query('SELECT TRUE'), { message: 'timeout exceeded when trying to connect' });
 
       await stream.destroy();
-      if(process.env.WAIT_AFTER_CLOSE) await new Promise(resolve => setTimeout(resolve, 100));
+      if(process.env.WAIT_AFTER_CLOSE === '1') await new Promise(resolve => setTimeout(resolve, 100));
+
+      if(process.env.WAIT_AFTER_CLOSE === '2') {
+        await new Promise(resolve => stream.once('close', resolve));
+      }
 
       await client.release();
 

--- a/packages/pg-query-stream/test/close.ts
+++ b/packages/pg-query-stream/test/close.ts
@@ -93,7 +93,7 @@ if (process.version.startsWith('v8.')) {
   })
 
   describe('use after error', () => {
-    it('should work if used after error', async () => {
+    it.only('should work if used after error', async () => {
       const pool = new pg.Pool({ max: 1, connectionTimeoutMillis: 400, statement_timeout: 400 });
 
       const res1 = await pool.query('SELECT TRUE');

--- a/packages/pg-query-stream/test/close.ts
+++ b/packages/pg-query-stream/test/close.ts
@@ -112,6 +112,8 @@ if (process.version.startsWith('v8.')) {
 
       const res2 = await pool.query('SELECT TRUE');
       assert.deepStrictEqual(res2.rows, [ { bool:true } ]);
+
+      await pool.end();
     })
   })
 }


### PR DESCRIPTION
Failing test case for https://github.com/brianc/node-postgres/issues/1674

On my machine, running postgres using `docker run --rm --name test_node_pg -p 5432:5432 -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=ci_db_test -e POSTGRES_USER=postgres postgres:11`, this sometimes fails with different errors:

```
$ PGTESTNOSSL=true PGUSER=postgres PGPASSWORD=postgres PGDATABASE=ci_db_test yarn test
yarn run v1.22.15
$ mocha -r ts-node/register test/**/*.ts


  use after error
    1) should work if used after error


  0 passing (547ms)
  1 failing

  1) use after error
       should work if used after error:

      AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

+ []
- [
-   {
-     bool: true
-   }
- ]
      + expected - actual

      -[]
      +[
      +  {
      +    "bool": true
      +  }
      +]
      
      at ~/node-postgres/packages/pg-query-stream/test/close.ts:112:14
      at Generator.next (<anonymous>)
      at fulfilled (test/close.ts:5:58)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)



^[[A^C[11:23] ~/node-postgres/packages/pg-query-stream (stream-after-error*)
$ PGTESTNOSSL=true PGUSER=postgres PGPASSWORD=postgres PGDATABASE=ci_db_test yarn test
yarn run v1.22.15
$ mocha -r ts-node/register test/**/*.ts


  use after error
    1) should work if used after error
    2) should work if used after error


  0 passing (547ms)
  2 failing

  1) use after error
       should work if used after error:
     Uncaught TypeError: Cannot read properties of null (reading 'handleRowDescription')
      at Client._handleRowDescription (~/node-postgres/packages/pg/lib/client.js:340:22)
      at Connection.emit (node:events:513:28)
      at ~/node-postgres/packages/pg/lib/connection.js:114:12
      at Parser.parse (~/node-postgres/packages/pg-protocol/src/parser.ts:104:9)
      at Socket.<anonymous> (~/node-postgres/packages/pg-protocol/src/index.ts:7:48)
      at Socket.emit (node:events:513:28)
      at addChunk (node:internal/streams/readable:315:12)
      at readableAddChunk (node:internal/streams/readable:289:9)
      at Socket.Readable.push (node:internal/streams/readable:228:10)
      at TCP.onStreamRead (node:internal/stream_base_commons:190:23)

  2) use after error
       should work if used after error:
     Error: done() called multiple times in test <use after error should work if used after error> of file ~/node-postgres/packages/pg-query-stream/test/close.ts; in addition, done() received error: AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

+ []
- [
-   {
-     bool: true
-   }
- ]
      at processTicksAndRejections (node:internal/process/task_queues:96:5)



error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```