### PR TITLE
fix(pg-connection-string): export default from esm wrapper

### DIFF
--- a/packages/pg-connection-string/esm/index.mjs
+++ b/packages/pg-connection-string/esm/index.mjs
@@ -2,6 +2,7 @@
 import connectionString from '../index.js'
 
 // Re-export the parse function
+export default connectionString.parse
 export const parse = connectionString.parse
 export const toClientConfig = connectionString.toClientConfig
 export const parseIntoClientConfig = connectionString.parseIntoClientConfig


### PR DESCRIPTION
Prior to v2.8.0, the parse function was the default when using import. When esm compatibility was introduced in v2.8.0, there was not default specified. This broke existing code that relied on that default.

Fixes #3424