### PR TITLE
chore: re-enable no-unused vars eslint rule and align to ts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,9 +14,13 @@
   },
   "rules": {
     "@typescript-eslint/no-unused-vars": ["error", {
-      "args": "none"
+      "args": "none",
+      "varsIgnorePattern": "^_$"
     }],
-    "no-unused-vars": "off",
+    "no-unused-vars": ["error", {
+      "args": "none",
+      "varsIgnorePattern": "^_$"
+    }],
     "no-var": "error",
     "prefer-const": "error"
   },

--- a/packages/pg-native/test/domains.js
+++ b/packages/pg-native/test/domains.js
@@ -8,7 +8,7 @@ const checkDomain = function (domain, when) {
 
 describe('domains', function () {
   it('remains bound after a query', function (done) {
-    var domain = require('domain').create() // eslint-disable-line
+    const domain = require('domain').create()
     domain.run(function () {
       const client = new Client()
       client.connect(function () {

--- a/packages/pg-protocol/src/serializer.ts
+++ b/packages/pg-protocol/src/serializer.ts
@@ -78,11 +78,9 @@ const parse = (query: ParseOpts): Buffer => {
   // normalize missing query names to allow for null
   const name = query.name || ''
   if (name.length > 63) {
-    /* eslint-disable no-console */
     console.error('Warning! Postgres only supports 63 characters for query names.')
     console.error('You supplied %s (%s)', name, name.length)
     console.error('This can cause conflicts and silent errors executing queries')
-    /* eslint-enable no-console */
   }
 
   const types = query.types || emptyArray

--- a/packages/pg-query-stream/test/async-iterator.ts
+++ b/packages/pg-query-stream/test/async-iterator.ts
@@ -122,11 +122,9 @@ if (!process.version.startsWith('v8')) {
       const pool = new pg.Pool({ max: 1 })
       const client = await pool.connect()
 
-      /* eslint-disable @typescript-eslint/no-unused-vars */
       for await (const _ of client.query(new QueryStream('select TRUE', [], { highWaterMark: 1 }))) break
       for await (const _ of client.query(new QueryStream('select TRUE', [], { highWaterMark: 1 }))) break
       for await (const _ of client.query(new QueryStream('select TRUE', [], { highWaterMark: 1 }))) break
-      /* eslint-enable @typescript-eslint/no-unused-vars */
 
       client.release()
       await pool.end()

--- a/packages/pg/lib/native/query.js
+++ b/packages/pg/lib/native/query.js
@@ -32,7 +32,6 @@ const NativeQuery = (module.exports = function (config, values, callback) {
 util.inherits(NativeQuery, EventEmitter)
 
 const errorFieldMap = {
-  /* eslint-disable quote-props */
   sqlState: 'code',
   statementPosition: 'position',
   messagePrimary: 'message',
@@ -130,11 +129,9 @@ NativeQuery.prototype.submit = function (client) {
   // named query
   if (this.name) {
     if (this.name.length > 63) {
-      /* eslint-disable no-console */
       console.error('Warning! Postgres only supports 63 characters for query names.')
       console.error('You supplied %s (%s)', this.name, this.name.length)
       console.error('This can cause conflicts and silent errors executing queries')
-      /* eslint-enable no-console */
     }
     const values = (this.values || []).map(utils.prepareValue)
 

--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -244,7 +244,6 @@ class Query extends EventEmitter {
     connection.sendCopyFail('No source stream defined')
   }
 
-  // eslint-disable-next-line no-unused-vars
   handleCopyData(msg, connection) {
     // noop
   }

--- a/packages/pg/test/integration/client/simple-query-tests.js
+++ b/packages/pg/test/integration/client/simple-query-tests.js
@@ -20,11 +20,7 @@ test('simple query interface', function () {
   })
   query.once('row', function (row) {
     test('Can iterate through columns', function () {
-      let columnCount = 0
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for (const column in row) {
-        columnCount++
-      }
+      const columnCount = Object.keys(row).length
       if ('length' in row) {
         assert.lengthIs(
           row,


### PR DESCRIPTION
- enable no-unused-vars eslint rule that was off
- fix errors about that rule, but ignore unused params in functions (like the already existing TS rule)
- remove some unused disable eslint lines