### PR TITLE
Destroy connection if the server does not support SSL

### DIFF
--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -72,11 +72,11 @@ class Connection extends EventEmitter {
         case 'S': // Server supports SSL connections, continue with a secure connection
           break
         case 'N': // Server does not support SSL connections
-          self.stream.end()
+          self.stream.destroy()
           return self.emit('error', new Error('The server does not support SSL connections'))
         default:
           // Any other response byte, including 'E' (ErrorResponse) indicating a server error
-          self.stream.end()
+          self.stream.destroy()
           return self.emit('error', new Error('There was an error establishing an SSL connection'))
       }
       var tls = require('tls')


### PR DESCRIPTION
Fix #2907 by removing the delay of ending the connection normally, as this is an error condition.