### PR TITLE
refactor: tighten up cloudflare detection

### DIFF
--- a/packages/pg/lib/stream.js
+++ b/packages/pg/lib/stream.js
@@ -1,37 +1,54 @@
-let isCloudflareRuntime
+const { getStream, getSecureStream } = getStreamFuncs()
+
+module.exports = {
+  /**
+   * Get a socket stream compatible with the current runtime environment.
+   * @returns {Duplex}
+   */
+  getStream,
+  /**
+   * Get a TLS secured socket, compatible with the current environment,
+   * using the socket and other settings given in `options`.
+   * @returns {Duplex}
+   */
+  getSecureStream,
+}
 
 /**
- * Get a socket stream compatible with the current runtime environment.
- * @returns {Duplex}
+ * The stream functions that work in Node.js
  */
-module.exports.getStream = function getStream(ssl) {
-  if (isCloudflareRuntime === undefined) {
-    isCloudflareRuntime = computeIsCloudflareRuntime()
-  }
-  if (isCloudflareRuntime) {
-    const { CloudflareSocket } = require('pg-cloudflare')
-    return new CloudflareSocket(ssl)
-  } else {
+function getNodejsStreamFuncs() {
+  function getStream(ssl) {
     const net = require('net')
     return new net.Socket()
+  }
+
+  function getSecureStream(options) {
+    var tls = require('tls')
+    return tls.connect(options)
+  }
+  return {
+    getStream,
+    getSecureStream,
   }
 }
 
 /**
- * Get a TLS secured socket, compatible with the current environment,
- * using the socket and other settings given in `options`.
- * @returns {Duplex}
+ * The stream functions that work in Cloudflare Workers
  */
-module.exports.getSecureStream = function getSecureStream(options) {
-  if (isCloudflareRuntime === undefined) {
-    isCloudflareRuntime = computeIsCloudflareRuntime()
+function getCloudflareStreamFuncs() {
+  function getStream(ssl) {
+    const { CloudflareSocket } = require('pg-cloudflare')
+    return new CloudflareSocket(ssl)
   }
-  if (isCloudflareRuntime) {
+
+  function getSecureStream(options) {
     options.socket.startTls(options)
     return options.socket
-  } else {
-    var tls = require('tls')
-    return tls.connect(options)
+  }
+  return {
+    getStream,
+    getSecureStream,
   }
 }
 
@@ -40,7 +57,7 @@ module.exports.getSecureStream = function getSecureStream(options) {
  *
  * @returns true if the code is currently running inside a Cloudflare Worker.
  */
-function computeIsCloudflareRuntime() {
+function isCloudflareRuntime() {
   // Since 2022-03-21 the `global_navigator` compatibility flag is on for Cloudflare Workers
   // which means that `navigator.userAgent` will be defined.
   if (typeof navigator === 'object' && navigator !== null && typeof navigator.userAgent === 'string') {
@@ -54,4 +71,11 @@ function computeIsCloudflareRuntime() {
     }
   }
   return false
+}
+
+function getStreamFuncs() {
+  if (isCloudflareRuntime()) {
+    return getCloudflareStreamFuncs()
+  }
+  return getNodejsStreamFuncs()
 }

--- a/packages/pg/lib/stream.js
+++ b/packages/pg/lib/stream.js
@@ -1,14 +1,19 @@
+let isCloudflareRuntime
+
 /**
  * Get a socket stream compatible with the current runtime environment.
  * @returns {Duplex}
  */
 module.exports.getStream = function getStream(ssl) {
-  const net = require('net')
-  if (typeof net.Socket === 'function') {
-    return new net.Socket()
-  } else {
+  if (isCloudflareRuntime === undefined) {
+    isCloudflareRuntime = computeIsCloudflareRuntime()
+  }
+  if (isCloudflareRuntime) {
     const { CloudflareSocket } = require('pg-cloudflare')
     return new CloudflareSocket(ssl)
+  } else {
+    const net = require('net')
+    return new net.Socket()
   }
 }
 
@@ -18,11 +23,35 @@ module.exports.getStream = function getStream(ssl) {
  * @returns {Duplex}
  */
 module.exports.getSecureStream = function getSecureStream(options) {
-  var tls = require('tls')
-  if (tls.connect) {
-    return tls.connect(options)
-  } else {
+  if (isCloudflareRuntime === undefined) {
+    isCloudflareRuntime = computeIsCloudflareRuntime()
+  }
+  if (isCloudflareRuntime) {
     options.socket.startTls(options)
     return options.socket
+  } else {
+    var tls = require('tls')
+    return tls.connect(options)
   }
+}
+
+/**
+ * Are we running in a Cloudflare Worker?
+ *
+ * @returns true if the code is currently running inside a Cloudflare Worker.
+ */
+function computeIsCloudflareRuntime() {
+  // Since 2022-03-21 the `global_navigator` compatibility flag is on for Cloudflare Workers
+  // which means that `navigator.userAgent` will be defined.
+  if (typeof navigator === 'object' && navigator !== null && typeof navigator.userAgent === 'string') {
+    return navigator.userAgent === 'Cloudflare-Workers'
+  }
+  // In case `navigator` or `navigator.userAgent` is not defined then try a more sneaky approach
+  if (typeof Response === 'function') {
+    const resp = new Response(null, { cf: { thing: true } })
+    if (typeof resp.cf === 'object' && resp.cf !== null && resp.cf.thing) {
+      return true
+    }
+  }
+  return false
 }


### PR DESCRIPTION
The previous approach to detecting whether to use Cloudflare's sockets was to check for missing polyfills.
But as we improve the polyfills that Wrangler can provide these checks are no longer valid.

Now we check if the `navigator.userAgent` is `'Cloudflare-Workers'` and fallback to Node.js if not.

**This is a refactoring - there is already a test in place to check that this works.**