### PR TITLE
Emit a 'release' event when a connection is released back to the pool

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -330,6 +330,8 @@ class Pool extends EventEmitter {
 
     client._poolUseCount = (client._poolUseCount || 0) + 1
 
+    this.emit('release', err, client)
+
     // TODO(bmc): expose a proper, public interface _queryable and _ending
     if (err || this.ending || !client._queryable || client._ending || client._poolUseCount >= this.options.maxUses) {
       if (client._poolUseCount >= this.options.maxUses) {

--- a/packages/pg-pool/test/events.js
+++ b/packages/pg-pool/test/events.js
@@ -60,6 +60,42 @@ describe('events', function () {
     }, 100)
   })
 
+  it('emits release every time a client is released', function (done) {
+    const pool = new Pool()
+    let releaseCount = 0
+    pool.on('release', function (err, client) {
+      expect(err instanceof Error).not.to.be(true)
+      expect(client).to.be.ok()
+      releaseCount++
+    })
+    for (let i = 0; i < 10; i++) {
+      pool.connect(function (err, client, release) {
+        if (err) return done(err)
+        release()
+      })
+      pool.query('SELECT now()')
+    }
+    setTimeout(function () {
+      expect(releaseCount).to.be(20)
+      pool.end(done)
+    }, 100)
+  })
+
+  it('emits release with an error if client is released due to an error', function (done) {
+    const pool = new Pool()
+    pool.connect(function (err, client, release) {
+      expect(err).to.equal(undefined)
+      const releaseError = new Error('problem')
+      pool.once('release', function (err, errClient) {
+        console.log(err, errClient)
+        expect(err).to.equal(releaseError)
+        expect(errClient).to.equal(client)
+        pool.end(done)
+      })
+      release(releaseError)
+    })
+  })
+
   it('emits error and client if an idle client in the pool hits an error', function (done) {
     const pool = new Pool()
     pool.connect(function (err, client) {


### PR DESCRIPTION
This PR has the `Pool` object emit a `'release'` event upon the release of a client/connection back to the pool.

We're experiencing an issue that feels quite similar to what's described in brianc/node-postgres#2262, and in reading through the comments there, I was interested to see @brianc's suggestion of [adding a `'release'` event as the corresponding bookend to the `'connect'` and `'acquire'` events](https://github.com/brianc/node-postgres/issues/2262#issuecomment-656751203). However, in searching the code, it seems this was never implemented, so I've implemented that here.