### PR TITLE
perf(pg-pool): optimize client retrieval from pool by prioritizing prepared client

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -149,7 +149,7 @@ class Pool extends EventEmitter {
         if (index > -1) {
           idleItem = this._idle.splice(index, 1)[0]
         }
-      } 
+      }
       if (!idleItem) {
         idleItem = this._idle.pop()
       }

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -179,6 +179,12 @@ class Pool extends EventEmitter {
   }
 
   connect(cb, name) {
+    // guard clause against passing a name as the first parameter
+    if (typeof cb === 'string') {
+      name = cb;
+      cb = undefined; 
+    }
+
     if (this.ending) {
       const err = new Error('Cannot use a pool after calling end on the pool')
       return cb ? cb(err) : this.Promise.reject(err)

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -142,7 +142,14 @@ class Pool extends EventEmitter {
     }
     const pendingItem = this._pendingQueue.shift()
     if (this._idle.length) {
-      let idleItem = name ? this._idle.find((item) => item.client.connection.parsedStatements[name]) : null
+      let idleItem = null
+      if (name) {
+        // find if there is a free client that already has cached prepared statements
+        const index = this._idle.findIndex((item) => item.client.connection.parsedStatements[name])
+        if (index > -1) {
+          idleItem = this._idle.splice(index, 1)[0]
+        }
+      } 
       if (!idleItem) {
         idleItem = this._idle.pop()
       }

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -434,7 +434,7 @@ class Pool extends EventEmitter {
         client.release(err)
         return cb(err)
       }
-    }, text.name)
+    }, text?.name)
     return response.result
   }
 

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -181,8 +181,8 @@ class Pool extends EventEmitter {
   connect(cb, name) {
     // guard clause against passing a name as the first parameter
     if (typeof cb === 'string') {
-      name = cb;
-      cb = undefined; 
+      name = cb
+      cb = undefined
     }
 
     if (this.ending) {

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -7,19 +7,20 @@ const it = require('mocha').it
 const Pool = require('../')
 
 describe('prioritizing prepared client', () => {
-  it('can create a single client with prepared statment and reuse it',
+  it(
+    'can create a single client with prepared statment and reuse it',
     co.wrap(function* () {
       const pool = new Pool({ max: 2 })
       expect(pool.waitingCount).to.equal(0)
 
       let res
-      
+
       res = yield pool.query({text: 'SELECT $1::text as name', values: ['hi'], name: 'foo'})
       expect(res.rows[0].name).to.equal('hi')
       expect(pool._idle.length).to.equal(1)
-      
-      res = yield pool.query({text: 'SELECT $1::text as name', values: ['hi'], name: 'foo'})
-      expect(res.rows[0].name).to.equal('hi')
+
+      res = yield pool.query({text: 'SELECT $1::text as name', values: ['ho'], name: 'foo'})
+      expect(res.rows[0].name).to.equal('ho')
       expect(pool._idle.length).to.equal(1)
 
       pool.end()

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -15,11 +15,11 @@ describe('prioritizing prepared client', () => {
 
       let res
 
-      res = yield pool.query({text: 'SELECT $1::text as name', values: ['hi'], name: 'foo'})
+      res = yield pool.query({ text: 'SELECT $1::text as name', values: ['hi'], name: 'foo' })
       expect(res.rows[0].name).to.equal('hi')
       expect(pool._idle.length).to.equal(1)
 
-      res = yield pool.query({text: 'SELECT $1::text as name', values: ['ho'], name: 'foo'})
+      res = yield pool.query({ text: 'SELECT $1::text as name', values: ['ho'], name: 'foo' })
       expect(res.rows[0].name).to.equal('ho')
       expect(pool._idle.length).to.equal(1)
 

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -12,6 +12,17 @@ describe('prioritizing prepared client', () => {
     co.wrap(function* () {
       const pool = new Pool({ max: 2 })
       expect(pool.waitingCount).to.equal(0)
+      expect(pool._idle.length).to.equal(0)
+
+      // force the creation of two client and release. 
+      // In this way we have two idle client
+      const firstClient = yield pool.connect()
+      expect(pool._clients.length).to.equal(1)
+      const secondClient = yield pool.connect()
+      expect(pool._clients.length).to.equal(2)
+      firstClient.release()
+      secondClient.release()
+      expect(pool._idle.length).to.equal(2)
 
       let res
 

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -15,13 +15,17 @@ describe('prioritizing prepared client', () => {
 
       let res
 
-      res = yield pool.query({ text: 'SELECT $1::text as name', values: ['hi'], name: 'foo' })
+      res = yield pool.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['hi'], name: 'foo' })
       expect(res.rows[0].name).to.equal('hi')
       expect(pool._idle.length).to.equal(1)
+      const firstPid = res.rows[0].pid
 
-      res = yield pool.query({ text: 'SELECT $1::text as name', values: ['ho'], name: 'foo' })
+      res = yield pool.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['ho'], name: 'foo' })
       expect(res.rows[0].name).to.equal('ho')
       expect(pool._idle.length).to.equal(1)
+      const secondPid = res.rows[0].pid
+
+      expect(firstPid).to.equal(secondPid)
 
       pool.end()
     })

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -1,0 +1,29 @@
+const expect = require('expect.js')
+const co = require('co')
+
+const describe = require('mocha').describe
+const it = require('mocha').it
+
+const Pool = require('../')
+
+describe('prioritizing prepared client', () => {
+  it('can create a single client with prepared statment and reuse it',
+    co.wrap(function* () {
+      const pool = new Pool({ max: 2 })
+      expect(pool.waitingCount).to.equal(0)
+
+      let res
+      
+      res = yield pool.query({text: 'SELECT $1::text as name', values: ['hi'], name: 'foo'})
+      expect(res.rows[0].name).to.equal('hi')
+      expect(pool._idle.length).to.equal(1)
+      
+      res = yield pool.query({text: 'SELECT $1::text as name', values: ['hi'], name: 'foo'})
+      expect(res.rows[0].name).to.equal('hi')
+      expect(pool._idle.length).to.equal(1)
+
+      pool.end()
+    })
+  )
+
+})

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -28,12 +28,12 @@ describe('prioritizing prepared client', () => {
 
       res = yield pool.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['hi'], name: 'foo' })
       expect(res.rows[0].name).to.equal('hi')
-      expect(pool._idle.length).to.equal(1)
+      expect(pool._idle.length).to.equal(2)
       const firstPid = res.rows[0].pid
 
       res = yield pool.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['ho'], name: 'foo' })
       expect(res.rows[0].name).to.equal('ho')
-      expect(pool._idle.length).to.equal(1)
+      expect(pool._idle.length).to.equal(2)
       const secondPid = res.rows[0].pid
 
       expect(firstPid).to.equal(secondPid)

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -43,9 +43,10 @@ describe('prioritizing prepared client', () => {
       // check also connect with name, return same client
 
       firstClient = yield pool.connect('foo')
+      expect(pool._idle.length).to.equal(1)
       res = yield firstClient.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['hi'] })
       expect(res.rows[0].name).to.equal('hi')
-      expect(firstPid).to.not.equal(res.rows[0].pid)
+      expect(firstPid).to.equal(res.rows[0].pid)
       firstClient.release()
       expect(pool._idle.length).to.equal(2)
 

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -26,5 +26,4 @@ describe('prioritizing prepared client', () => {
       pool.end()
     })
   )
-
 })

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -40,20 +40,6 @@ describe('prioritizing prepared client', () => {
 
       expect(firstPid).to.equal(secondPid)
 
-      // not the same client without prepared query
-
-      res = yield pool.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['hi'] })
-      expect(res.rows[0].name).to.equal('hi')
-      expect(pool._idle.length).to.equal(2)
-      firstPid = res.rows[0].pid
-
-      res = yield pool.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['ho'] })
-      expect(res.rows[0].name).to.equal('ho')
-      expect(pool._idle.length).to.equal(2)
-      secondPid = res.rows[0].pid
-
-      expect(firstPid).to.not.equal(secondPid)
-
       pool.end()
     })
   )

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -24,19 +24,35 @@ describe('prioritizing prepared client', () => {
       secondClient.release()
       expect(pool._idle.length).to.equal(2)
 
-      let res
+      let res, firstPid, secondPid
+
+      // check the same client with prepared query
 
       res = yield pool.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['hi'], name: 'foo' })
       expect(res.rows[0].name).to.equal('hi')
       expect(pool._idle.length).to.equal(2)
-      const firstPid = res.rows[0].pid
+      firstPid = res.rows[0].pid
 
       res = yield pool.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['ho'], name: 'foo' })
       expect(res.rows[0].name).to.equal('ho')
       expect(pool._idle.length).to.equal(2)
