### PR TITLE
fix: ensure that pg-cloudflare can be used with bundlers that don't know about Cloudflare sockets

### DIFF
--- a/packages/pg-cloudflare/package.json
+++ b/packages/pg-cloudflare/package.json
@@ -2,12 +2,16 @@
   "name": "pg-cloudflare",
   "version": "1.1.0",
   "description": "A socket implementation that can run on Cloudflare Workers using native TCP connections.",
-  "main": "dist/index.js",
+  "main": "dist/empty.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
   "devDependencies": {
     "ts-node": "^8.5.4",
     "typescript": "^4.0.3"
+  },
+  "exports": {
+    "workerd": "./dist/index.js",
+    "default": "./dist/empty.js"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/pg-cloudflare/src/empty.ts
+++ b/packages/pg-cloudflare/src/empty.ts
@@ -1,0 +1,3 @@
+// This is an empty module that is served up when outside of a workerd environment
+// See the `exports` field in package.json
+export default {}


### PR DESCRIPTION
Fixes #2975

By implementing package.json `exports` we can avoid processing the Cloudflare specific code, which contains `import ... from "cloudflare:sockets"`, in bundlers such as Webpack.

If you are bundling for a Worker environment using Webpack then you need to add the `workerd` condition and ignore `cloudflare:sockets` imports:

**webpack.config.js**
```js
  resolve: { conditionNames: ["require", "node", "workerd"] },
  plugins: [
    new webpack.IgnorePlugin({
      resourceRegExp: /^cloudflare:sockets$/,
    }),
  ],
```