### PR TITLE
Serialize arrays of Uint8Array objects as hex escape sequences

### DIFF
--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -23,8 +23,17 @@ function arrayString(val) {
       result = result + 'NULL'
     } else if (Array.isArray(val[i])) {
       result = result + arrayString(val[i])
-    } else if (val[i] instanceof Buffer) {
-      result += '\\\\x' + val[i].toString('hex')
+    } else if (ArrayBuffer.isView(val[i])) {
+      var item = val[i]
+      if (!(item instanceof Buffer)) {
+        var buf = Buffer.from(item.buffer, item.byteOffset, item.byteLength)
+        if (buf.length === item.byteLength) {
+          item = buf
+        } else {
+          item = buf.slice(item.byteOffset, item.byteOffset + item.byteLength)
+        }
+      }
+      result += '\\\\x' + item.toString('hex')
     } else {
       result += escapeElement(prepareValue(val[i]))
     }

--- a/packages/pg/test/unit/utils-tests.js
+++ b/packages/pg/test/unit/utils-tests.js
@@ -175,6 +175,13 @@ test('prepareValue: buffer array prepared properly', function () {
   assert.strictEqual(out, '{\\\\xdead,\\\\xbeef}')
 })
 
+test('prepareValue: Uint8Array array prepared properly', function () {
+  var buffer1 = Uint8Array.from(Buffer.from('dead', 'hex'))
+  var buffer2 = Uint8Array.from(Buffer.from('beef', 'hex'))
+  var out = utils.prepareValue([buffer1, buffer2])
+  assert.strictEqual(out, '{\\\\xdead,\\\\xbeef}')
+})
+
 test('prepareValue: objects with complex toPostgres prepared properly', function () {
   var buf = Buffer.from('zomgcustom!')
   var customType = {


### PR DESCRIPTION
Previously, if you attempted to pass an array of `Uint8Array` objects to a prepared statement, it would render each literal numeric value of that array.

Since `Uint8Array` (and other `TypedArray` types) represent views over raw bytes, ensure these are serialized to Postgres as bytes via hex escape sequence.
