### PR TITLE
docs(pg.Pool): describe `maxLifetimeSeconds` config option

### DIFF
--- a/docs/pages/apis/pool.mdx
+++ b/docs/pages/apis/pool.mdx
@@ -50,6 +50,12 @@ type Config = {
   // to the postgres server.  This can be handy in scripts & tests
   // where you don't want to wait for your clients to go idle before your process exits.
   allowExitOnIdle?: boolean
+
+  // Sets a max overall life for the connection.
+  // A value of 60 would evict connections that have been around for over 60 seconds,
+  // regardless of whether they are idle. It's useful to force rotation of connection pools through
+  // middleware so that you can rotate the underlying servers. The default is disabled (value of zero)
+  maxLifetimeSeconds?: number
 }
 ```
 
@@ -64,6 +70,7 @@ const pool = new Pool({
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000,
+  maxLifetimeSeconds: 60
 })
 ```
 


### PR DESCRIPTION
The official [`pg.Pool`](https://node-postgres.com/apis/pool) page doesn't describe the `maxLifetimeSeconds` option, which is nonetheless [supported by the code](https://github.com/brianc/node-postgres/blob/03642abec1c09337fa9cfb4b7ce5543b086c6437/packages/pg-pool/index.js#L93), and present in the `@types/pg` package (it was added in https://github.com/brianc/node-postgres/pull/2698 all the way back in 2022). The lack of documentation makes it slightly difficult to discover the option.

The wording I've used was taken from https://github.com/brianc/node-postgres/issues/3298#issuecomment-2305207256. Feel free to change it if you're not happy with it.