### PR TITLE
docs: fix bug in transaction example

### DIFF
--- a/docs/pages/features/transactions.mdx
+++ b/docs/pages/features/transactions.mdx
@@ -31,10 +31,10 @@ try {
   const insertPhotoValues = [res.rows[0].id, 's3.bucket.foo']
   await client.query(insertPhotoText, insertPhotoValues)
   await client.query('COMMIT')
+  client.release()
 } catch (e) {
   await client.query('ROLLBACK')
-  throw e
-} finally {
   client.release()
+  throw e
 }
 ```


### PR DESCRIPTION
Throwing error will not allow "finally" execution, so client.release() must be invoked before it.

Here a very simple example of JS behaviour:
```
try {
  console.log('init');
  throw new Error('TestError');
} catch (e) {
  console.log('catch'); / prints "Error: TestError"
  throw e
} finally {
  console.log('finally'); // not printed
}
```

I know this is an easy catch for experienced js developers, nevertheless i'm afraid providing this bugged example will cause (and caused) a lot of subtle bugs into beginners code.