### PR TITLE
Add option to force use of Extended Queries

### DIFF
--- a/docs/pages/apis/client.mdx
+++ b/docs/pages/apis/client.mdx
@@ -76,9 +76,8 @@ type QueryConfig {
   // custom type parsers just for this query result
   types?: Types;
 
-  // force extended query usage - prevents multiple statements in a
-  // single query
-  forcePreparation?: boolean;
+  // TODO: document
+  queryMode?: string;
 }
 ```
 

--- a/docs/pages/apis/client.mdx
+++ b/docs/pages/apis/client.mdx
@@ -75,6 +75,10 @@ type QueryConfig {
 
   // custom type parsers just for this query result
   types?: Types;
+
+  // force extended query usage - prevents multiple statements in a
+  // single query
+  forcePreparation?: boolean;
 }
 ```
 

--- a/packages/pg-native/index.js
+++ b/packages/pg-native/index.js
@@ -57,7 +57,7 @@ Client.prototype.query = function (text, values, cb) {
     cb = values
   }
 
-  if (Array.isArray(values) && values.length > 0) {
+  if (Array.isArray(values)) {
     queryFn = function () {
       return self.pq.sendQueryParams(text, values)
     }

--- a/packages/pg/lib/native/query.js
+++ b/packages/pg/lib/native/query.js
@@ -10,7 +10,7 @@ var NativeQuery = (module.exports = function (config, values, callback) {
   this.text = config.text
   this.values = config.values
   this.name = config.name
-  this.forcePreparation = config.forcePreparation
+  this.queryMode = config.forcePreparation
   this.callback = config.callback
   this.state = 'new'
   this._arrayMode = config.rowMode === 'array'
@@ -160,7 +160,7 @@ NativeQuery.prototype.submit = function (client) {
     }
     var vals = this.values.map(utils.prepareValue)
     client.native.query(this.text, vals, after)
-  } else if (this.forcePreparation) {
+  } else if (this.queryMode === 'extended') {
     client.native.query(this.text, [], after)
   } else {
     client.native.query(this.text, after)

--- a/packages/pg/lib/native/query.js
+++ b/packages/pg/lib/native/query.js
@@ -10,6 +10,7 @@ var NativeQuery = (module.exports = function (config, values, callback) {
   this.text = config.text
   this.values = config.values
   this.name = config.name
+  this.forcePreparation = config.forcePreparation
   this.callback = config.callback
   this.state = 'new'
   this._arrayMode = config.rowMode === 'array'
@@ -159,6 +160,8 @@ NativeQuery.prototype.submit = function (client) {
     }
     var vals = this.values.map(utils.prepareValue)
     client.native.query(this.text, vals, after)
+  } else if (this.forcePreparation) {
+    client.native.query(this.text, [], after)
   } else {
     client.native.query(this.text, after)
   }

--- a/packages/pg/lib/native/query.js
+++ b/packages/pg/lib/native/query.js
@@ -10,7 +10,7 @@ var NativeQuery = (module.exports = function (config, values, callback) {
   this.text = config.text
   this.values = config.values
   this.name = config.name
-  this.queryMode = config.forcePreparation
+  this.queryMode = config.queryMode
   this.callback = config.callback
   this.state = 'new'
   this._arrayMode = config.rowMode === 'array'

--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -16,6 +16,7 @@ class Query extends EventEmitter {
     this.rows = config.rows
     this.types = config.types
     this.name = config.name
+    this.forcePreparation = config.forcePreparation
     this.binary = config.binary
     // use unique portal name each time
     this.portal = config.portal || ''
@@ -32,6 +33,11 @@ class Query extends EventEmitter {
   }
 
   requiresPreparation() {
+    // preparation has been requested
+    if (this.forcePreparation) {
+      return true
+    }
+
     // named queries must always be prepared
     if (this.name) {
       return true

--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -16,7 +16,7 @@ class Query extends EventEmitter {
     this.rows = config.rows
     this.types = config.types
     this.name = config.name
-    this.forcePreparation = config.forcePreparation
+    this.queryMode = config.queryMode
     this.binary = config.binary
     // use unique portal name each time
     this.portal = config.portal || ''
@@ -33,8 +33,7 @@ class Query extends EventEmitter {
   }
 
   requiresPreparation() {
-    // preparation has been requested
-    if (this.forcePreparation) {
+    if (this.queryMode === 'extended') {
       return true
     }
 

--- a/packages/pg/test/integration/client/multiple-results-tests.js
+++ b/packages/pg/test/integration/client/multiple-results-tests.js
@@ -26,6 +26,31 @@ suite.test(
 )
 
 suite.test(
+  'throws if queryMode set to "extended"',
+  co.wrap(function* () {
+    const client = new helper.Client()
+    yield client.connect()
+
+    // TODO should be text or sql?
+    try {
+      const results = yield client.query({
+        text: `SELECT 'foo'::text as name; SELECT 'bar'::text as baz`,
+        queryMode: 'extended',
+      })
+      assert.fail('Should have thrown');
+    } catch(err) {
+      if(err instanceof assert.AssertionError) throw err;
+
+      assert.equal(err.severity, 'ERROR');
+      assert.equal(err.code, '42601');
+      assert.equal(err.message, 'cannot insert multiple commands into a prepared statement');
+    }
+
+    return client.end()
+  })
+)
+
+suite.test(
   'multiple selects work',
   co.wrap(function* () {
     const client = new helper.Client()

--- a/packages/pg/test/integration/client/multiple-results-tests.js
+++ b/packages/pg/test/integration/client/multiple-results-tests.js
@@ -37,13 +37,13 @@ suite.test(
         text: `SELECT 'foo'::text as name; SELECT 'bar'::text as baz`,
         queryMode: 'extended',
       })
-      assert.fail('Should have thrown');
-    } catch(err) {
-      if(err instanceof assert.AssertionError) throw err;
+      assert.fail('Should have thrown')
+    } catch (err) {
+      if (err instanceof assert.AssertionError) throw err
 
-      assert.equal(err.severity, 'ERROR');
-      assert.equal(err.code, '42601');
-      assert.equal(err.message, 'cannot insert multiple commands into a prepared statement');
+      assert.equal(err.severity, 'ERROR')
+      assert.equal(err.code, '42601')
+      assert.equal(err.message, 'cannot insert multiple commands into a prepared statement')
     }
 
     return client.end()


### PR DESCRIPTION
In some circumstances, e.g. https://github.com/gajus/slonik/pull/595, https://github.com/gajus/slonik/issues/601, it can add safety to force use of the [Extended Query protocol](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY).

