### PR TITLE
chore (ci): add node v20 to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         PGTESTNOSSL: 'true'
         SCRAM_TEST_PGUSER: scram_test
         SCRAM_TEST_PGPASSWORD: test4scram
+        TEST_SKIP_NATIVE: ${{ matrix.node == 20 }}
     steps:
       - name: Show OS
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           - '14'
           - '16'
           - '18'
+          - '20'
         os:
           - ubuntu-latest
     name: Node.js ${{ matrix.node }} (${{ matrix.os }})

--- a/packages/pg/Makefile
+++ b/packages/pg/Makefile
@@ -39,10 +39,14 @@ test-missing-native:
 
 test-native: test-connection
 	@echo "***Testing native bindings***"
+ifeq ($(TEST_SKIP_NATIVE), true)
+	@echo "***Skipping tests***"
+else
 	@npm i --no-save pg-native
 	@find test/native -name "*-tests.js" | $(node-command)
 	@find test/integration -name "*-tests.js" | $(node-command) native
 	@npm uninstall pg-native
+endif
 
 test-integration: test-connection
 	@echo "***Testing Pure Javascript***"


### PR DESCRIPTION
Per https://nodejs.org/en/about/previous-releases, node v20 is "active".

`pg-native` tests are skipped on Node 20 __TODO because pg-native doesn't support node 20?__