-      const secondPid = res.rows[0].pid
+      secondPid = res.rows[0].pid
 
       expect(firstPid).to.equal(secondPid)
+
+      // not the same client without prepared query
+
+      res = yield pool.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['hi'] })
+      expect(res.rows[0].name).to.equal('hi')
+      expect(pool._idle.length).to.equal(2)
+      firstPid = res.rows[0].pid
+
+      res = yield pool.query({ text: 'SELECT $1::text as name, pg_backend_pid() as pid', values: ['ho'] })
+      expect(res.rows[0].name).to.equal('ho')
+      expect(pool._idle.length).to.equal(2)
+      secondPid = res.rows[0].pid
+
+      expect(firstPid).to.not.equal(secondPid)
 
       pool.end()
     })

--- a/packages/pg-pool/test/prioritizing-prepared-client.js
+++ b/packages/pg-pool/test/prioritizing-prepared-client.js
@@ -14,7 +14,7 @@ describe('prioritizing prepared client', () => {
       expect(pool.waitingCount).to.equal(0)
       expect(pool._idle.length).to.equal(0)
 
-      // force the creation of two client and release. 
+      // force the creation of two client and release.
       // In this way we have two idle client
       const firstClient = yield pool.connect()
       expect(pool._clients.length).to.equal(1)


### PR DESCRIPTION
see https://github.com/brianc/node-postgres/issues/3397

Instead of retrieving the first available client from the pool, check if there is a free client that already has cached prepared statements. This could improve performance by reducing the need to re-prepare statements on different clients.