### PR TITLE
Remove unused protocol-related dependencies from pg

### DIFF
--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -20,8 +20,6 @@
   "author": "Brian Carlson <brian.m.carlson@gmail.com>",
   "main": "./lib",
   "dependencies": {
-    "buffer-writer": "2.0.0",
-    "packet-reader": "1.0.0",
     "pg-connection-string": "^2.6.2",
     "pg-pool": "^3.6.1",
     "pg-protocol": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1931,11 +1931,6 @@ buffer-from@^1.0.0:
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-buffer-writer@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz"
-  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
-
 builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz"
@@ -5412,11 +5407,6 @@ p-waterfall@^1.0.0:
   integrity sha1-ftlLPOszMngjU69qrhGqn8I1uwA=
   dependencies:
     p-reduce "^1.0.0"
-
-packet-reader@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz"
-  integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
 
 parallel-transform@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
buffer-writer was replaced with pg-protocol in 3ff91eaa3222657fd51ea463b8086d134a505404, and packet-reader in 520bd3531990f32c3e00b20020c67f6ac6c70261.