### PR TITLE
query: remove unused prop: _promise

### DIFF
--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -30,7 +30,6 @@ class Query extends EventEmitter {
     this._results = this._result
     this.isPreparedStatement = false
     this._canceledDueToError = false
-    this._promise = null
   }
 
   requiresPreparation() {


### PR DESCRIPTION
Use of this prop was probably removed in 2017 (a0eb36d81938e488b3bc5369faee74fe22f36949).