### PR TITLE
Update theme.config.js

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -53,7 +53,7 @@ l-161 -22 -94 41 c-201 87 -327 113 -533 112 -77 -1 -166 -7 -196 -13z m-89
     </>
   ),
   chat: {
-    link: 'https://discord.gg/4nbb6zJa',
+    link: 'https://discord.gg/2afXp5vUWm',
   },
   head: (
     <>


### PR DESCRIPTION
closes #3466 

Apparently by default discord generates invite links that expire in 7 days. I should have read the fine print. This invite never expires.