### PR TITLE
feat(pg-connection-string): warn if non-standard ssl options are used

### DIFF
--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -210,7 +210,7 @@ function deprecatedSslModeWarning(sslmode) {
   if (!deprecatedSslModeWarning.warned) {
     deprecatedSslModeWarning.warned = true
     emitWarning(`SECURITY WARNING: The SSL modes 'prefer', 'require', and 'verify-ca' are treated as aliases for 'verify-full'.
-In the next major version (v3.0.0), these modes will adopt standard libpq semantics, which have weaker security guarantees.
+In the next major version (pg-connection-string v3.0.0 and pg v9.0.0), these modes will adopt standard libpq semantics, which have weaker security guarantees.
 
 To prepare for this change:
 - If you want the current behavior, explicitly use 'sslmode=verify-full'

--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { emitWarning } = require('node:process')
+
 //Parse method copied from https://github.com/brianc/node-postgres
 //Copyright (c) 2010-2014 Brian Carlson (brian.m.carlson@gmail.com)
 //MIT License
@@ -133,6 +135,9 @@ function parse(str, options = {}) {
       case 'require':
       case 'verify-ca':
       case 'verify-full': {
+        if (config.sslmode !== 'verify-full') {
+          deprecatedSslModeWarning(config.sslmode)
+        }
         break
       }
       case 'no-verify': {
@@ -199,6 +204,20 @@ function toClientConfig(config) {
 // parses a connection string into ClientConfig
 function parseIntoClientConfig(str) {
   return toClientConfig(parse(str))
+}
+
+function deprecatedSslModeWarning(sslmode) {
+  if (!deprecatedSslModeWarning.warned) {
+    deprecatedSslModeWarning.warned = true
+    emitWarning(`SECURITY WARNING: The SSL modes 'prefer', 'require', and 'verify-ca' are treated as aliases for 'verify-full'.
+In the next major version (v3.0.0), these modes will adopt standard libpq semantics, which have weaker security guarantees.
+
+To prepare for this change:
+- If you want the current behavior, explicitly use 'sslmode=verify-full'
+- If you want libpq compatibility now, use 'uselibpqcompat=true&sslmode=${sslmode}'
+
+See https://www.postgresql.org/docs/current/libpq-ssl.html for libpq SSL mode definitions.`)
+  }
 }
 
 module.exports = parse


### PR DESCRIPTION
In preparation for v3.0.0, we start warning users to be explicit about the sslmode they want.