### PR TITLE
pg-protocol: fix link to message format docs

### DIFF
--- a/packages/pg-protocol/src/testing/test-buffers.ts
+++ b/packages/pg-protocol/src/testing/test-buffers.ts
@@ -1,4 +1,4 @@
-// http://developer.postgresql.org/pgdocs/postgres/protocol-message-formats.html
+// https://www.postgresql.org/docs/current/protocol-message-formats.html
 import BufferList from './buffer-list'
 
 const buffers = {


### PR DESCRIPTION
developer.postgresql.org is dead for me; this looks like it's probably the same doc.

The current URL was redirecting to https://www.postgresql.org/docs/devel/protocol-message-formats.html in 2015, so that might be an alternative.