### PR TITLE
Cancellable Query with AbortSignal option

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -51,6 +51,7 @@ class Client extends EventEmitter {
         keepAlive: c.keepAlive || false,
         keepAliveInitialDelayMillis: c.keepAliveInitialDelayMillis || 0,
         encoding: this.connectionParameters.client_encoding || 'utf8',
+        Promise: this._Promise,
       })
     this.queryQueue = []
     this.binary = c.binary || defaults.binary

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -56,15 +56,8 @@ class Client extends EventEmitter {
     this.binary = c.binary || defaults.binary
     this.processID = null
     this.secretKey = null
+    // TODO: remove in next major release?
     this.ssl = this.connectionParameters.ssl || false
-    // As with Password, make SSL->Key (the private key) non-enumerable.
-    // It won't show up in stack traces
-    // or if the client is console.logged
-    if (this.ssl && this.ssl.key) {
-      Object.defineProperty(this.ssl, 'key', {
-        enumerable: false,
-      })
-    }
 
     this._connectionTimeoutMillis = c.connectionTimeoutMillis || 0
   }
@@ -115,14 +108,6 @@ class Client extends EventEmitter {
 
     // once connection is established send startup message
     con.on('connect', function () {
-      if (self.ssl) {
-        con.requestSsl()
-      } else {
-        con.startup(self.getStartupConf())
-      }
-    })
-
-    con.on('sslconnect', function () {
       con.startup(self.getStartupConf())
     })
 

--- a/packages/pg/test/integration/cancel/cancel-query-with-abort-signal-tests.js
+++ b/packages/pg/test/integration/cancel/cancel-query-with-abort-signal-tests.js
@@ -1,0 +1,108 @@
+var helper = require('./../test-helper')
+
+var pg = helper.pg
+const Client = pg.Client
+const DatabaseError = pg.DatabaseError
+
+if (!global.AbortController) {
+  // skip these tests on node < 15
+  return
+}
+
+const suite = new helper.Suite('query cancellation with abort signal')
+
+suite.test('query with signal succeeds if not aborted', function (done) {
+  const client = new Client()
+  const { signal } = new AbortController()
+
+  client.connect(
+    assert.success(() => {
+      client.query(
+        new pg.Query({ text: 'select pg_sleep(0.1)', signal }),
+        assert.success((result) => {
+          assert.equal(result.rows[0].pg_sleep, '')
+          client.end(done)
+        })
+      )
+    })
+  )
+})
+
+suite.test('query with signal is not submitted if the signal is already aborted', function (done) {
+  const client = new Client()
+  const signal = AbortSignal.abort()
+
+  let counter = 0
+
+  client.query(
+    new pg.Query({ text: 'INVALID SQL...' }),
+    assert.calls((err) => {
+      assert(err instanceof DatabaseError)
+      counter++
+    })
+  )
+
+  client.query(
+    new pg.Query({ text: 'begin' }),
+    assert.success(() => {
+      counter++
+    })
+  )
+
+  client.query(
+    new pg.Query({ text: 'INVALID SQL...', signal }),
+    assert.calls((err) => {
+      assert.equal(err.name, 'AbortError')
+      counter++
+    })
+  )
+
+  client.query(
+    new pg.Query({ text: 'select 1' }),
+    assert.success(() => {
+      counter++
+      assert.equal(counter, 4)
+      client.end(done)
+    })
+  )
+
+  client.connect(assert.success(() => {}))
+})
+
+suite.test('query can be canceled with abort signal', function (done) {
+  const client = new Client()
+  const ac = new AbortController()
+  const { signal } = ac
+
+  client.query(
+    new pg.Query({ text: 'SELECT pg_sleep(0.5)', signal }),
+    assert.calls((err) => {
+      assert(err instanceof DatabaseError)
+      assert(err.code === '57014')
+      client.end(done)
+    })
+  )
+
+  client.connect(
+    assert.success(() => {
+      setTimeout(() => {
+        ac.abort()
+      }, 50)
+    })
+  )
+})
+
+suite.test('long abort signal timeout does not keep the query / connection going', function (done) {
+  const client = new Client()
+  const signal = AbortSignal.timeout(10_000)
+
+  client.query(
+    new pg.Query({ text: 'SELECT pg_sleep(0.1)', signal }),
+    assert.success((result) => {
+      assert.equal(result.rows[0].pg_sleep, '')
+      client.end(done)
+    })
+  )
+
+  client.connect(assert.success(() => {}))
+})

--- a/packages/pg/test/unit/connection/error-tests.js
+++ b/packages/pg/test/unit/connection/error-tests.js
@@ -42,7 +42,7 @@ var SSLNegotiationPacketTests = [
     testName: 'connection does not emit ECONNRESET errors during disconnect also when using SSL',
     errorMessage: null,
     response: 'S',
-    responseType: 'sslconnect',
+    responseType: 'connect',
   },
   {
     testName: 'connection emits an error when SSL is not supported',


### PR DESCRIPTION
A suggestion for a new cancellation API (based on the original request in https://github.com/brianc/node-postgres/issues/2774)

This query-specific cancellation API only makes sense because the library waits for each query to complete before it submits the next. With query pipelining it would be a lot messier - or simpler, because the API could offer less guarantees.

While the tests are turned off if `AbortController` is not available, the library code itself should still be compatible with older node versions.

**Example**

```js
const r1 = await client.query('SELECT now()')

try {
  await client.query({
    text: 'SELECT pg_sleep(10)',
    signal: AbortSignal.timeout(1_000),
  })
} catch (err) {
  console.log(err.code, err.message) // 57014 canceling statement due to user request
}

const r2 = await client.query(
  'SELECT now() - $1 AS delay',
  [r1.rows[0].now],
)

console.log(r2.rows[0].delay) // PostgresInterval { seconds: 1, milliseconds: 9.592 }
```

---

First, in a separate commit (https://github.com/brianc/node-postgres/commit/913967f795b1a3a72865d94e0020671fba68f0ae) is a small change that moves the SSL initialization logic to the `Connection`.
This means the `Connection` no longer needs a separate an `'sslconnect'` event.

---

Then, the `Connection` got a new `con.cancelWithClone()` method that tries to connect to the exact same server, and send a cancel request.

This required a bit of extra state in the `Connection`, to keep track of the `host`, `port`, `config` and the `backendKeyData`.

I'm not thrilled with duplicating state from the `Client` (or with the name of the method for that matter).

What I like about this approach is that all the logic around the cancellation can be implemented in the `Submittable` and doesn't depend on any special handling by the `Client`.

---

Finally the `Query` got a `signal` option that can be used to cancel it either before, or after it has been submitted to the server.

If the query has been canceled before submit, it will return the abort reason in submit.

If an actual cancel request has been sent, the query callback and the `'error'` and `'end'` events are delayed until the cancel request has finished.

This is done to avoid accidentally canceling a different query on the same connection.

If the cancel request isn't completed cleanly, the original connection is destroyed.

_This might be triggered if you get an ECONNRESET after sending the cancel request? Honestly I'm not sure._
_This should probably treat the errors after the cancel request has been sent differently from errors during connecting._
