### PR TITLE
Fixed to work with cloudflare's nodejs_compat_v2

### DIFF
--- a/packages/pg/lib/crypto/utils-webcrypto.js
+++ b/packages/pg/lib/crypto/utils-webcrypto.js
@@ -13,7 +13,7 @@ module.exports = {
  * The Web Crypto API - grabbed from the Node.js library or the global
  * @type Crypto
  */
-const webCrypto = nodeCrypto.webcrypto || globalThis.crypto
+const webCrypto = globalThis.crypto ?? nodeCrypto.webcrypto
 /**
  * The SubtleCrypto API for low level crypto operations.
  * @type SubtleCrypto


### PR DESCRIPTION
When using Prisma in Cloudflare's nodejs_compat_v2 environment, pg works directly.