### PR TITLE
Add "unref" to timers

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -204,6 +204,9 @@ class Pool extends EventEmitter {
         pendingItem.timedOut = true
         response.callback(new Error('timeout exceeded when trying to connect'))
       }, this.options.connectionTimeoutMillis)
+      if(tid.unref){
+          tid.unref()  
+      }
 
       this._pendingQueue.push(pendingItem)
       return result

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -204,8 +204,9 @@ class Pool extends EventEmitter {
         pendingItem.timedOut = true
         response.callback(new Error('timeout exceeded when trying to connect'))
       }, this.options.connectionTimeoutMillis)
+      
       if(tid.unref){
-          tid.unref()  
+        tid.unref()  
       }
 
       this._pendingQueue.push(pendingItem)

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -204,9 +204,9 @@ class Pool extends EventEmitter {
         pendingItem.timedOut = true
         response.callback(new Error('timeout exceeded when trying to connect'))
       }, this.options.connectionTimeoutMillis)
-      
-      if(tid.unref){
-        tid.unref()  
+
+      if (tid.unref) {
+        tid.unref()
       }
 
       this._pendingQueue.push(pendingItem)

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -104,6 +104,7 @@ class Client extends EventEmitter {
         con._ending = true
         con.stream.destroy(new Error('timeout expired'))
       }, this._connectionTimeoutMillis)
+
       if(this.connectionTimeoutHandle.unref){
         this.connectionTimeoutHandle.unref()
       }

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -104,6 +104,9 @@ class Client extends EventEmitter {
         con._ending = true
         con.stream.destroy(new Error('timeout expired'))
       }, this._connectionTimeoutMillis)
+      if(this.connectionTimeoutHandle.unref){
+        this.connectionTimeoutHandle.unref()
+      }
     }
 
     if (this.host && this.host.indexOf('/') === 0) {

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -105,7 +105,7 @@ class Client extends EventEmitter {
         con.stream.destroy(new Error('timeout expired'))
       }, this._connectionTimeoutMillis)
 
-      if(this.connectionTimeoutHandle.unref){
+      if (this.connectionTimeoutHandle.unref) {
         this.connectionTimeoutHandle.unref()
       }
     }


### PR DESCRIPTION
from https://nodejs.org/api/timers.html#timeoutunref

> When called, the active Timeout object will not require the Node.js event loop to remain active. If there is no other activity keeping the event loop running, the process may exit before the Timeout object's callback is invoked. Calling timeout.unref() multiple times will have no effect.