### PR TITLE
More tests & exports from pg-protocol

### DIFF
--- a/packages/pg-esm-test/common-js-imports.test.cjs
+++ b/packages/pg-esm-test/common-js-imports.test.cjs
@@ -2,7 +2,13 @@ const assert = require('node:assert')
 const test = require('node:test')
 const { describe, it } = test
 
-const paths = ['pg', 'pg/lib/index.js', 'pg/lib/connection-parameters.js']
+const paths = [
+  'pg',
+  'pg/lib/index.js',
+  'pg/lib/connection-parameters.js',
+  'pg-protocol/dist/messages.js',
+  'pg-native/lib/build-result.js',
+]
 for (const path of paths) {
   describe(`importing ${path}`, () => {
     it('works with require', () => {

--- a/packages/pg-esm-test/package.json
+++ b/packages/pg-esm-test/package.json
@@ -19,7 +19,8 @@
     "pg-cursor": "^2.14.1",
     "pg-native": "^3.4.0",
     "pg-pool": "^3.9.1",
-    "pg-query-stream": "^4.9.1"
+    "pg-query-stream": "^4.9.1",
+    "pg-protocol": "^1.9.0"
   },
   "author": "Brian M. Carlson <brian.m.carlson@gmail.com>",
   "license": "MIT"

--- a/packages/pg-esm-test/pg-protocol.test.js
+++ b/packages/pg-esm-test/pg-protocol.test.js
@@ -1,0 +1,18 @@
+import protocol, { NoticeMessage, DatabaseError } from 'pg-protocol/dist/messages.js'
+import { describe, it } from 'node:test'
+import { strict as assert } from 'node:assert'
+
+describe('pg-protocol', () => {
+  it('should export database error', () => {
+    assert.ok(DatabaseError)
+  })
+  it('should export protocol', () => {
+    assert.ok(protocol)
+    assert.ok(protocol.noData)
+    assert.ok(protocol.parseComplete)
+    assert.ok(protocol.NoticeMessage)
+  })
+  it('should export NoticeMessage from file in dist folder', () => {
+    assert.ok(NoticeMessage)
+  })
+})

--- a/packages/pg-native/package.json
+++ b/packages/pg-native/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "index.js",
+    "lib",
     "esm"
   ]
 }

--- a/packages/pg-protocol/esm/index.js
+++ b/packages/pg-protocol/esm/index.js
@@ -1,5 +1,5 @@
 // ESM wrapper for pg-protocol
-import protocol from '../dist/index.js'
+import * as protocol from '../dist/index.js'
 
 // Re-export all the properties
 export const DatabaseError = protocol.DatabaseError

--- a/packages/pg-protocol/package.json
+++ b/packages/pg-protocol/package.json
@@ -9,6 +9,11 @@
       "import": "./esm/index.js",
       "require": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./dist/*": {
+      "import": "./dist/*",
+      "require": "./dist/*",
+      "default": "./dist/*"
     }
   },
   "license": "MIT",


### PR DESCRIPTION
Update more exports and visibility of files.  Also, include the `./lib` sub-directory in pg-native (it was mistakenly excluded) when the library is published to npm.  This wasn't caught in my tests since they reference local copy of all source and it was a publishing specific issue.