### PR TITLE
Document client.escapeIdentifier and client.escapeLiteral

### DIFF
--- a/docs/pages/apis/client.mdx
+++ b/docs/pages/apis/client.mdx
@@ -1,6 +1,7 @@
 ---
 title: pg.Client
 ---
+import { Alert } from '/components/alert.tsx'
 
 ## new Client
 
@@ -255,6 +256,44 @@ client
 ```
 
 _note: end returning a promise is only available in pg7.0 and above_
+
+## client.escapeIdentifier
+
+Escapes a string as a [SQL identifier](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS). There are two ways of using this method: 
+
+First, this can be used on an existing instance of `Client`:
+```js
+const escpaedIdentifier = client.escapeIdentifier('FooIdentifier')
+console.log(escpaedIdentifier) // '"FooIdentifier"'
+```
+
+Alternatively, this can be used via `Client.prototype`:
+```js
+const { Client } = require('pg')
+const escpaedIdentifier = Client.prototype.escapeIdentifier('Bar"Identifier')
+console.log(escpaedIdentifier) // '"Bar""Identifier"'
+```
+
+## client.escapeLiteral
+
+Escapes a string as a [SQL literal](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS). There are two ways of using this method:
+
+<Alert>
+  **Note**: Instead of manually escaping SQL literals, it is recommended to use parameterized queries. Refer to [parameterized queries](/features/queries#parameterized-query) and the [client.query](#clientquery) API for more information.
+</Alert>
+
+First, this can be used on an existing instance of `Client`:
+```js
+const escapedLiteral = client.escapeLiteral("hello 'world'")
+console.log(escapedLiteral) // "Hello ''world''"
+```
+
+Alternatively, this can be used via `Client.prototype`:
+```js
+const { Client } = require('pg')
+const escapedLiteral = Client.prototype.escapeLiteral("hello \\ ' world")
+console.log(escapedLiteral) // " E'hello \\\\ '' world'"
+```
 
 ## events
 


### PR DESCRIPTION
Per #1978 it seems that these client APIs are undocumented. I added documentation for these methods along with some examples and relevant links.

I wasn't too sure what kind of structure to take with the documentation, such as documenting the usage via a client instance and the Client prototype. I can shuffle things around if there is a better way of expressing the usage.