### PR TITLE
Extend test for issue 3174 - add cursor cases

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -357,11 +357,21 @@ class Client extends EventEmitter {
   }
 
   _handleRowDescription(msg) {
+    if (this.activeQuery == null) {
+      const error = new Error('Received unexpected rowDescription message from backend.')
+      this._handleErrorEvent(error)
+      return
+    }
     // delegate rowDescription to active query
     this.activeQuery.handleRowDescription(msg)
   }
 
   _handleDataRow(msg) {
+    if (this.activeQuery == null) {
+      const error = new Error('Received unexpected dataRow message from backend.')
+      this._handleErrorEvent(error)
+      return
+    }
     // delegate dataRow to active query
     this.activeQuery.handleDataRow(msg)
   }


### PR DESCRIPTION
This PR is just an extension for https://github.com/brianc/node-postgres/pull/3289. It aims to solve the message ordering issues described in #3174 for [this single particular case](https://github.com/brianc/node-postgres/issues/3174#issuecomment-2473394510) involving the use of cursors.