### PR TITLE
Revert "fix: conflict between browser URL object and Node URL object"

### DIFF
--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -1,9 +1,9 @@
 'use strict'
+
 //Parse method copied from https://github.com/brianc/node-postgres
 //Copyright (c) 2010-2014 Brian Carlson (brian.m.carlson@gmail.com)
 //MIT License
 
-const { URL } = require('url')
 //parses a connection string
 function parse(str) {
   //unix socket


### PR DESCRIPTION
Reverts brianc/node-postgres#3061

This addresses a backwards incompatible regression described by #3187