### PR TITLE
Cursor.handleError(): notify all listeners

### DIFF
--- a/packages/pg-cursor/index.js
+++ b/packages/pg-cursor/index.js
@@ -171,8 +171,9 @@ class Cursor extends EventEmitter {
     }
     // dispatch error to all waiting callbacks
     for (let i = 0; i < this._queue.length; i++) {
-      this._queue.pop()[1](msg)
+      this._queue[i][1](msg)
     }
+    this._queue.length = 0
 
     if (this.listenerCount('error') > 0) {
       // only dispatch error events if we have a listener

--- a/packages/pg-cursor/test/error-handling.js
+++ b/packages/pg-cursor/test/error-handling.js
@@ -64,6 +64,39 @@ describe('read callback does not fire sync', () => {
     })
     after = true
   })
+
+  it('should fire for every listener', (done) => {
+    const client = new pg.Client()
+    client.connect()
+    const cursor = client.query(new Cursor('SYNTAX ERROR?  YOU BET!'))
+    const callbackCounts = [0, 0, 0, 0, 0];
+    cursor.read(1, err => {
+      ++callbackCounts[0];
+      assert.strictEqual(err.message, 'syntax error at or near "SYNTAX"');
+    })
+    cursor.read(1, err => {
+      ++callbackCounts[1];
+      assert.strictEqual(err.message, 'syntax error at or near "SYNTAX"');
+    })
+    cursor.read(1, err => {
+      ++callbackCounts[2];
+      assert.strictEqual(err.message, 'syntax error at or near "SYNTAX"');
+    })
+    cursor.read(1, err => {
+      ++callbackCounts[3];
+      assert.strictEqual(err.message, 'syntax error at or near "SYNTAX"');
+    })
+    cursor.read(1, err => {
+      ++callbackCounts[4];
+      assert.strictEqual(err.message, 'syntax error at or near "SYNTAX"');
+    })
+    setTimeout(() => {
+      assert.deepStrictEqual(callbackCounts, [1, 1, 1, 1, 1], 'all callbacks should be called exactly once')
+      assert.deepStrictEqual(cursor._queue, [], 'should empty the queue')
+      client.end()
+      done()
+    }, 100);
+  })
 })
 
 describe('proper cleanup', function () {


### PR DESCRIPTION
It seems like `Cursor.handleError()` does not currently notify all listeners when there is an error.