### PR TITLE
Changed docs header title to projects name

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -23,8 +23,7 @@ export default {
   },
   logo: (
     <>
-      <svg>...</svg>
-      <span>Next.js Static Site Generator</span>
+      <h1>Node Postgres</h1>
     </>
   ),
   head: (


### PR DESCRIPTION
Noticed that the title in the docs displays a generic text from Nextra.

Tought it would be nice to change it to the projects name.