### PR TITLE
eslint: use cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ package-lock.json
 *.swp
 dist
 .DS_Store
+/.eslintcache
 .vscode/
 manually-test-on-heroku.js

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs:start": "cd docs && yarn start",
     "pretest": "yarn build",
     "prepublish": "yarn build",
-    "lint": "eslint '*/**/*.{js,ts,tsx}'"
+    "lint": "eslint --cache '*/**/*.{js,ts,tsx}'"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",


### PR DESCRIPTION
This significantly speeds up eslint after first run.

For me, this cuts `yarn lint` from ~6.5s to <1s when a single file has changed.