### PR TITLE
Catch errors thrown by connect

### DIFF
--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -84,19 +84,20 @@ class Connection extends EventEmitter {
         socket: self.stream,
       }
 
-      if (self.ssl !== true) {
-        Object.assign(options, self.ssl)
-
-        if ('key' in self.ssl) {
-          options.key = self.ssl.key
-        }
-      }
-
-      var net = require('net')
-      if (net.isIP && net.isIP(host) === 0) {
-        options.servername = host
-      }
       try {
+        if (self.ssl !== true) {
+          Object.assign(options, self.ssl)
+
+          if ('key' in self.ssl) {
+            options.key = self.ssl.key
+          }
+        }
+
+        var net = require('net')
+        if (net.isIP && net.isIP(host) === 0) {
+          options.servername = host
+        }
+
         self.stream = getSecureStream(options)
       } catch (err) {
         return self.emit('error', err)

--- a/packages/pg/test/integration/client/error-handling-tests.js
+++ b/packages/pg/test/integration/client/error-handling-tests.js
@@ -191,6 +191,19 @@ suite.test('when connecting to an invalid host with callback', function (done) {
   })
 })
 
+suite.test('when connecting with an invalid ssl value', function (done) {
+  var client = new Client({
+    ssl: 'off',
+  })
+  client.on('error', () => {
+    assert.fail('unexpected error event when connecting')
+  })
+  client.connect(function (error, client) {
+    assert(error instanceof Error)
+    done()
+  })
+})
+
 suite.test('when connecting to invalid host with promise', function (done) {
   var client = new Client({
     user: 'very invalid username',


### PR DESCRIPTION
We had a user submit a PG connstring with `?ssl=off`, while this is invalid, it's not failing the parsing, and connect() throws on:

> Cannot use 'in' operator to search for 'key' in off TypeError: Cannot use 'in' operator to search for 'key' in off at Socket.<anonymous> (/Users/xavier/git/node-postgres/packages/pg/lib/connection.js:90:19)

Because `Connection` extends `EventEmitter`, that exception is not `catch`-able with a `try` / `catch` around the call to `client.connect()`. I am following on the footsteps of https://github.com/brianc/node-postgres/pull/2569, and making sure that exception is properly caught internally.

Ideally, this `?ssl=off` value should trigger a validation error, but:
  - I'm not certain not to break compat by adding a stricter input validation
  - With this PR, we're possibly covering other edge cases

Added a unit test, that fails if `connection.js` is not patched: an unhandled exception bubbles up.