### PR TITLE
Attempt to fix timing test flake on older versions of node in CI

### DIFF
--- a/packages/pg-pool/test/lifetime-timeout.js
+++ b/packages/pg-pool/test/lifetime-timeout.js
@@ -21,7 +21,7 @@ describe('lifetime timeout', () => {
   })
   it('connection lifetime should expire and remove the client after the client is done working', (done) => {
     const pool = new Pool({ maxLifetimeSeconds: 1 })
-    pool.query('SELECT pg_sleep(1.01)')
+    pool.query('SELECT pg_sleep(1.4)')
     pool.on('remove', () => {
       console.log('expired while busy - on-remove event')
       expect(pool.expiredCount).to.equal(0)
@@ -33,10 +33,11 @@ describe('lifetime timeout', () => {
     'can remove expired clients and recreate them',
     co.wrap(function* () {
       const pool = new Pool({ maxLifetimeSeconds: 1 })
-      let query = pool.query('SELECT pg_sleep(1)')
+      let query = pool.query('SELECT pg_sleep(1.4)')
       expect(pool.expiredCount).to.equal(0)
       expect(pool.totalCount).to.equal(1)
       yield query
+      yield new Promise((resolve) => setTimeout(resolve, 100))
       expect(pool.expiredCount).to.equal(0)
       expect(pool.totalCount).to.equal(0)
       yield pool.query('SELECT NOW()')


### PR DESCRIPTION
Sometimes, particularly in node v10.0 there's a bit of a timing issue where the client isn't removed _immediately_ after the query is finished...this gives a little wiggle to prevent the test from failing so much and screwing up CI.