### PR TITLE
Fix: deal with bigint types in objects stored as jsonb

### DIFF
--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -78,7 +78,7 @@ function prepareObject(val, seen) {
 
     return prepareValue(val.toPostgres(prepareValue), seen)
   }
-  return JSON.stringify(val)
+  return JSON.stringify(val, (_, val) => typeof val === 'bigint' ? val.toString() : val)
 }
 
 function pad(number, digits) {


### PR DESCRIPTION
The pg library fails to serialize query values in case when an object for jsonb column contains bigint. 

The failed error message is as follows because JSON.serialize does not know how to deal with bigint.

```
TypeError: Do not know how to serialize a BigInt
```

Reproducible example could look like this:
```ts
const queryConfig = `INSERT INTO my_table (id, data) VALUES ($1, $2)`;
const values = ['someId', { someValue: BigInt(1) }]
await pgClient.query(queryConfig, values);
```
