### PR TITLE
perf: remove superfluous flush message

### DIFF
--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -173,7 +173,6 @@ class Connection extends EventEmitter {
 
   sync() {
     this._ending = true
-    this._send(flushBuffer)
     this._send(syncBuffer)
   }
 


### PR DESCRIPTION
node-postgres sends both a `Flush` and a `Sync` message at the end of an extended protocol query protocol session. This is not necessary, as `Sync` already implicitly includes `Flush`. `Flush` will cause the backend to flush its network buffers and return any pending responses to the client. `Sync` will do the same, but also commit the implicit transaction (if any) and the backend will respond with a `ReadyForQuery` message. Removing this extra step will save one network message for each extended query protocol session that is executed.

We noticed this behavior while testing the node-postgres driver with [our proxy that allows Cloud Spanner](https://github.com/GoogleCloudPlatform/pgadapter) to be used with PostgreSQL drivers.
