### PR TITLE
Fail gracefully when connecting to other database

### DIFF
--- a/packages/pg-protocol/src/parser.ts
+++ b/packages/pg-protocol/src/parser.ts
@@ -199,7 +199,7 @@ export class Parser {
       case MessageCodes.CopyData:
         return this.parseCopyData(offset, length, bytes)
       default:
-        assert.fail(`unknown message code: ${code.toString(16)}`)
+        return new DatabaseError('invalid database response', length, 'error')
     }
   }
 

--- a/packages/pg-protocol/src/parser.ts
+++ b/packages/pg-protocol/src/parser.ts
@@ -199,7 +199,7 @@ export class Parser {
       case MessageCodes.CopyData:
         return this.parseCopyData(offset, length, bytes)
       default:
-        return new DatabaseError('invalid database response', length, 'error')
+        return new DatabaseError('received invalid response: ' + code.toString(16), length, 'error')
     }
   }
 

--- a/packages/pg/test/integration/gh-issues/2627-tests.js
+++ b/packages/pg/test/integration/gh-issues/2627-tests.js
@@ -1,0 +1,65 @@
+'use strict'
+const net = require('net')
+const helper = require('./../test-helper')
+
+const suite = new helper.Suite()
+
+const options = {
+  host: 'localhost',
+  port: Math.floor(Math.random() * 2000) + 2000,
+  connectionTimeoutMillis: 2000,
+  user: 'not',
+  database: 'existing',
+}
+
+// This is the content of the packets sent by a MySQL server during the handshake.
+// Those were captured with the `mysql:8.0.33` docker image.
+const MySqlHandshake = Buffer.from(
+  'SgAAAAo4LjAuMjgAHwAAAB4dKyUJZ2p6AP///wIA/98VAAAAAAAAAAAA' +
+  'AAo1YiNJajgKKGkpfgBjYWNoaW5nX3NoYTJfcGFzc3dvcmQAIQAAAf+EBC' +
+  'MwOFMwMUdvdCBwYWNrZXRzIG91dCBvZiBvcmRlcg==',
+  'base64'
+)
+
+const serverWithInvalidResponse = (port, callback) => {
+  const sockets = new Set()
+
+  const server = net.createServer((socket) => {
+    socket.write(MySqlHandshake)
+
+    // This server sends an invalid response which should throw in pg-protocol
+    sockets.add(socket)
+
+  })
+
+  let closing = false
+  const closeServer = (done) => {
+    if (closing) return
+    closing = true
+
+    server.close(done)
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+  }
+
+  server.listen(port, options.host, () => callback(closeServer))
+}
+
+
+suite.test('client should fail to connect', (done) => {
+  serverWithInvalidResponse(options.port, (closeServer) => {
+    const client = new helper.Client(options)
+
+    client
+      .connect()
+      .then(() => {
+        done(new Error('Expected client.connect() to fail'))
+      })
+      .catch((err) => {
+        assert(err)
+        assert.strictEqual(err.message, 'invalid database response')
+        closeServer(done)
+      })
+  })
+});

--- a/packages/pg/test/integration/gh-issues/2627-tests.js
+++ b/packages/pg/test/integration/gh-issues/2627-tests.js
@@ -16,8 +16,8 @@ const options = {
 // Those were captured with the `mysql:8.0.33` docker image.
 const MySqlHandshake = Buffer.from(
   'SgAAAAo4LjAuMjgAHwAAAB4dKyUJZ2p6AP///wIA/98VAAAAAAAAAAAA' +
-  'AAo1YiNJajgKKGkpfgBjYWNoaW5nX3NoYTJfcGFzc3dvcmQAIQAAAf+EBC' +
-  'MwOFMwMUdvdCBwYWNrZXRzIG91dCBvZiBvcmRlcg==',
+    'AAo1YiNJajgKKGkpfgBjYWNoaW5nX3NoYTJfcGFzc3dvcmQAIQAAAf+EBC' +
+    'MwOFMwMUdvdCBwYWNrZXRzIG91dCBvZiBvcmRlcg==',
   'base64'
 )
 
@@ -29,7 +29,6 @@ const serverWithInvalidResponse = (port, callback) => {
 
     // This server sends an invalid response which should throw in pg-protocol
     sockets.add(socket)
-
   })
 
   let closing = false
@@ -46,7 +45,6 @@ const serverWithInvalidResponse = (port, callback) => {
   server.listen(port, options.host, () => callback(closeServer))
 }
 
-
 suite.test('client should fail to connect', (done) => {
   serverWithInvalidResponse(options.port, (closeServer) => {
     const client = new helper.Client(options)
@@ -58,8 +56,8 @@ suite.test('client should fail to connect', (done) => {
       })
       .catch((err) => {
         assert(err)
-        assert.strictEqual(err.message, 'invalid database response')
+        assert(err.message.includes('invalid response'))
         closeServer(done)
       })
   })
-});
+})


### PR DESCRIPTION
Fixes #2627 

I'm currently working at Forest Admin.
We're a French company building a SaaS that generates admin panels.

During onboarding, we connect to our customer's databases to introspect the structure.
However, customers don't always know which database vendor they are using, and click on the wrong one during onboarding.

This causes pg-protocol to throw an unhandled exception, and our backend workers to go down.

I tried to follow the coding style and test this.
Don't hesitate to come back to me if anything is not at it should be!

Note that I never managed to run all the tests locally... so I'm likely to break others.
I'm creating the PR so that the CI runs, and that I can check if everything is OK