### PR TITLE
Support Min connection pool parameter #3009

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -367,17 +367,15 @@ class Pool extends EventEmitter {
 
     // idle timeout
     let tid
-    if (this.options.idleTimeoutMillis) {
-      if (this._isAboveMin()) {
-        tid = setTimeout(() => {
-          this.log('remove idle client')
-          this._remove(client)
-        }, this.options.idleTimeoutMillis)
+    if (this.options.idleTimeoutMillis && this._isAboveMin()) {
+      tid = setTimeout(() => {
+        this.log('remove idle client')
+        this._remove(client)
+      }, this.options.idleTimeoutMillis)
 
-        if (this.options.allowExitOnIdle) {
-          // allow Node to exit if this is all that's left
-          tid.unref()
-        }
+      if (this.options.allowExitOnIdle) {
+        // allow Node to exit if this is all that's left
+        tid.unref()
       }
     }
 

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -339,10 +339,8 @@ class Pool extends EventEmitter {
 
   // release a client back to the poll, include an error
   // to remove it from the pool
-  _release(client, idleListener, err, registerListener = true) {
-    if (registerListener) {
-      client.on('error', idleListener)
-    }
+  _release(client, idleListener, err) {
+    client.on('error', idleListener)
 
     client._poolUseCount = (client._poolUseCount || 0) + 1
 

--- a/packages/pg-pool/test/sizing.js
+++ b/packages/pg-pool/test/sizing.js
@@ -55,4 +55,72 @@ describe('pool size of 1', () => {
       return yield pool.end()
     })
   )
+
+  it(
+    'does not remove clients when at or below min',
+    co.wrap(function* () {
+      const pool = new Pool({ max: 1, min: 1, idleTimeoutMillis: 10 })
+      const client = yield pool.connect()
+      client.release()
+      yield new Promise((resolve) => setTimeout(resolve, 20))
+      expect(pool.idleCount).to.equal(1)
+      return yield pool.end()
+    })
+  )
+
+  it(
+    'does remove clients when at or below min if maxUses is reached',
+    co.wrap(function* () {
+      const pool = new Pool({ max: 1, min: 1, idleTimeoutMillis: 10, maxUses: 1 })
+      const client = yield pool.connect()
+      client.release()
+      yield new Promise((resolve) => setTimeout(resolve, 20))
+      expect(pool.idleCount).to.equal(0)
+      return yield pool.end()
+    })
+  )
+
+  it(
+    'does remove clients when at or below min if maxLifetimeSeconds is reached',
+    co.wrap(function* () {
+      const pool = new Pool({ max: 1, min: 1, idleTimeoutMillis: 10, maxLifetimeSeconds: 1 })
+      const client = yield pool.connect()
+      client.release()
+      yield new Promise((resolve) => setTimeout(resolve, 1020))
+      expect(pool.idleCount).to.equal(0)
+      return yield pool.end()
+    })
+  )
+})
+
+describe('pool size of 2', () => {
+  it(
+    'does not remove clients when at or below min',
+    co.wrap(function* () {
+      const pool = new Pool({ max: 2, min: 2, idleTimeoutMillis: 10 })
+      const client = yield pool.connect()
+      const client2 = yield pool.connect()
+      client.release()
+      yield new Promise((resolve) => setTimeout(resolve, 20))
+      client2.release()
+      yield new Promise((resolve) => setTimeout(resolve, 20))
+      expect(pool.idleCount).to.equal(2)
+      return yield pool.end()
+    })
+  )
+
+  it(
+    'does remove clients when above min',
+    co.wrap(function* () {
+      const pool = new Pool({ max: 2, min: 1, idleTimeoutMillis: 10 })
+      const client = yield pool.connect()
+      const client2 = yield pool.connect()
+      client.release()
+      yield new Promise((resolve) => setTimeout(resolve, 20))
+      client2.release()
+      yield new Promise((resolve) => setTimeout(resolve, 20))
+      expect(pool.idleCount).to.equal(1)
+      return yield pool.end()
+    })
+  )
 })


### PR DESCRIPTION
My attempt to address #3009 

Hopefully this is sensible with the tests I've included

I suspect that lack of this functionality is causing my company's app to frequently hit bottlenecks with allocating new db pool connections