### PR TITLE
docs: remove remaining "sslcompat" references

### DIFF
--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -85,11 +85,11 @@ Query parameters follow a `?` character, including the following special query p
  * `encoding=<encoding>` - sets the `client_encoding` property
  * `ssl=1`, `ssl=true`, `ssl=0`, `ssl=false` - sets `ssl` to true or false, accordingly
  * `uselibpqcompat=true` - use libpq semantics
- * `sslmode=<sslmode>` when `sslcompat` is not set
+ * `sslmode=<sslmode>` when `uselibpqcompat=true` is not set
    * `sslmode=disable` - sets `ssl` to false
    * `sslmode=no-verify` - sets `ssl` to `{ rejectUnauthorized: false }`
    * `sslmode=prefer`, `sslmode=require`, `sslmode=verify-ca`, `sslmode=verify-full` - sets `ssl` to true
- * `sslmode=<sslmode>` when `sslcompat=libpq`
+ * `sslmode=<sslmode>` when `uselibpqcompat=true`
    * `sslmode=disable` - sets `ssl` to false
    * `sslmode=prefer` - sets `ssl` to `{ rejectUnauthorized: false }`
    * `sslmode=require` - sets `ssl` to `{ rejectUnauthorized: false }` unless `sslrootcert` is specified, in which case it behaves like `verify-ca`

--- a/packages/pg-connection-string/test/parse.ts
+++ b/packages/pg-connection-string/test/parse.ts
@@ -403,7 +403,7 @@ describe('parse', function () {
     expect(subject.ssl?.checkServerIdentity()).be.undefined
   })
 
-  it('does not allow sslcompat query parameter and useLibpqCompat option at the same time', function () {
+  it('does not allow uselibpqcompat query parameter and useLibpqCompat option at the same time', function () {
     const connectionString = 'pg:///?uselibpqcompat=true'
     expect(function () {
       parse(connectionString, { useLibpqCompat: true })


### PR DESCRIPTION
looks like there were just a couple missed [here](https://github.com/brianc/node-postgres/pull/2709/commits/89161f388009e2295cfe02ec79cb508bc7d12169). should be 0 left now