### PR TITLE
Add release event to Pool API docs

### DIFF
--- a/docs/pages/apis/pool.mdx
+++ b/docs/pages/apis/pool.mdx
@@ -271,6 +271,12 @@ The error listener is passed the error as the first argument and the client upon
   uncaught error and potentially crash your node process.
 </Alert>
 
+### release
+
+`pool.on('release', (err: Error, client: Client) => void) => void`
+
+Whenever a client is released back into the pool, the pool will emit the `release` event.
+
 ### remove
 
 `pool.on('remove', (client: Client) => void) => void`


### PR DESCRIPTION
@brianc I realized with your release including #2845 and the update of the docs link in #2925 that I hadn't done the documentation update to match the feature change for the new event in pg-pool.

This small PR makes that documentation update.

Apologies for the prior oversight!