### PR TITLE
pg-connection-string: avoid clobbering port from queryparams

### DIFF
--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -31,7 +31,6 @@ function parse(str) {
   config.user = auth[0]
   config.password = auth.splice(1).join(':')
 
-  config.port = result.port
   if (result.protocol == 'socket:') {
     config.host = decodeURI(result.pathname)
     config.database = result.query.db
@@ -41,6 +40,10 @@ function parse(str) {
   if (!config.host) {
     // Only set the host if there is no equivalent query param.
     config.host = result.hostname
+  }
+  if (!config.port) {
+    // Only set the port if there is no equivalent query param.
+    config.port = result.port
   }
 
   // If the host is missing it might be a URL-encoded path to a socket.

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -317,4 +317,10 @@ describe('parse', function () {
     var subject = parse(connectionString)
     subject.keepalives.should.equal('0')
   })
+
+  it('use the port specified in the query parameters', function () {
+    var connectionString = 'postgres:///?host=localhost&port=1234'
+    var subject = parse(connectionString)
+    subject.port.should.equal('1234')
+  })
 })


### PR DESCRIPTION
If the connection string is something like:
    postgresql://demo:password@/postgres?host=localhost&port=26258

Then the port from the query parameters should be used. Previously, the parsing function would end up with a null port, and the default port would end up being used by the connection package.