### PR TITLE
Add informative SASL empty password error message

### DIFF
--- a/packages/pg/lib/sasl.js
+++ b/packages/pg/lib/sasl.js
@@ -23,6 +23,9 @@ function continueSession(session, password, serverData) {
   if (typeof password !== 'string') {
     throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string')
   }
+  if (password === '') {
+    throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a non-empty string')
+  }
   if (typeof serverData !== 'string') {
     throw new Error('SASL: SCRAM-SERVER-FIRST-MESSAGE: serverData must be a string')
   }

--- a/packages/pg/test/unit/client/sasl-scram-tests.js
+++ b/packages/pg/test/unit/client/sasl-scram-tests.js
@@ -100,6 +100,24 @@ test('sasl/scram', function () {
       }
     })
 
+    test('fails when client password is an empty string', function () {
+      assert.throws(
+        function () {
+          sasl.continueSession(
+            {
+              message: 'SASLInitialResponse',
+              clientNonce: 'a',
+            },
+            '',
+            'r=1,i=1'
+          )
+        },
+        {
+          message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a non-empty string',
+        }
+      )
+    })
+
     test('fails when iteration is missing in server message', function () {
       assert.throws(
         function () {

--- a/packages/pg/test/unit/client/sasl-scram-tests.js
+++ b/packages/pg/test/unit/client/sasl-scram-tests.js
@@ -80,6 +80,26 @@ test('sasl/scram', function () {
       )
     })
 
+    test('fails when client password is not a string', function () {
+      for(const badPasswordValue of [null, undefined, 123, new Date(), {}]) {
+        assert.throws(
+          function () {
+            sasl.continueSession(
+              {
+                message: 'SASLInitialResponse',
+                clientNonce: 'a',
+              },
+              badPasswordValue,
+              'r=1,i=1'
+            )
+          },
+          {
+            message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string',
+          }
+        )
+      }
+    })
+
     test('fails when iteration is missing in server message', function () {
       assert.throws(
         function () {


### PR DESCRIPTION
First commit adds a test for non-string password values being used for SASL authentication. The main code already throws an error for it but it wasn't tested anywhere.

Second commit adds a new error message when SASL authentication is requested by the server but the password is a zero-length string. This would already be a failure situation as you cannot have a zero-length password with SASL auth. This commit just changes it so the user gets an error of: `SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a non-empty string`. Also adds a unit test for it.

I didn't merge the two checks and error messages as they're more informative for the end user separately.

Addresses and somewhat closes #2757.