### PR TITLE
docs(api/result): clarify that `result.rowCount` can be `null`

### DIFF
--- a/docs/pages/apis/result.mdx
+++ b/docs/pages/apis/result.mdx
@@ -37,9 +37,9 @@ await client.end()
 
 The command type last executed: `INSERT` `UPDATE` `CREATE` `SELECT` etc.
 
-### `result.rowCount: int`
+### `result.rowCount: int | null`
 
-The number of rows processed by the last command. 
+The number of rows processed by the last command. Can be `null` for commands that never affect rows, such as the `LOCK`-command. More specifically, some commands, including `LOCK`, only return a command tag of the form `COMMAND`, without any `[ROWS]`-field to parse. For such commands `rowCount` will be `null`.
 
 _note: this does not reflect the number of rows __returned__ from a query.  e.g. an update statement could update many rows (so high `result.rowCount` value) but `result.rows.length` would be zero.  To check for an empty query reponse on a `SELECT` query use `result.rows.length === 0`_.
 


### PR DESCRIPTION
I stumbled upon this when running a `LOCK`-command and looking at the `result.rowCount`-field, which was `null`.

This is because `result.rowCount` is initialized to `null`, but only set to an `int`-value if the returned command tag consists of more than one word, which is not the case in general.

The postgres docs (https://www.postgresql.org/docs/current/protocol-message-formats.html, ctrl+f for `CommandComplete`) say:

> The command tag. This is usually a single word that identifies which SQL command was completed.

This explains why, for commands such as `LOCK`, there is no `[ROWS]`-field to parse.

See the logic in `node-postgres` here: https://github.com/brianc/node-postgres/blob/b357e1884ad25b23a4ab034b443ddfc8c8261951/packages/pg/lib/result.js#L13-L47

Running a command such as `LOCK`, postgres will return a command tag of simply the form `LOCK`, and thus `result.rowCount` will stay `null`.

This PR clarififes this in the docs.