### PR TITLE
Fix: pg-pool readme grammar

### DIFF
--- a/packages/pg-pool/README.md
+++ b/packages/pg-pool/README.md
@@ -265,7 +265,7 @@ pool
 
 #### acquire
 
-Fired whenever the a client is acquired from the pool
+Fired whenever a client is acquired from the pool
 
 Example:
 


### PR DESCRIPTION
Found in pg-pool`s readme a grammar error using "the" and "a" articles one after another