### PR TITLE
Add test for date type

### DIFF
--- a/packages/pg/test/integration/client/timezone-tests.js
+++ b/packages/pg/test/integration/client/timezone-tests.js
@@ -20,6 +20,11 @@ pool.connect(function (err, client, done) {
     })
   })
 
+  suite.testAsync('date comes out as a date', async function () {
+    const { rows } = await client.query('SELECT NOW()::DATE AS date')
+    assert(rows[0].date instanceof Date)
+  })
+
   suite.test('timestamp with time zone', function (cb) {
     client.query('SELECT CAST($1 AS TIMESTAMP WITH TIME ZONE) AS "val"', [date], function (err, result) {
       assert(!err)


### PR DESCRIPTION
When updating to `pg-types@4.x` this test will break.  I want to make sure it's caught so I can document the breaking changes (will need to be semver major upgrade to node-postgres to upgrade pg-types due to the date handling differences). 