### PR TITLE
ci: add build timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   lint:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +21,7 @@ jobs:
       - run: yarn install
       - run: yarn lint
   build:
+    timeout-minutes: 10
     needs: lint
     services:
       postgres:


### PR DESCRIPTION
This should prevent runaway builds.

I noticed this issue when working on a fork of https://github.com/brianc/node-postgres/pull/2836.  Example builds with/without these timeouts:

1. 6 hours: https://github.com/alxndrsn/node-postgres/actions/runs/8277192701
2. 10 minutes: https://github.com/alxndrsn/node-postgres/actions/runs/8277388503

These timeouts are 4-5x what a current healthy build takes.