### PR TITLE
error-handling-tests: remove unused "CREATE TABLE"

### DIFF
--- a/packages/pg/test/integration/client/error-handling-tests.js
+++ b/packages/pg/test/integration/client/error-handling-tests.js
@@ -113,8 +113,6 @@ var ensureFuture = function (testClient, done) {
 suite.test('when query is parsing', (done) => {
   var client = createErorrClient()
 
-  var q = client.query({ text: 'CREATE TEMP TABLE boom(age integer); INSERT INTO boom (age) VALUES (28);' })
-
   // this query wont parse since there isn't a table named bang
   var query = client.query(
     new pg.Query({


### PR DESCRIPTION
This looks like it's a copy/paste from the adjacent test.