### PR TITLE
Support .toPostgres() on Array-derived objects

### DIFF
--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -66,7 +66,7 @@ var prepareValue = function (val, seen) {
       return dateToString(val)
     }
   }
-  if (Array.isArray(val)) {
+  if (Array.isArray(val) && val.toPostgres !== 'function') {
     return arrayString(val)
   }
   if (typeof val === 'object') {


### PR DESCRIPTION
Related to #2012.

Since we cannot disambiguate between Arrays that should be converted to PostgreSQL array types and Arrays that should be treated as JSON, make it at least possible to define custom Array-derived types.

This also makes it possible to properly serialize Array-derived multirange collections where elements must not be independently escaped.