### PR TITLE
Escape \0 in identifiers and literals

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -444,7 +444,7 @@ class Client extends EventEmitter {
 
   // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
   escapeIdentifier(str) {
-    return '"' + str.replace(/"/g, '""') + '"'
+    return '"' + str.replace(/["\0]/g, '""') + '"'
   }
 
   // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
@@ -459,6 +459,8 @@ class Client extends EventEmitter {
       } else if (c === '\\') {
         escaped += c + c
         hasBackslash = true
+      } else if (c === '\0') {
+        // Ignore it
       } else {
         escaped += c
       }


### PR DESCRIPTION
> Quoted identifiers can contain any character, **except the character with code zero**. (To include a double quote, write two double quotes.)
> -- https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS (emphasis mine)

Current escaping was ported from the PostgreSQL source code, wherein `\0` cannot occur in a string (because C). However, it can in JS.

Currently if you `escapeIdentifier` with a `\0` in the string, no error is thrown, but when you run the query an 'invalid message format' error is thrown:

```js
const pg = require('pg');
const p = new pg.Pool({connectionString: 'test'});
p.query('select 1 as ' + p.Client.prototype.escapeIdentifier('"one\0"')).then(a=>a, e=>e).then(console.log.bind(console))
```

```
> error: invalid message format
    at Parser.parseErrorMessage (.../node_modules/pg-protocol/dist/parser.js:287:98)
    at Parser.handlePacket (.../node_modules/pg-protocol/dist/parser.js:126:29)
    at Parser.parse (.../node_modules/pg-protocol/dist/parser.js:39:38)
    at Socket.<anonymous> (.../node_modules/pg-protocol/dist/index.js:11:42)
    at Socket.emit (node:events:520:28)
    at Socket.emit (node:domain:537:15)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
  length: 81,
  severity: 'ERROR',
  code: '08P01',
  detail: undefined,
  hint: undefined,
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'pqformat.c',
  line: '640',
  routine: 'pq_getmsgend'
}
```

I don't think any legitimate code would ever trigger this, but it does feel like `escapeIdentifier` should ensure that independent of the input, no PostgreSQL protocol errors should be raised. To address this with minimal impact on performance, I've simply had `\0` be replaced with `"`. There are definitely other options for handling it, but I don't think any of them are worth the trade-off in performance. Since we already have a loop in `escapeLiteral` I just had `\0` stripped from there as if it didn't exist.

Thanks for `pg` ❤️ 