### PR TITLE
ci: don't fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
+      fail-fast: false
       matrix:
         node:
           - '10'


### PR DESCRIPTION
This allows all matrix builds to run, making it easier to understand if a given failure is specific to nodejs version(s), or more general.