### PR TITLE
fix: conflict between browser URL object and Node URL object

### DIFF
--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -1,9 +1,9 @@
 'use strict'
-
 //Parse method copied from https://github.com/brianc/node-postgres
 //Copyright (c) 2010-2014 Brian Carlson (brian.m.carlson@gmail.com)
 //MIT License
 
+const { URL } = require('url')
 //parses a connection string
 function parse(str) {
   //unix socket


### PR DESCRIPTION
I am running this package using electron, what i noticed was that due to the fact that the lines between node and browser environments become a bit blurred, the URL class that was being used was the one defined by the browser and not node. By making an explicit require it ensures the correct Class is used.

While creating a test for this would be difficuilt i think adding an eslint rule to stop using globally defined objects and require imports instead would resolve issues like this in the future