### PR TITLE
docs: Link to current PostgreSQL data types page

### DIFF
--- a/docs/pages/features/types.mdx
+++ b/docs/pages/features/types.mdx
@@ -4,7 +4,7 @@ title: Data Types
 
 import { Alert } from '/components/alert.tsx'
 
-PostgreSQL has a rich system of supported [data types](https://www.postgresql.org/docs/9.5/static/datatype.html). node-postgres does its best to support the most common data types out of the box and supplies an extensible type parser to allow for custom type serialization and parsing.
+PostgreSQL has a rich system of supported [data types](https://www.postgresql.org/docs/current/datatype.html). node-postgres does its best to support the most common data types out of the box and supplies an extensible type parser to allow for custom type serialization and parsing.
 
 ## strings by default
 


### PR DESCRIPTION
The data types link pointed at PostgreSQL 9.5. Update the link to always point to the latest version of PostgreSQL.