### PR TITLE
perf(pg-types): update pg-types to 4.0.2

### DIFF
--- a/packages/pg-native/package.json
+++ b/packages/pg-native/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/brianc/node-postgres/tree/master/packages/pg-native",
   "dependencies": {
     "libpq": "1.8.13",
-    "pg-types": "^2.1.0"
+    "pg-types": "^4.0.2"
   },
   "devDependencies": {
     "async": "^0.9.0",

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -23,7 +23,7 @@
     "pg-connection-string": "^2.7.0",
     "pg-pool": "^3.7.0",
     "pg-protocol": "^1.7.0",
-    "pg-types": "^2.1.0",
+    "pg-types": "^4.0.2",
     "pgpass": "1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
pg-types 4.0.2 has some performance improvements:
- https://github.com/brianc/node-pg-types/pull/160
- https://github.com/brianc/node-pg-types/pull/148
- https://github.com/brianc/node-pg-types/pull/142