### PR TITLE
Reorder the user, password, host, port and database appearances for uniformity.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: ci_db_test
           POSTGRES_HOST_AUTH_METHOD: 'md5'
+          POSTGRES_DB: ci_db_test
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -50,8 +50,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
         PGUSER: postgres
-        PGHOST: localhost
         PGPASSWORD: postgres
+        PGHOST: localhost
         PGDATABASE: ci_db_test
         PGTESTNOSSL: 'true'
         SCRAM_TEST_PGUSER: scram_test

--- a/docs/pages/apis/client.mdx
+++ b/docs/pages/apis/client.mdx
@@ -13,8 +13,8 @@ type Config = {
   user?: string, // default process.env.PGUSER || process.env.USER
   password?: string or function, //default process.env.PGPASSWORD
   host?: string, // default process.env.PGHOST
-  database?: string, // default process.env.PGDATABASE || user
   port?: number, // default process.env.PGPORT
+  database?: string, // default process.env.PGDATABASE || user
   connectionString?: string, // e.g. postgres://user:password@host:5432/database
   ssl?: any, // passed directly to node.TLSSocket, supports all tls.connect options
   types?: any, // custom type parsers
@@ -34,11 +34,11 @@ import pg from 'pg'
 const { Client } = pg
 
 const client = new Client({
+  user: 'database-user',
+  password: 'secretpassword!!',
   host: 'my.database-server.com',
   port: 5334,
   database: 'database-name',
-  user: 'database-user',
-  password: 'secretpassword!!',
 })
 ```
 

--- a/docs/pages/features/connecting.mdx
+++ b/docs/pages/features/connecting.mdx
@@ -31,10 +31,10 @@ To run the above program and specify which database to connect to we can invoke 
 
 ```sh
 $ PGUSER=dbuser \
-  PGHOST=database.server.com \
   PGPASSWORD=secretpassword \
-  PGDATABASE=mydb \
+  PGHOST=database.server.com \
   PGPORT=3211 \
+  PGDATABASE=mydb \
   node script.js
 ```
 
@@ -43,11 +43,11 @@ This allows us to write our programs without having to specify connection inform
 The default values for the environment variables used are:
 
 ```
-PGHOST=localhost
 PGUSER=process.env.USER
-PGDATABASE=process.env.USER
 PGPASSWORD=null
+PGHOST=localhost
 PGPORT=5432
+PGDATABASE=process.env.USER
 ```
 
 ## Programmatic
@@ -60,20 +60,20 @@ const { Pool, Client } = pg
 
 const pool = new Pool({
   user: 'dbuser',
-  host: 'database.server.com',
-  database: 'mydb',
   password: 'secretpassword',
+  host: 'database.server.com',
   port: 3211,
+  database: 'mydb',
 })
 
 console.log(await pool.query('SELECT NOW()'))
 
 const client = new Client({
   user: 'dbuser',
-  host: 'database.server.com',
-  database: 'mydb',
   password: 'secretpassword',
+  host: 'database.server.com',
   port: 3211,
+  database: 'mydb',
 })
 
 await client.connect()
@@ -106,11 +106,11 @@ const signer = new RDS.Signer()
 const getPassword = () => signer.getAuthToken(signerOptions)
 
 const pool = new Pool({
+  user: signerOptions.username,
+  password: getPassword,
   host: signerOptions.hostname,
   port: signerOptions.port,
-  user: signerOptions.username,
   database: 'my-db',
-  password: getPassword,
 })
 ```
 
@@ -122,9 +122,9 @@ Connections to unix sockets can also be made. This can be useful on distros like
 import pg from 'pg'
 const { Client } = pg
 client = new Client({
-  host: '/cloudsql/myproject:zone:mydb',
   user: 'username',
   password: 'password',
+  host: '/cloudsql/myproject:zone:mydb',
   database: 'database_name',
 })
 ```

--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -22,10 +22,10 @@ var config = parse('postgres://someuser:somepassword@somehost:381/somedatabase')
 
 The resulting config contains a subset of the following properties:
 
-* `host` - Postgres server hostname or, for UNIX domain sockets, the socket filename
-* `port` - port on which to connect
 * `user` - User with which to authenticate to the server
 * `password` - Corresponding password
+* `host` - Postgres server hostname or, for UNIX domain sockets, the socket filename
+* `port` - port on which to connect
 * `database` - Database name within the server
 * `client_encoding` - string encoding the client will use
 * `ssl`, either a boolean or an object with properties

--- a/packages/pg-connection-string/test/parse.js
+++ b/packages/pg-connection-string/test/parse.js
@@ -63,8 +63,8 @@ describe('parse', function () {
     var sourceConfig = {
       user: 'brian',
       password: 'hello<ther>e',
-      port: 5432,
       host: 'localhost',
+      port: 5432,
       database: 'postgres',
     }
     var connectionString =
@@ -86,8 +86,8 @@ describe('parse', function () {
     var sourceConfig = {
       user: 'brian',
       password: 'hello:pass:world',
-      port: 5432,
       host: 'localhost',
+      port: 5432,
       database: 'postgres',
     }
     var connectionString =

--- a/packages/pg/script/create-test-tables.js
+++ b/packages/pg/script/create-test-tables.js
@@ -32,10 +32,10 @@ var people = [
 ]
 
 var con = new pg.Client({
-  host: args.host,
-  port: args.port,
   user: args.user,
   password: args.password,
+  host: args.host,
+  port: args.port,
   database: args.database,
 })
 

--- a/packages/pg/test/integration/client/configuration-tests.js
+++ b/packages/pg/test/integration/client/configuration-tests.js
@@ -31,26 +31,26 @@ suite.test('default values are used in new clients', function () {
   var client = new pg.Client()
   assert.same(client, {
     user: process.env.USER,
-    database: process.env.USER,
     password: null,
     port: 5432,
+    database: process.env.USER,
   })
 })
 
 suite.test('modified values are passed to created clients', function () {
   pg.defaults.user = 'boom'
   pg.defaults.password = 'zap'
-  pg.defaults.database = 'pow'
-  pg.defaults.port = 1234
   pg.defaults.host = 'blam'
+  pg.defaults.port = 1234
+  pg.defaults.database = 'pow'
 
   var client = new Client()
   assert.same(client, {
     user: 'boom',
     password: 'zap',
-    database: 'pow',
-    port: 1234,
     host: 'blam',
+    port: 1234,
+    database: 'pow',
   })
 })
 

--- a/packages/pg/test/unit/client/configuration-tests.js
+++ b/packages/pg/test/unit/client/configuration-tests.js
@@ -99,21 +99,21 @@ test('initializing from a config string', function () {
   test('when not including all values the environment variables are used', function () {
     var envUserDefined = process.env['PGUSER'] !== undefined
     var envPasswordDefined = process.env['PGPASSWORD'] !== undefined
-    var envDBDefined = process.env['PGDATABASE'] !== undefined
     var envHostDefined = process.env['PGHOST'] !== undefined
     var envPortDefined = process.env['PGPORT'] !== undefined
+    var envDBDefined = process.env['PGDATABASE'] !== undefined
 
     var savedEnvUser = process.env['PGUSER']
     var savedEnvPassword = process.env['PGPASSWORD']
-    var savedEnvDB = process.env['PGDATABASE']
     var savedEnvHost = process.env['PGHOST']
     var savedEnvPort = process.env['PGPORT']
+    var savedEnvDB = process.env['PGDATABASE']
 
     process.env['PGUSER'] = 'utUser1'
     process.env['PGPASSWORD'] = 'utPass1'
-    process.env['PGDATABASE'] = 'utDB1'
     process.env['PGHOST'] = 'utHost1'
     process.env['PGPORT'] = 5464
+    process.env['PGDATABASE'] = 'utDB1'
 
     var client = new Client('postgres://host1')
     assert.equal(client.user, process.env['PGUSER'])

--- a/packages/pg/test/unit/connection-parameters/creation-tests.js
+++ b/packages/pg/test/unit/connection-parameters/creation-tests.js
@@ -167,8 +167,8 @@ suite.testAsync('builds simple string', async function () {
   var config = {
     user: 'brian',
     password: 'xyz',
-    port: 888,
     host: 'localhost',
+    port: 888,
     database: 'bam',
   }
   var subject = new ConnectionParameters(config)
@@ -179,8 +179,8 @@ suite.testAsync('builds simple string', async function () {
       var parts = constring.split(' ')
       checkForPart(parts, "user='brian'")
       checkForPart(parts, "password='xyz'")
-      checkForPart(parts, "port='888'")
       checkForPart(parts, `hostaddr='${dnsHost}'`)
+      checkForPart(parts, "port='888'")
       checkForPart(parts, "dbname='bam'")
       resolve()
     })
@@ -191,8 +191,8 @@ suite.test('builds dns string', async function () {
   var config = {
     user: 'brian',
     password: 'asdf',
-    port: 5432,
     host: 'localhost',
+    port: 5432,
   }
   var subject = new ConnectionParameters(config)
   const dnsHost = await getDNSHost(config.host)
@@ -211,8 +211,8 @@ suite.test('error when dns fails', function () {
   var config = {
     user: 'brian',
     password: 'asf',
-    port: 5432,
     host: 'asdlfkjasldfkksfd#!$!!!!..com',
+    port: 5432,
   }
   var subject = new ConnectionParameters(config)
   subject.getLibpqConnectionString(
@@ -227,8 +227,8 @@ suite.test('connecting to unix domain socket', function () {
   var config = {
     user: 'brian',
     password: 'asf',
-    port: 5432,
     host: '/tmp/',
+    port: 5432,
   }
   var subject = new ConnectionParameters(config)
   subject.getLibpqConnectionString(
@@ -245,8 +245,8 @@ suite.test('config contains quotes and backslashes', function () {
   var config = {
     user: 'not\\brian',
     password: "bad'chars",
-    port: 5432,
     host: '/tmp/',
+    port: 5432,
   }
   var subject = new ConnectionParameters(config)
   subject.getLibpqConnectionString(
@@ -277,8 +277,8 @@ suite.test('password contains  < and/or >  characters', function () {
   var sourceConfig = {
     user: 'brian',
     password: 'hello<ther>e',
-    port: 5432,
     host: 'localhost',
+    port: 5432,
     database: 'postgres',
   }
   var connectionString =
@@ -333,8 +333,8 @@ suite.test('ssl is set on client', function () {
   var sourceConfig = {
     user: 'brian',
     password: 'hello<ther>e',
-    port: 5432,
     host: 'localhost',
+    port: 5432,
     database: 'postgres',
     ssl: {
       sslmode: 'verify-ca',


### PR DESCRIPTION
Hi,
Trying to add uniformity to the use of the keys (user, password, host, port and database) in the code and docs.
I see the use of fields scattered in code and in documentation, in many different orders. Figured it could help for clarity to try to have a similar as possible order. Makes it easier to see if you're forgetting one of them, identify changes, etc...

New to pg. Figured could be helpful. Thanks for a great package. 

Fun fact (Had to check it out).
When you have 3 terms -> ternary.
when you have 4  terms -> quaternary. (ref.[stack exchange discussion](https://english.stackexchange.com/questions/25116/what-follows-next-in-the-sequence-unary-binary-ternary))

 