### PR TITLE
fix(pg-pool): don't throw on readonly .message e.g. ErrorEvent, preserve original exception

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -244,7 +244,7 @@ class Pool extends EventEmitter {
         // remove the dead client from our list of clients
         this._clients = this._clients.filter((c) => c !== client)
         if (timeoutHit) {
-          err = new Error('Connection terminated due to connection timeout', { cause: err } )
+          err = new Error('Connection terminated due to connection timeout', { cause: err })
         }
 
         // this client won’t be released, so move on immediately

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -244,7 +244,7 @@ class Pool extends EventEmitter {
         // remove the dead client from our list of clients
         this._clients = this._clients.filter((c) => c !== client)
         if (timeoutHit) {
-          err.message = 'Connection terminated due to connection timeout'
+          err = new Error('Connection terminated due to connection timeout', { cause: err } )
         }
 
         // this client won’t be released, so move on immediately


### PR DESCRIPTION
Fixes https://github.com/brianc/node-postgres/issues/3373