### PR TITLE
feat: add connection parameter nativeConnectionString

### DIFF
--- a/packages/pg/lib/native/client.js
+++ b/packages/pg/lib/native/client.js
@@ -29,6 +29,7 @@ var Client = (module.exports = function (config) {
   // keep these on the object for legacy reasons
   // for the time being. TODO: deprecate all this jazz
   var cp = (this.connectionParameters = new ConnectionParameters(config))
+  if (config.nativeConnectionString) cp.nativeConnectionString = config.nativeConnectionString
   this.user = cp.user
 
   // "hiding" the password so it doesn't show up in stack traces
@@ -82,6 +83,7 @@ Client.prototype._connect = function (cb) {
   this._connecting = true
 
   this.connectionParameters.getLibpqConnectionString(function (err, conString) {
+    if (self.connectionParameters.nativeConnectionString) conString = self.connectionParameters.nativeConnectionString
     if (err) return cb(err)
     self.native.connect(conString, function (err) {
       if (err) {

--- a/packages/pg/test/native/native-connection-string-tests.js
+++ b/packages/pg/test/native/native-connection-string-tests.js
@@ -1,0 +1,50 @@
+'use strict'
+var helper = require('../test-helper')
+var Client = require('../../lib/native')
+const suite = new helper.Suite()
+
+suite.test('respects nativeConnectionString in config', function (done) {
+  const realPort = helper.config.port
+  const nativeConnectionString = `host=${helper.config.host} port=${helper.config.port} dbname=${helper.config.database} user=${helper.config.user} password=${helper.config.password}`
+
+  // setting wrong port to make sure config is take from nativeConnectionString and not env
+  helper.config.port = '90929'
+
+  var client = new Client({
+    ...helper.config,
+    nativeConnectionString,
+  })
+
+  client.connect(function (err) {
+    assert(!err)
+    client.query(
+      'SELECT 1 as num',
+      assert.calls(function (err, result) {
+        assert(!err)
+        assert.equal(result.rows[0].num, 1)
+        assert.strictEqual(result.rowCount, 1)
+        // restore post in case helper config will be reused
+        helper.config.port = realPort
+        client.end(done)
+      })
+    )
+  })
+})
+
+suite.test('respects nativeConnectionString in config even when it is corrupted', function (done) {
+  const nativeConnectionString = `foobar`
+
+  var client = new Client({
+    nativeConnectionString,
+  })
+
+  client.connect(function (err) {
+    assert(err)
+    assert.equal(
+      err.message,
+      'missing "=" after "foobar" in connection info string\n',
+      'Connection error should have been thrown'
+    )
+    client.end(done)
+  })
+})


### PR DESCRIPTION
This is a follow-up of MR https://github.com/brianc/node-postgres/pull/2751

I copy-paster the solution itself, but also I have added tests as you asked

Support of nativeConnectionString in some cases could be really useful like
* specifying multihost URI
* specifying additional params (like target_session_attrs)
* having different formats of the connection URI, anything what is described in the [libpq docs](https://www.postgresql.org/docs/9.3/libpq-connect.html#LIBPQ-CONNSTRING)

using ConnectionParameters class not always be helpful since it doesn't support all possible variants of the connection string