### PR TITLE
pg-cursor: Fix errors only being sent to half the queue

### DIFF
--- a/packages/pg-cursor/index.js
+++ b/packages/pg-cursor/index.js
@@ -171,8 +171,10 @@ class Cursor extends EventEmitter {
     }
     // dispatch error to all waiting callbacks
     for (let i = 0; i < this._queue.length; i++) {
-      this._queue.pop()[1](msg)
+      const queuedCallback = this._queue[i][1]
+      queuedCallback.call(this, msg)
     }
+    this._queue.length = 0
 
     if (this.listenerCount('error') > 0) {
       // only dispatch error events if we have a listener

--- a/packages/pg-cursor/test/error-handling.js
+++ b/packages/pg-cursor/test/error-handling.js
@@ -19,6 +19,23 @@ describe('error handling', function () {
       })
     })
   })
+
+  it('errors queued reads', async () => {
+    const client = new pg.Client()
+    await client.connect()
+
+    const cursor = client.query(new Cursor('asdfdffsdf'))
+
+    const immediateRead = cursor.read(1)
+    const queuedRead1 = cursor.read(1)
+    const queuedRead2 = cursor.read(1)
+
+    assert(await immediateRead.then(() => null, (err) => err))
+    assert(await queuedRead1.then(() => null, (err) => err))
+    assert(await queuedRead2.then(() => null, (err) => err))
+
+    client.end()
+  })
 })
 
 describe('read callback does not fire sync', () => {


### PR DESCRIPTION
`pop` decreases the length while `i` is still being checked against it.