### PR TITLE
Fix typo in URL on Pooling page

### DIFF
--- a/docs/pages/features/pooling.mdx
+++ b/docs/pages/features/pooling.mdx
@@ -19,7 +19,7 @@ The easiest and by far most common way to use node-postgres is through a connect
 
 ### Good news
 
-node-postgres ships with built-in connection pooling via the [pg-pool](/api/pool) module.
+node-postgres ships with built-in connection pooling via the [pg-pool](/apis/pool) module.
 
 ## Examples
 


### PR DESCRIPTION
The [features/pooling page](https://node-postgres.com/features/pooling#good-news) links to `https://node-postgres.com/api/pool` (404) which I believe should be `https://node-postgres.com/apis/pool`.

So here a small PR to fix that!