### PR TITLE
Fix devcontainer build failure

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       PGHOST: db
       # set this to true in the development environment until I can get SSL setup on the 
       # docker postgres instance
-      PGTESTNOSSL: true
+      PGTESTNOSSL: 'true'
       
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity


### PR DESCRIPTION
When opening this project using devcontainers in VS Code and Github CodeSpaces, the build was failing due to the `PGTESTNOSSL` environment variable being interpreted as a boolean rather than a string. This small fix just adds quotes to enforce string typing on that env var.

To replicate the problem on `master` before merging, you can just open a CodeSpaces instance in Github (located in the green "Code" dropdown at the top-right of the file listing) and it will fail consistently. In the startup pane in the resulting window, you'll see it fail, spawn a recovery container, and there will be a popup with a link "View recovery logs". There, you should see logs containing this:

```{txt}
2022-10-18 15:13:33.649Z: The Compose file '/var/lib/docker/codespacemount/workspace/node-postgres/.devcontainer/docker-compose.yml' is invalid because:
2022-10-18 15:13:33.649Z: services.web.environment.PGTESTNOSSL contains true, which is an invalid type, it should be a string, number, or a null
2022-10-18 15:13:33.649Z: 
2022-10-18 15:13:33.649Z: Exit code 1
```
<details><summary>Click for full log example</summary>
<pre>
2022-10-18 15:13:30.459Z: Configuration starting...
2022-10-18 15:13:30.488Z: $ git -C "/var/lib/docker/codespacemount/workspace" clone --branch feature/pg-pool/events/emit-release --depth 1 https://github.com/nihonjinrxs/node-postgres "/var/lib/docker/codespacemount/workspace/node-postgres"
2022-10-18 15:13:30.530Z: Cloning into '/var/lib/docker/codespacemount/workspace/node-postgres'...
2022-10-18 15:13:31.444Z: git process exited with exit code 0
2022-10-18 15:13:31.448Z: $ git -C "/var/lib/docker/codespacemount/workspace/node-postgres" config --local remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
2022-10-18 15:13:31.457Z: git process exited with exit code 0
2022-10-18 15:13:32.389Z: @microsoft/vscode-dev-containers-cli 0.71.0.
2022-10-18 15:13:32.389Z: Start: Resolving Remote
2022-10-18 15:13:32.389Z: $ docker ps -q -a --filter label=Type=codespaces
2022-10-18 15:13:32.417Z: Stop (39 ms): Run: docker ps -q -a --filter label=Type=codespaces
2022-10-18 15:13:32.417Z: $ /usr/bin/node /usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /var/lib/docker/codespacemount/.persistedshare --container-data-folder .vscode-remote/data/Machine --container-system-data-folder /var/vscode-remote --workspace-folder /var/lib/docker/codespacemount/workspace/node-postgres --id-label Type=codespaces --log-level info --log-format json --config /var/lib/docker/codespacemount/workspace/node-postgres/.devcontainer/devcontainer.json --override-config /root/.codespaces/shared/merged_devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=bind,source=/.codespaces/agent/mount/cache,target=/vscode --skip-post-create --update-remote-user-uid-default never --mount-workspace-git-root false
2022-10-18 15:13:32.528Z: @devcontainers/cli 0.15.0. Node.js v14.20.0. linux 5.4.0-1090-azure x64.
2022-10-18 15:13:32.528Z: $ docker buildx version
2022-10-18 15:13:32.613Z: Stop (74 ms): Run: docker buildx version
2022-10-18 15:13:32.613Z: github.com/docker/buildx 0.9.1+azure-1 ed00243a0ce2a0aee75311b06e32d33b44729689
2022-10-18 15:13:32.613Z: 
2022-10-18 15:13:32.613Z: Start: Resolving Remote
2022-10-18 15:13:32.613Z: $ docker-compose version --short
2022-10-18 15:13:33.117Z: Stop (514 ms): Run: docker-compose version --short
2022-10-18 15:13:33.117Z: Docker Compose version: 1.29.2
2022-10-18 15:13:33.117Z: $ docker ps -q -a --filter label=com.docker.compose.project=node-postgres_devcontainer --filter label=com.docker.compose.service=web
2022-10-18 15:13:33.145Z: Stop (31 ms): Run: docker ps -q -a --filter label=com.docker.compose.project=node-postgres_devcontainer --filter label=com.docker.compose.service=web
2022-10-18 15:13:33.145Z: $ docker-compose -f /var/lib/docker/codespacemount/workspace/node-postgres/.devcontainer/docker-compose.yml -f /var/lib/docker/codespacemount/.persistedshare/docker-compose.codespaces.yml config
2022-10-18 15:13:33.649Z: Stop (500 ms): Run: docker-compose -f /var/lib/docker/codespacemount/workspace/node-postgres/.devcontainer/docker-compose.yml -f /var/lib/docker/codespacemount/.persistedshare/docker-compose.codespaces.yml config
2022-10-18 15:13:33.649Z: 
2022-10-18 15:13:33.649Z: The Compose file '/var/lib/docker/codespacemount/workspace/node-postgres/.devcontainer/docker-compose.yml' is invalid because:
2022-10-18 15:13:33.649Z: services.web.environment.PGTESTNOSSL contains true, which is an invalid type, it should be a string, number, or a null
2022-10-18 15:13:33.649Z: 
2022-10-18 15:13:33.649Z: Exit code 1
2022-10-18 15:13:33.649Z: Error: Command failed: docker-compose -f /var/lib/docker/codespacemount/workspace/node-postgres/.devcontainer/docker-compose.yml -f /var/lib/docker/codespacemount/.persistedshare/docker-compose.codespaces.yml config
2022-10-18 15:13:33.649Z:     at bc (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:271:907)
2022-10-18 15:13:33.649Z:     at processTicksAndRejections (internal/process/task_queues.js:95:5)
2022-10-18 15:13:33.649Z:     at async wF (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:245:1353)
2022-10-18 15:13:33.649Z:     at async mF (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:229:2375)
2022-10-18 15:13:33.649Z:     at async NF (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:286:2177)
2022-10-18 15:13:33.649Z:     at async so (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:286:3110)
2022-10-18 15:13:33.650Z:     at async kk (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:406:8224)
2022-10-18 15:13:33.650Z:     at async Fk (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:406:7980)
2022-10-18 15:13:33.650Z: Stop (1237 ms): Run: /usr/bin/node /usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /var/lib/docker/codespacemount/.persistedshare --container-data-folder .vscode-remote/data/Machine --container-system-data-folder /var/vscode-remote --workspace-folder /var/lib/docker/codespacemount/workspace/node-postgres --id-label Type=codespaces --log-level info --log-format json --config /var/lib/docker/codespacemount/workspace/node-postgres/.devcontainer/devcontainer.json --override-config /root/.codespaces/shared/merged_devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=bind,source=/.codespaces/agent/mount/cache,target=/vscode --skip-post-create --update-remote-user-uid-default never --mount-workspace-git-root false
2022-10-18 15:13:33.650Z: Exit code 1
2022-10-18 15:13:33.678Z: Failed to create container.
2022-10-18 15:13:33.684Z: Error: Command failed: /usr/bin/node /usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /var/lib/docker/codespacemount/.persistedshare --container-data-folder .vscode-remote/data/Machine --container-system-data-folder /var/vscode-remote --workspace-folder /var/lib/docker/codespacemount/workspace/node-postgres --id-label Type=codespaces --log-level info --log-format json --config /var/lib/docker/codespacemount/workspace/node-postgres/.devcontainer/devcontainer.json --override-config /root/.codespaces/shared/merged_devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=bind,source=/.codespaces/agent/mount/cache,target=/vscode --skip-post-create --update-remote-user-uid-default never --mount-workspace-git-root false
2022-10-18 15:13:33.688Z: Error Code: 1302
2022-10-18 15:13:33.690Z: Container creation failed.
2022-10-18 15:13:33.697Z: 
2022-10-18 15:13:33.700Z: Creating recovery container.
2022-10-18 15:14:33.531Z: Running blocking commands...
</pre>
</details>

Implementing this change and rebuilding the instance will allow it to succeed.