### PR TITLE
fix(exports): resolve issues with module imports and requires

### DIFF
--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -24,6 +24,11 @@
       "import": "./esm/index.mjs",
       "require": "./lib/index.js",
       "default": "./lib/index.js"
+    },
+    "./lib/*": {
+      "import": "./lib/*",
+      "require": "./lib/*",
+      "default": "./lib/*"
     }
   },
   "dependencies": {


### PR DESCRIPTION
This PR addresses a regression introduced in `pg@8.15.1` due to the addition of ESM support via #3423. The updated `exports` field in `package.json` restricts access to internal modules such as `lib/connection-parameters.js`, which are utilized by tools like [node-pg-migrate](https://github.com/salsita/node-pg-migrate)

As a result, users (https://github.com/salsita/node-pg-migrate/issues/1398) encounter the following error:

```bash

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/connection-parameters.js' is not defined by "exports" in [path-to-repo]/node_modules/pg/package.json
```

To resolve this, I've updated the `exports` field to include `./lib/*`, ensuring compatibility with existing tools that rely on them.