### PR TITLE
Use performance.now() instead of Date.now()...

### DIFF
--- a/packages/pg-native/bench/leaks.js
+++ b/packages/pg-native/bench/leaks.js
@@ -1,15 +1,6 @@
 const Client = require('../')
 const async = require('async')
 
-let performance
-try {
-  // Support for node < 16.0.0
-  performance = require('perf_hooks').performance
-} catch (e) {
-  // failback for node < 8.5.0
-  performance = { now: Date.now } // Fallback to Date.now
-}
-
 const loop = function () {
   const client = new Client()
 

--- a/packages/pg-native/bench/leaks.js
+++ b/packages/pg-native/bench/leaks.js
@@ -1,7 +1,7 @@
 const Client = require('../')
 const async = require('async')
 
-let performance = { now: () => number }
+let performance
 try {
   // Support for node < 16.0.0
   performance = require('perf_hooks').performance

--- a/packages/pg-native/bench/leaks.js
+++ b/packages/pg-native/bench/leaks.js
@@ -1,6 +1,15 @@
 const Client = require('../')
 const async = require('async')
 
+let performance: { now: () => number };
+try {
+  // Support for node < 16.0.0
+  performance = require('perf_hooks').performance;
+} catch (e) {
+  // failback for node < 8.5.0
+  performance = { now: Date.now }; // Fallback to Date.now
+}
+
 const loop = function () {
   const client = new Client()
 
@@ -37,10 +46,10 @@ const loop = function () {
 
   const ops = [connect, simpleQuery, paramsQuery, prepared, sync, end]
 
-  const start = Date.now()
+  const start = performance.now()
   async.series(ops, function (err) {
     if (err) throw err
-    console.log(Date.now() - start)
+    console.log(performance.now() - start)
     setImmediate(loop)
   })
 }

--- a/packages/pg-native/bench/leaks.js
+++ b/packages/pg-native/bench/leaks.js
@@ -1,13 +1,13 @@
 const Client = require('../')
 const async = require('async')
 
-let performance: { now: () => number };
+let performance = { now: () => number }
 try {
   // Support for node < 16.0.0
-  performance = require('perf_hooks').performance;
+  performance = require('perf_hooks').performance
 } catch (e) {
   // failback for node < 8.5.0
-  performance = { now: Date.now }; // Fallback to Date.now
+  performance = { now: Date.now } // Fallback to Date.now
 }
 
 const loop = function () {

--- a/packages/pg-protocol/src/b.ts
+++ b/packages/pg-protocol/src/b.ts
@@ -2,15 +2,6 @@
 
 import { BufferReader } from './buffer-reader'
 
-let performance: { now: () => number }
-try {
-  // Support for node < 16.0.0
-  performance = require('perf_hooks').performance
-} catch (e) {
-  // failback for node < 8.5.0
-  performance = { now: Date.now } // Fallback to Date.now
-}
-
 const LOOPS = 1000
 let count = 0
 const start = performance.now()

--- a/packages/pg-protocol/src/b.ts
+++ b/packages/pg-protocol/src/b.ts
@@ -2,16 +2,25 @@
 
 import { BufferReader } from './buffer-reader'
 
+let performance: { now: () => number };
+try {
+  // Support for node < 16.0.0
+  performance = require('perf_hooks').performance;
+} catch (e) {
+  // failback for node < 8.5.0
+  performance = { now: Date.now }; // Fallback to Date.now
+}
+
 const LOOPS = 1000
 let count = 0
-const start = Date.now()
+const start = performance.now()
 
 const reader = new BufferReader()
 const buffer = Buffer.from([33, 33, 33, 33, 33, 33, 33, 0])
 
 const run = () => {
   if (count > LOOPS) {
-    console.log(Date.now() - start)
+    console.log(performance.now() - start)
     return
   }
   count++

--- a/packages/pg-protocol/src/b.ts
+++ b/packages/pg-protocol/src/b.ts
@@ -2,13 +2,13 @@
 
 import { BufferReader } from './buffer-reader'
 
-let performance: { now: () => number };
+let performance: { now: () => number }
 try {
   // Support for node < 16.0.0
-  performance = require('perf_hooks').performance;
+  performance = require('perf_hooks').performance
 } catch (e) {
   // failback for node < 8.5.0
-  performance = { now: Date.now }; // Fallback to Date.now
+  performance = { now: Date.now } // Fallback to Date.now
 }
 
 const LOOPS = 1000

--- a/packages/pg/bench.js
+++ b/packages/pg/bench.js
@@ -1,14 +1,5 @@
 const pg = require('./lib')
 
-let performance
-try {
-  // Support for node < 16.0.0
-  performance = require('perf_hooks').performance
-} catch (e) {
-  // failback for node < 8.5.0
-  performance = { now: () => Date.now() }
-}
-
 const params = {
   text: 'select typname, typnamespace, typowner, typlen, typbyval, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray from pg_type where typtypmod = $1 and typisdefined = $2',
   values: [-1, true],

--- a/packages/pg/bench.js
+++ b/packages/pg/bench.js
@@ -1,13 +1,13 @@
 const pg = require('./lib')
 
-let performance;
+let performance
 try {
-    // Support for node < 16.0.0
-    performance = require('perf_hooks').performance
+  // Support for node < 16.0.0
+  performance = require('perf_hooks').performance
 } catch (e) {
-    // failback for node < 8.5.0
-    performance = { now: () => Date.now() }
-};
+  // failback for node < 8.5.0
+  performance = { now: () => Date.now() }
+}
 
 const params = {
   text: 'select typname, typnamespace, typowner, typlen, typbyval, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray from pg_type where typtypmod = $1 and typisdefined = $2',


### PR DESCRIPTION
Replaced Date.now() for performance.now() (wherever applicable) to improve timing accuracy.

Date.now() is prone to system clock shifts, while performance.now() offers a high-resolution, monotonic clock for consistent, reliable measurements.

Not sure, but it could be involved in timeout issues we experience in VM environment but, anyway, this is the best way to measure time.

Added faliback code to support node prior to 16.0.0 (where perf_hook were not globally exposed by default) and even prior to 8.5.0 (defaulting to Date.now()).

Verified tests passes with node 22.12.0.

Attempted to pass with node prior to 16.0.0 but faced issues due to picked dependencies versions and other code of node_postgres that I guess it haven't been tested with so old node versions.

(I attempted to support at least from 8.0.0 which is declared in engines.node of packages/pg/package.json)

References:

https://nodejs.org/docs/latest-v8.x/api/perf_hooks.html#perf_hooks_performance_now

https://w3c.github.io/hr-time/
