### PR TITLE
fix(devcontainer): upgrade node to version 20

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM node:12
+FROM node:20
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
-	"name": "Node.js 12 & Postgres",
+	"name": "Node.js 20 & Postgres",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "web",
 	"workspaceFolder": "/workspace",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ dist
 /.eslintcache
 .vscode/
 manually-test-on-heroku.js
-* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 /.eslintcache
 .vscode/
 manually-test-on-heroku.js
+* text=auto eol=lf


### PR DESCRIPTION
_This PR is only for help contributiors_

Upgrade to node 20 and also fix on windows the git history showing most of the files as modified in devcontainer due to this [issue](https://code.visualstudio.com/docs/remote/troubleshooting#_resolving-git-line-ending-issues-in-wsl-resulting-in-many-modified-files) fixed by adding `* text=auto eol=lf` into `.gitattributes`

Tested on: 
- Windows 11 (latest)
- VSCODE 1.97.2 (latest)
- Docker Desktop 4.38.0  (latest)
- Docker Engine 27.5.1 (latest)