### PR TITLE
Make Result iterable

### DIFF
--- a/packages/pg/lib/result.js
+++ b/packages/pg/lib/result.js
@@ -23,6 +23,10 @@ class Result {
     }
   }
 
+  [Symbol.iterator]() {
+    return this.rows.values()
+  }
+  
   // adds a command complete message
   addCommandComplete(msg) {
     var match


### PR DESCRIPTION
Make `Result` automatically iterable, so one can iterate through data without having to access `rows` explicitly:

```js
client.query('select...', (err, res) => {
    // below we can use just "res", not "res.rows"
    for(const a of res) {
        console.log(a); // print the row
    }
})
```