### PR TITLE
updated pg-native github url in package.json

### DIFF
--- a/packages/pg-native/package.json
+++ b/packages/pg-native/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/brianc/node-pg-native.git"
+    "url": "https://github.com/brianc/node-postgres.git"
   },
   "keywords": [
     "postgres",
@@ -18,9 +18,9 @@
   "author": "Brian M. Carlson",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/brianc/node-pg-native/issues"
+    "url": "https://github.com/brianc/node-postgres/issues"
   },
-  "homepage": "https://github.com/brianc/node-pg-native",
+  "homepage": "https://github.com/brianc/node-postgres/tree/master/packages/pg-native",
   "dependencies": {
     "libpq": "1.8.13",
     "pg-types": "^1.12.1"


### PR DESCRIPTION
The current repository link for the pg-native module in npm points to an [archived repository](https://github.com/brianc/node-pg-native), which is now outdated. The repository has been moved into this main pg monorepo for easier maintenance. To avoid confusion and ensure proper usage, it is necessary to update the repository URL in the npm package to reflect the correct and active repository.

Additional Information:

The official message explaining the archive:

> "This repository has been archived because it has been moved into the main pg monorepo for easier maintenance. Please use the main repo for issues/PRs/questions/etc. Thanks! ❤️"

This PR updates the pg-native module’s URL in package.json to point to the correct repository, ensuring that users and developers are directed to the right place for issues, pull requests, and updates.