### PR TITLE
docs: add missing parameters on pg.Client Config

### DIFF
--- a/docs/pages/apis/client.mdx
+++ b/docs/pages/apis/client.mdx
@@ -23,7 +23,10 @@ type Config = {
   lock_timeout?: number, // number of milliseconds a query is allowed to be en lock state before it's cancelled due to lock timeout
   application_name?: string, // The name of the application that created this Client instance
   connectionTimeoutMillis?: number, // number of milliseconds to wait for connection, default is no timeout
-  idle_in_transaction_session_timeout?: number // number of milliseconds before terminating any session with an open idle transaction, default is no timeout
+  idle_in_transaction_session_timeout?: number, // number of milliseconds before terminating any session with an open idle transaction, default is no timeout
+  client_encoding?: string, // specifies the character set encoding that the database uses for sending data to the client
+  fallback_application_name?: string, // provide an application name to use if application_name is not set
+  options?: string // command-line options to be sent to the server
 }
 ```
 


### PR DESCRIPTION
- client_encoding
- fallback_application_name
- options

==========

While working on pg-connection-string, I noticed that `client_encoding` did not exist on `ClientConfig` in [@types/pg](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a2293665c880f8b59794bca227db53c8a84c4a7f/types/pg/index.d.ts#L12-L30). This led to me to discover that it was not a documented parameter as well.

Reference: https://www.postgresql.org/docs/current/libpq-connect.html

Use in code:

`client_encoding`

https://github.com/brianc/node-postgres/blob/d8fb2f9c3585485d99efa0c511d8c06b5bf1e450/packages/pg/lib/connection-parameters.js#L98

`fallback_application_name`

https://github.com/brianc/node-postgres/blob/d8fb2f9c3585485d99efa0c511d8c06b5bf1e450/packages/pg/lib/connection-parameters.js#L104

`options`

https://github.com/brianc/node-postgres/blob/d8fb2f9c3585485d99efa0c511d8c06b5bf1e450/packages/pg/lib/connection-parameters.js#L79