### PR TITLE
Fix: Add validation for invalid date query parameter values

### DIFF
--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -61,7 +61,7 @@ var prepareValue = function (val, seen) {
   }
   if (val instanceof Date) {
     if (isNaN(val.getTime())) {
-      throw new Error('Query parameter value cannot be an invalid date.');
+      throw new Error('Query parameter value cannot be an invalid date.')
     }
     if (defaults.parseInputDatesAsUTC) {
       return dateToStringUTC(val)

--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -60,6 +60,9 @@ var prepareValue = function (val, seen) {
     return buf.slice(val.byteOffset, val.byteOffset + val.byteLength) // Node.js v4 does not support those Buffer.from params
   }
   if (val instanceof Date) {
+    if (isNaN(val.getTime())) {
+      throw new Error('Query parameter value cannot be an invalid date.');
+    }
     if (defaults.parseInputDatesAsUTC) {
       return dateToStringUTC(val)
     } else {

--- a/packages/pg/test/integration/client/error-handling-tests.js
+++ b/packages/pg/test/integration/client/error-handling-tests.js
@@ -258,24 +258,17 @@ suite.test('cannot pass non-string values to query as text', (done) => {
   })
 })
 
-
 if (!helper.args.native) {
   suite.test('when a query has an invalid date binding', function (done) {
     var client = createErorrClient()
     var calledDone = false
 
-    client.query(
-      new pg.Query({
-        text: 'SELECT $1::timestamp',
-        values: [new Date(undefined)],
-      }),
-      function (err, res) {
-        if (!calledDone) {
-          calledDone = true
-          assert.equal(err.message, 'Query parameter value cannot be an invalid date.')
-          client.end(done)
-        }
+    client.query(new pg.Query({ text: 'SELECT $1::timestamp', values: [new Date(undefined)] }), function (err, res) {
+      if (!calledDone) {
+        calledDone = true
+        assert.equal(err.message, 'Query parameter value cannot be an invalid date.')
+        client.end(done)
       }
-    )
+    })
   })
 }

--- a/packages/pg/test/integration/client/error-handling-tests.js
+++ b/packages/pg/test/integration/client/error-handling-tests.js
@@ -257,3 +257,25 @@ suite.test('cannot pass non-string values to query as text', (done) => {
     })
   })
 })
+
+
+if (!helper.args.native) {
+  suite.test('when a query has an invalid date binding', function (done) {
+    var client = createErorrClient()
+    var calledDone = false
+
+    client.query(
+      new pg.Query({
+        text: 'SELECT $1::timestamp',
+        values: [new Date(undefined)],
+      }),
+      function (err, res) {
+        if (!calledDone) {
+          calledDone = true
+          assert.equal(err.message, 'Query parameter value cannot be an invalid date.')
+          client.end(done)
+        }
+      }
+    )
+  })
+}


### PR DESCRIPTION
PR for Issue #3318

Issue Description:
Currently, new Date(undefined) (an invalid date) is serialized as "0NaN-NaN-NaNTNaN:NaN:NaN.NaN+NaN:NaN". It should fail early with a JS error instead of being passed to the database.