### PR TITLE
Remove await from client release

### DIFF
--- a/docs/pages/features/pooling.mdx
+++ b/docs/pages/features/pooling.mdx
@@ -43,7 +43,7 @@ const client = await pool.connect()
 const res = await client.query('SELECT * FROM users WHERE id = $1', [1])
 console.log(res.rows[0])
 
-await client.release()
+client.release()
 ```
 
 <Alert>


### PR DESCRIPTION
The `client.release()` does not return a promise.