### PR TITLE
ci: fail if yarn.lock is out of date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 18
           cache: yarn
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn lint
   build:
     needs: lint
@@ -68,6 +68,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       # TODO(bmc): get ssl tests working in ci
       - run: yarn test


### PR DESCRIPTION
From yarn docs:

> If you need reproducible dependencies, which is usually the case with the continuous integration systems, you should pass --frozen-lockfile flag.
> - https://classic.yarnpkg.com/lang/en/docs/cli/install/