### PR TITLE
Batch query packets to avoid additional latency

### DIFF
--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -161,7 +161,7 @@ class Query extends EventEmitter {
       return new Error('Query values must be an array')
     }
     if (this.requiresPreparation()) {
-      this.prepare(connection)
+      connection.queryWithPacketBatching(this, utils.prepareValue)
     } else {
       connection.query(this.text)
     }


### PR DESCRIPTION
This fixes issue described in https://github.com/brianc/node-postgres/issues/3325
It seems like batching packages helps avoiding additional ~40ms latency (even on local network) for queries that require bind params.

I wrote short bench to reproduce the problem locally https://gist.github.com/thedadow451/b1ed04441bfa6fdf70a7b1c56504e988

It takes 60-70ms after this fix and ~42**s** without the fix. 

I imagine query path is already good covered with tests and since it's just optimization and not new feature I'm not adding any more tests. (Let me know if there are any you would like to have, I can add them)

Cheers!