### PR TITLE
pg-pool: don't allow connection reuse after streaming

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -331,7 +331,7 @@ class Pool extends EventEmitter {
     client._poolUseCount = (client._poolUseCount || 0) + 1
 
     // TODO(bmc): expose a proper, public interface _queryable and _ending
-    if (err || this.ending || !client._queryable || client._ending || client._poolUseCount >= this.options.maxUses) {
+    if (err || this.ending || !client._queryable || client._ending || client._poolUseCount >= this.options.maxUses || client?.activeQuery?.cursor) {
       if (client._poolUseCount >= this.options.maxUses) {
         this.log('remove expended client')
       }

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -331,7 +331,7 @@ class Pool extends EventEmitter {
     client._poolUseCount = (client._poolUseCount || 0) + 1
 
     // TODO(bmc): expose a proper, public interface _queryable and _ending
-    if (err || this.ending || !client._queryable || client._ending || client._poolUseCount >= this.options.maxUses || client?.activeQuery?.cursor) {
+    if (err || this.ending || !client._queryable || client._ending || client._poolUseCount >= this.options.maxUses || (client && client.activeQuery && client.activeQuery.cursor)) {
       if (client._poolUseCount >= this.options.maxUses) {
         this.log('remove expended client')
       }

--- a/packages/pg-query-stream/test/close.ts
+++ b/packages/pg-query-stream/test/close.ts
@@ -110,6 +110,8 @@ if (process.version.startsWith('v8.')) {
 
       const res2 = await pool.query('SELECT TRUE');
       assert.deepStrictEqual(res2.rows, [ { bool:true } ]);
+
+      await pool.end();
     })
   })
 }

--- a/packages/pg-query-stream/test/close.ts
+++ b/packages/pg-query-stream/test/close.ts
@@ -1,6 +1,5 @@
 import assert from 'assert'
 import concat from 'concat-stream'
-import pg from 'pg'
 import QueryStream from '../src'
 import helper from './helper'
 
@@ -89,29 +88,6 @@ if (process.version.startsWith('v8.')) {
       stream.on('data', () => done(new Error('stream should not have returned rows')))
       stream.destroy()
       stream.on('close', done)
-    })
-  })
-
-  describe('use after error', () => {
-    it('should work if used after error', async () => {
-      const pool = new pg.Pool({ max: 1, connectionTimeoutMillis: 400, statement_timeout: 400 });
-
-      const res1 = await pool.query('SELECT TRUE');
-      assert.deepStrictEqual(res1.rows, [ { bool:true } ]);
-
-      const query = new QueryStream('SELECT TRUE');
-      const client = await pool.connect();
-      const stream = await client.query(query);
-
-      await assert.rejects(() => pool.query('SELECT TRUE'), { message: 'timeout exceeded when trying to connect' });
-
-      await stream.destroy();
-      await client.release();
-
-      const res2 = await pool.query('SELECT TRUE');
-      assert.deepStrictEqual(res2.rows, [ { bool:true } ]);
-
-      await pool.end();
     })
   })
 }

--- a/packages/pg-query-stream/test/error.ts
+++ b/packages/pg-query-stream/test/error.ts
@@ -118,7 +118,7 @@ describe('error recovery', () => {
   })
 
   it.only('should work if used after syntax error', async () => {
-    const pool = new Pool({ max: 1, statement_timeout: 1 }); // statement_timeout is required here, so maybe this is just another timeout error?
+    const pool = new Pool({ max: 1, statement_timeout: 100 }); // statement_timeout is required here, so maybe this is just another timeout error?
 
     const res1 = await pool.query('SELECT 1 AS a');
     assert.deepStrictEqual(res1.rows, [ { a:1 } ]);

--- a/packages/pg-query-stream/test/error.ts
+++ b/packages/pg-query-stream/test/error.ts
@@ -89,4 +89,58 @@ describe('error recovery', () => {
       await client.end()
     })
   })
+
+  it.only('should work if used after timeout error', async () => {
+    const pool = new Pool({ max: 1, connectionTimeoutMillis: 400, statement_timeout: 400 });
+
+    const res1 = await pool.query('SELECT 1 AS a');
+    assert.deepStrictEqual(res1.rows, [ { a:1 } ]);
+
+    const query = new QueryStream('SELECT 2 AS b');
+    const client = await pool.connect();
+    const stream = await client.query(query);
+
+    await assert.rejects(() => pool.query('SELECT TRUE'), { message: 'timeout exceeded when trying to connect' });
+
+    await stream.destroy();
+    if(process.env.WAIT_AFTER_CLOSE === '1') await new Promise(resolve => setTimeout(resolve, 100));
+
+    if(process.env.WAIT_AFTER_CLOSE === '2') {
+      await new Promise(resolve => stream.once('close', resolve));
+    }
+
+    await client.release();
+
+    const res2 = await pool.query('SELECT 4 AS d');
+    assert.deepStrictEqual(res2.rows, [ { d:4 } ]);
+
+    await pool.end();
+  })
+
+  it.only('should work if used after syntax error', async () => {
+    const pool = new Pool({ max: 1, statement_timeout: 1 }); // statement_timeout is required here, so maybe this is just another timeout error?
+
+    const res1 = await pool.query('SELECT 1 AS a');
+    assert.deepStrictEqual(res1.rows, [ { a:1 } ]);
+
+    const query = new QueryStream('SELECT 2 AS b');
+    const client = await pool.connect();
+    const stream = await client.query(query);
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    await stream.destroy();
+    if(process.env.WAIT_AFTER_CLOSE === '1') await new Promise(resolve => setTimeout(resolve, 100));
+
+    if(process.env.WAIT_AFTER_CLOSE === '2') {
+      await new Promise(resolve => stream.once('close', resolve));
+    }
+
+    await client.release();
+
+    const res2 = await pool.query('SELECT 4 AS d');
+    assert.deepStrictEqual(res2.rows, [ { d:4 } ]);
+
+    await pool.end();
+  })
 })


### PR DESCRIPTION
This might be a fix for https://github.com/brianc/node-postgres/issues/1674.

I would expect that connections _could_ be re-used safely after streaming though, so there should be a more correct way of approaching this...