### PR TITLE
chore: align pg-types of pg-native to the same version of vanilla pg

### DIFF
--- a/packages/pg-native/package.json
+++ b/packages/pg-native/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/brianc/node-pg-native",
   "dependencies": {
     "libpq": "1.8.13",
-    "pg-types": "^1.12.1"
+    "pg-types": "^2.1.0"
   },
   "devDependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
This PR align the version of `pg-types` into `pg-native` to the same version of vanilla `pg` ( 2.1.0 see https://github.com/brianc/node-postgres/blob/master/packages/pg/package.json#L26C18-L26C24 )