### PR TITLE
chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/packages/pg-connection-string @hjr3


### PR DESCRIPTION
This makes it clear who is maintaining which package. This will also allow commit privileges for a specific package instead of the entire repo.