### PR TITLE
simple-query-tests: remove no-op test

### DIFF
--- a/packages/pg/test/unit/client/simple-query-tests.js
+++ b/packages/pg/test/unit/client/simple-query-tests.js
@@ -112,10 +112,6 @@ test('executing query', function () {
         text: 'INSERT 31 1',
       })
     })
-
-    test('removes itself after another readyForQuery message', function () {
-      return false
-    })
   })
 
   test('handles errors', function () {


### PR DESCRIPTION
Originally skipped in daa370a61