### PR TITLE
ci: remove git credentials after checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     name: Node.js ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This PR removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to false, they are not used after the initial checkout.