### PR TITLE
Update pg-connection-string url in connecting.mdx

### DIFF
--- a/docs/pages/features/connecting.mdx
+++ b/docs/pages/features/connecting.mdx
@@ -127,7 +127,7 @@ client = new Client({
 
 ## Connection URI
 
-You can initialize both a pool and a client with a connection string URI as well. This is common in environments like Heroku where the database connection string is supplied to your application dyno through an environment variable. Connection string parsing brought to you by [pg-connection-string](https://github.com/iceddev/pg-connection-string).
+You can initialize both a pool and a client with a connection string URI as well. This is common in environments like Heroku where the database connection string is supplied to your application dyno through an environment variable. Connection string parsing brought to you by [pg-connection-string](https://github.com/brianc/node-postgres/tree/master/packages/pg-connection-string).
 
 ```js
 import { Pool, Client } from 'pg'


### PR DESCRIPTION
The contents of the repository the link is pointing to have been moved to the monorepo.