### PR TITLE
query: remove unused prop: isPreparedStatement

### DIFF
--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -28,7 +28,6 @@ class Query extends EventEmitter {
 
     // potential for multiple results
     this._results = this._result
-    this.isPreparedStatement = false
     this._canceledDueToError = false
     this._promise = null
   }
@@ -190,10 +189,6 @@ class Query extends EventEmitter {
 
   // http://developer.postgresql.org/pgdocs/postgres/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
   prepare(connection) {
-    // prepared statements need sync to be called after each command
-    // complete or when an error is encountered
-    this.isPreparedStatement = true
-
     // TODO refactor this poor encapsulation
     if (!this.hasBeenParsed(connection)) {
       connection.parse({


### PR DESCRIPTION
Use of this property was removed in 2020 (dd3ce616d0fbdb92a7e146ecf4171bf3c1b3ea97).