### PR TITLE
read dataTypeID and tableID as unsigned uint

### DIFF
--- a/packages/pg-protocol/src/buffer-reader.ts
+++ b/packages/pg-protocol/src/buffer-reader.ts
@@ -31,6 +31,12 @@ export class BufferReader {
     return result
   }
 
+  public uint32(): number {
+    const result = this.buffer.readUInt32BE(this.offset)
+    this.offset += 4
+    return result
+  }
+
   public string(length: number): string {
     const result = this.buffer.toString(this.encoding, this.offset, this.offset + length)
     this.offset += length

--- a/packages/pg-protocol/src/inbound-parser.test.ts
+++ b/packages/pg-protocol/src/inbound-parser.test.ts
@@ -39,6 +39,17 @@ var twoRowBuf = buffers.rowDescription([
   },
 ])
 
+var rowWithBigOids = {
+  name: 'bigoid',
+  tableID: 3000000001,
+  attributeNumber: 2,
+  dataTypeID: 3000000003,
+  dataTypeSize: 4,
+  typeModifier: 5,
+  formatCode: 0,
+}
+var bigOidDescBuff = buffers.rowDescription([rowWithBigOids])
+
 var emptyRowFieldBuf = new BufferList().addInt16(0).join(true, 'D')
 
 var emptyRowFieldBuf = buffers.dataRow([])
@@ -128,6 +139,22 @@ var expectedTwoRowMessage = {
       dataTypeID: 12,
       dataTypeSize: 13,
       dataTypeModifier: 14,
+      format: 'text',
+    },
+  ],
+}
+var expectedBigOidMessage = {
+  name: 'rowDescription',
+  length: 31,
+  fieldCount: 1,
+  fields: [
+    {
+      name: 'bigoid',
+      tableID: 3000000001,
+      columnID: 2,
+      dataTypeID: 3000000003,
+      dataTypeSize: 4,
+      dataTypeModifier: 5,
       format: 'text',
     },
   ],
@@ -261,6 +288,7 @@ describe('PgPacketStream', function () {
     testForMessage(emptyRowDescriptionBuffer, expectedEmptyRowDescriptionMessage)
     testForMessage(oneRowDescBuff, expectedOneRowMessage)
     testForMessage(twoRowBuf, expectedTwoRowMessage)
+    testForMessage(bigOidDescBuff, expectedBigOidMessage)
   })
 
   describe('parameterDescription messages', function () {

--- a/packages/pg-protocol/src/parser.ts
+++ b/packages/pg-protocol/src/parser.ts
@@ -258,9 +258,9 @@ export class Parser {
 
   private parseField(): Field {
     const name = this.reader.cstring()
-    const tableID = this.reader.int32()
+    const tableID = this.reader.uint32()
     const columnID = this.reader.int16()
-    const dataTypeID = this.reader.int32()
+    const dataTypeID = this.reader.uint32()
     const dataTypeSize = this.reader.int16()
     const dataTypeModifier = this.reader.int32()
     const mode = this.reader.int16() === 0 ? 'text' : 'binary'


### PR DESCRIPTION
The oids are supposed to be unsigned ints, according to the [docs](https://www.postgresql.org/docs/current/datatype-oid.html#:~:text=The%20oid%20type%20is%20currently,has%20few%20operations%20beyond%20comparison.).
This causes issues with oids larger than 2^31 since they become negative.
This is causing issues in other projects, like https://github.com/sequelize/sequelize/issues/15466#issuecomment-2514805522