### PR TITLE
fix: Precision loss on extremely large floating-point numbers

### DIFF
--- a/packages/pg-protocol/src/serializer.ts
+++ b/packages/pg-protocol/src/serializer.ts
@@ -26,6 +26,7 @@ const startup = (opts: Record<string, string>): Buffer => {
   }
 
   writer.addCString('client_encoding').addCString('UTF8')
+  writer.addCString('extra_float_digits').addCString('1')
 
   var bodyBuffer = writer.addCString('').flush()
   // this message is sent without a code

--- a/packages/pg/test/integration/client/type-coercion-tests.js
+++ b/packages/pg/test/integration/client/type-coercion-tests.js
@@ -108,7 +108,7 @@ var types = [
   },
   {
     name: 'double precision',
-    values: [-101.3, -1.2, 0, 1.2, 101.1, null],
+    values: [-101.3, -1.2, 0, 1.2, 101.1, Number.MAX_SAFE_INTEGER, null],
   },
   {
     name: 'timestamptz',


### PR DESCRIPTION
Sets `extra_float_digits` setting to 1 when connecting to DB. For older
(<12) Postgres, this should be enough to cover all values JS can store
preciesely. For 12+ postgres this setting should have no effect.

Fix #3092
