### PR TITLE
GitHub Actions: Add Node v23 to the testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           - '18'
           - '20'
           - '22'
+          - '23'
         os:
           - ubuntu-latest
     name: Node.js ${{ matrix.node }}

--- a/packages/pg-native/package.json
+++ b/packages/pg-native/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/brianc/node-postgres/tree/master/packages/pg-native",
   "dependencies": {
-    "libpq": "1.8.13",
+    "libpq": "1.8.14",
     "pg-types": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Node.js v23 still fails until upgrade [`libpq`](https://www.npmjs.com/package/libpq) v1.8.13 --> v1.8.14
* #3332
* #3337 which was `closed by deleting the head repository`

Fixes: #3332
Fixes: #3364