### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/pages/apis/cursor.mdx
+++ b/docs/pages/apis/cursor.mdx
@@ -1,6 +1,6 @@
 ---
 title: pg.Cursor
-slug: /api/cursor
+slug: /apis/cursor
 ---
 
 A cursor can be used to efficiently read through large result sets without loading the entire result-set into memory ahead of time. It's useful to simulate a 'streaming' style read of data, or exit early from a large result set. The cursor is passed to `client.query` and is dispatched internally in a way very similar to how normal queries are sent, but the API it presents for consuming the result set is different.

--- a/docs/pages/apis/result.mdx
+++ b/docs/pages/apis/result.mdx
@@ -1,6 +1,6 @@
 ---
 title: pg.Result
-slug: /api/result
+slug: /apis/result
 ---
 
 The `pg.Result` shape is returned for every successful query.

--- a/docs/pages/apis/types.mdx
+++ b/docs/pages/apis/types.mdx
@@ -1,6 +1,6 @@
 ---
 title: Types
-slug: /api/types
+slug: /apis/types
 ---
 
 These docs are incomplete, for now please reference [pg-types docs](https://github.com/brianc/node-pg-types).

--- a/docs/pages/features/queries.mdx
+++ b/docs/pages/features/queries.mdx
@@ -123,7 +123,7 @@ console.log(res.rows[0]) // ['Brian', 'Carlson']
 
 ### Types
 
-You can pass in a custom set of type parsers to use when parsing the results of a particular query. The `types` property must conform to the [Types](/api/types) API. Here is an example in which every value is returned as a string:
+You can pass in a custom set of type parsers to use when parsing the results of a particular query. The `types` property must conform to the [Types](/apis/types) API. Here is an example in which every value is returned as a string:
 
 ```js
 const query = {


### PR DESCRIPTION
Hi :slightly_smiling_face:  :wave:,

when browsing [node-postgres.com/features/queries](https://node-postgres.com/features/queries) I noticed that the link to the types API a the bottom of the page appears to be broken. It seemed likely that the intention was to link to [node-postgres.com/apis/types](https://node-postgres.com/apis/types) instead.

Similarly since api related documentation pages are hosted under `/apis/` instead of `/api/` I'd suggest adjusting the slugs in some cases.