### PR TITLE
Add `package.json` in exports

### DIFF
--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -25,6 +25,9 @@
       "require": "./lib/index.js",
       "default": "./lib/index.js"
     },
+    "./package.json": {
+      "default": "./package.json"
+    },
     "./lib/*": {
       "import": "./lib/*",
       "require": "./lib/*",


### PR DESCRIPTION
Many tools rely on resolving the `./package.json` path to find packages, not having this export path breaks a lot of tools.