### PR TITLE
fix: use existing Result types for new Result

### DIFF
--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -65,7 +65,7 @@ class Query extends EventEmitter {
       if (!Array.isArray(this._results)) {
         this._results = [this._result]
       }
-      this._result = new Result(this._rowMode, this.types)
+      this._result = new Result(this._rowMode, this._result._types)
       this._results.push(this._result)
     }
   }

--- a/packages/pg/test/integration/client/custom-types-tests.js
+++ b/packages/pg/test/integration/client/custom-types-tests.js
@@ -22,6 +22,21 @@ suite.test('custom type parser in client config', (done) => {
   })
 })
 
+suite.test('custom type parser in client config with multiple results', (done) => {
+  const client = new Client({ types: customTypes })
+
+  client.connect().then(() => {
+    client.query(
+      `SELECT 'foo'::text as name; SELECT 'bar'::text as baz`,
+      assert.success(function (res) {
+        assert.equal(res[0].rows[0].name, 'okay!')
+        assert.equal(res[1].rows[0].baz, 'okay!')
+        client.end().then(done)
+      })
+    )
+  })
+})
+
 // Custom type-parsers per query are not supported in native
 if (!helper.args.native) {
   suite.test('custom type parser in query', (done) => {


### PR DESCRIPTION
## Context

Closes https://github.com/brianc/node-postgres/issues/3309
Related to https://github.com/sequelize/sequelize/issues/17479

## Approach

The issue seems to be that the `_types` member of `Result` is directly overwritten by `Client.query`:
https://github.com/brianc/node-postgres/blob/54eb0fa216aaccd727765641e7d1cf5da2bc483d/packages/pg/lib/client.js#L567

However, in `_checkForMultiRow`, we then create new `Result`s, but without the overridden types:
https://github.com/brianc/node-postgres/blob/54eb0fa216aaccd727765641e7d1cf5da2bc483d/packages/pg/lib/query.js#L68

The approach is to reuse the types of the original `Result` when creating a new one.