### PR TITLE
Documented lock_timeout in client.mdx

### DIFF
--- a/docs/pages/apis/client.mdx
+++ b/docs/pages/apis/client.mdx
@@ -20,6 +20,7 @@ type Config = {
   types?: any, // custom type parsers
   statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout
   query_timeout?: number, // number of milliseconds before a query call will timeout, default is no timeout
+  lock_timeout?: number, // number of milliseconds a query is allowed to be en lock state before it's cancelled due to lock timeout
   application_name?: string, // The name of the application that created this Client instance
   connectionTimeoutMillis?: number, // number of milliseconds to wait for connection, default is no timeout
   idle_in_transaction_session_timeout?: number // number of milliseconds before terminating any session with an open idle transaction, default is no timeout


### PR DESCRIPTION
Added 'lock_timeout' option in Config object documentation since it's explicitly declared in node-postgres (packages/pg/lib/connection-parameters.js)

I also checked it works as documented in PostgreSQL Docs:

https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT