### PR TITLE
improve performance by using splitting steps to different transforms

### DIFF
--- a/packages/pg-protocol/src/index.ts
+++ b/packages/pg-protocol/src/index.ts
@@ -1,10 +1,24 @@
 import { BackendMessage, DatabaseError } from './messages'
 import { serialize } from './serializer'
 import { Parser, MessageCallback } from './parser'
+import {pipeline} from 'stream';
 
 export function parse(stream: NodeJS.ReadableStream, callback: MessageCallback): Promise<void> {
   const parser = new Parser()
-  stream.on('data', (buffer: Buffer) => parser.parse(buffer, callback))
+  stream.on('data', (buffer: Buffer) => parser.parse(buffer, callback));
+
+  pipeline(
+    stream,
+    parser.splitMessagesTransform.bind(parser),
+    parser.convertToMessageTransform.bind(parser),
+    async function* (stream) {
+      for await(const message of stream) {
+        callback(message)
+      }
+    },
+    (err) => err ? reject(err) : resolve()
+  );
+
   return new Promise((resolve) => stream.on('end', () => resolve()))
 }
 

--- a/packages/pg-protocol/src/index.ts
+++ b/packages/pg-protocol/src/index.ts
@@ -1,25 +1,24 @@
 import { BackendMessage, DatabaseError } from './messages'
 import { serialize } from './serializer'
 import { Parser, MessageCallback } from './parser'
-import {pipeline} from 'stream';
+import { pipeline } from 'stream'
 
 export function parse(stream: NodeJS.ReadableStream, callback: MessageCallback): Promise<void> {
   const parser = new Parser()
-  stream.on('data', (buffer: Buffer) => parser.parse(buffer, callback));
 
-  pipeline(
-    stream,
-    parser.splitMessagesTransform.bind(parser),
-    parser.convertToMessageTransform.bind(parser),
-    async function* (stream) {
-      for await(const message of stream) {
-        callback(message)
-      }
-    },
-    (err) => err ? reject(err) : resolve()
-  );
-
-  return new Promise((resolve) => stream.on('end', () => resolve()))
+  return new Promise((resolve, reject) => {
+    pipeline(
+      stream,
+      parser.splitMessagesTransform.bind(parser),
+      parser.convertToMessageTransform.bind(parser),
+      async function* (stream) {
+        for await(const message of stream) {
+          callback(message)
+        }
+      },
+      (err) => err ? reject(err) : resolve()
+    );
+  })
 }
 
 export { serialize, DatabaseError }


### PR DESCRIPTION
Improve the performance of the parser by splitting the parse function into 3 steps:
1. split buffers to messages (each message is gonna go to the next transform)
2. parse message
3. call the callback 

This improve the performance as it add back pressure and reduce event loop lag as each message parsed in  async way

Would like your opinion before cleaning code duplication.

also, I saw that this package supports node version 10 and 12 which are dead for a long time, which prevent from using async iterator in pipeline