### PR TITLE
docs: update queries.mdx pg-format link to markdown

### DIFF
--- a/docs/pages/features/queries.mdx
+++ b/docs/pages/features/queries.mdx
@@ -27,7 +27,7 @@ console.log(res.rows[0])
 ```
 
 <div class="alert alert-warning">
-  PostgreSQL does not support parameters for identifiers. If you need to have dynamic database, schema, table, or column names (e.g. in DDL statements) use <a href="https://www.npmjs.com/package/pg-format">pg-format</a> package for handling escaping these values to ensure you do not have SQL injection!
+  PostgreSQL does not support parameters for identifiers. If you need to have dynamic database, schema, table, or column names (e.g. in DDL statements) use [pg-format](https://www.npmjs.com/package/pg-format) package for handling escaping these values to ensure you do not have SQL injection!
 </div>
 
 Parameters passed as the second argument to `query()` will be converted to raw data types using the following rules:


### PR DESCRIPTION
If we use `<a>` here, the template does not visually identify it as a link, so I have switched to the markdown link format.

With `a`:
![image](https://github.com/brianc/node-postgres/assets/11761170/e8a4087e-38fc-498d-8c88-f538f9df9900)

With markdown:
![image](https://github.com/brianc/node-postgres/assets/11761170/4b059384-926c-4118-bad6-75fc31cc3dd1)
