### PR TITLE
Remove 1 loop on rowDescription event

### DIFF
--- a/packages/pg/lib/result.js
+++ b/packages/pg/lib/result.js
@@ -98,7 +98,7 @@ class Result {
         this._parsers[i] = types.getTypeParser(desc.dataTypeID, desc.format || 'text')
       }
     }
-    this._prebuiltEmptyResultObject = row
+    this._prebuiltEmptyResultObject = { ...row }
   }
 }
 

--- a/packages/pg/lib/result.js
+++ b/packages/pg/lib/result.js
@@ -61,7 +61,7 @@ class Result {
   }
 
   parseRow(rowData) {
-    var row = { ... this._prebuiltEmptyResultObject }
+    var row = { ...this._prebuiltEmptyResultObject }
     for (var i = 0, len = rowData.length; i < len; i++) {
       var rawValue = rowData[i]
       var field = this.fields[i].name
@@ -85,22 +85,20 @@ class Result {
     if (this.fields.length) {
       this._parsers = new Array(fieldDescriptions.length)
     }
+
+    var row = {}
+
     for (var i = 0; i < fieldDescriptions.length; i++) {
       var desc = fieldDescriptions[i]
+      row[desc.name] = null
+
       if (this._types) {
         this._parsers[i] = this._types.getTypeParser(desc.dataTypeID, desc.format || 'text')
       } else {
         this._parsers[i] = types.getTypeParser(desc.dataTypeID, desc.format || 'text')
       }
     }
-    this._createPrebuiltEmptyResultObject()
-  }
-  _createPrebuiltEmptyResultObject() {
-    var row = {}
-    for (var i = 0; i < this.fields.length; i++) {
-      row[this.fields[i].name] = null
-    }
-    this._prebuiltEmptyResultObject = { ... row }
+    this._prebuiltEmptyResultObject = row
   }
 }
 


### PR DESCRIPTION
Addresses #3055

This is functionally the same but avoids the 1 extra loop being added by building the prebuilt results within the same loop already used to build other cached pieces of the result parser when it receives the `rowDescription` event.

