### PR TITLE
fix(theme.config.js): Replace default meta description and social title

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -30,8 +30,8 @@ export default {
   head: (
     <>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <meta name="description" content="Nextra: the next docs builder" />
-      <meta name="og:title" content="Nextra: the next docs builder" />
+      <meta name="description" content="node-postgres is a collection of node.js modules for interfacing with your PostgreSQL database." />
+      <meta name="og:title" content="node-postgres" />
       <script async src="https://www.googletagmanager.com/gtag/js?id=UA-100138145-1"></script>
       <script
         dangerouslySetInnerHTML={{


### PR DESCRIPTION
Currently still nextra default.

Those are shown in Slack and other social apps when sharing the website.
<img width="219" alt="image" src="https://user-images.githubusercontent.com/183673/230488783-309c0ce7-d295-44e4-b37e-4aeb11c5ccb9.png">
