### PR TITLE
Fix get value of last column with same name in result rows

### DIFF
--- a/packages/pg/lib/result.js
+++ b/packages/pg/lib/result.js
@@ -67,6 +67,8 @@ class Result {
       var field = this.fields[i].name
       if (rawValue !== null) {
         row[field] = this._parsers[i](rawValue)
+      } else {
+        row[field] = null
       }
     }
     return row

--- a/packages/pg/test/integration/gh-issues/3062-tests.js
+++ b/packages/pg/test/integration/gh-issues/3062-tests.js
@@ -1,0 +1,21 @@
+'use strict'
+const helper = require('../test-helper')
+var assert = require('assert')
+const suite = new helper.Suite()
+
+// https://github.com/brianc/node-postgres/issues/3062
+suite.testAsync('result fields with the same name should pick the last value', async () => {
+  const client = new helper.pg.Client()
+  await client.connect()
+
+  const { rows: [shouldBeNullRow] } = await client.query('SELECT NULL AS test, 10 AS test, NULL AS test')
+  assert.equal(shouldBeNullRow.test, null)
+
+  const { rows: [shouldBeTwelveRow] } = await client.query('SELECT NULL AS test, 10 AS test, 12 AS test')
+  assert.equal(shouldBeTwelveRow.test, 12)
+
+  const { rows: [shouldBeAbcRow] } = await client.query(`SELECT NULL AS test, 10 AS test, 12 AS test, 'ABC' AS test`)
+  assert.equal(shouldBeAbcRow.test, 'ABC')
+
+  await client.end()
+})


### PR DESCRIPTION
First commit adds a failing test for the issue and the second one fixes the issue by explicitly setting a null value in the else block (like before). I think we'll still get most of the gains from prebuilt object patch as the shape is still not dynamic and I'd bet V8 is smart enough to optimize setting a value to itself (i.e. null to null).

Here's the failing test without the patch: https://github.com/sehrope/node-postgres/actions/runs/6112124966/job/16588908962#step:7:677

Fixes #3062