### PR TITLE
Replace `cloudflare` export condition in `pg-cloudflare` with `workerd`

### DIFF
--- a/packages/pg-bundler-test/esbuild-cloudflare.config.mjs
+++ b/packages/pg-bundler-test/esbuild-cloudflare.config.mjs
@@ -4,5 +4,5 @@ await esbuild.build({
   entryPoints: ['./src/index.mjs'],
   bundle: true,
   outfile: './dist/esbuild-cloudflare.js',
-  conditions: ['import', 'cloudflare'],
+  conditions: ['import', 'workerd'],
 })

--- a/packages/pg-bundler-test/rollup-cloudflare.config.mjs
+++ b/packages/pg-bundler-test/rollup-cloudflare.config.mjs
@@ -8,6 +8,6 @@ export default defineConfig({
     file: 'dist/rollup-cloudflare.js',
     format: 'es',
   },
-  plugins: [nodeResolve({ exportConditions: ['import', 'cloudflare'], preferBuiltins: true }), commonjs()],
+  plugins: [nodeResolve({ exportConditions: ['import', 'workerd'], preferBuiltins: true }), commonjs()],
   external: ['cloudflare:sockets'],
 })

--- a/packages/pg-bundler-test/vite-cloudflare.config.mjs
+++ b/packages/pg-bundler-test/vite-cloudflare.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
     },
   },
   resolve: {
-    conditions: ['import', 'cloudflare'],
+    conditions: ['import', 'workerd'],
   },
   plugins: [commonjs()],
 })

--- a/packages/pg-bundler-test/webpack-cloudflare.config.mjs
+++ b/packages/pg-bundler-test/webpack-cloudflare.config.mjs
@@ -6,7 +6,7 @@ export default {
   output: {
     filename: 'webpack-cloudflare.js',
   },
-  resolve: { conditionNames: ['import', 'cloudflare'] },
+  resolve: { conditionNames: ['import', 'workerd'] },
   plugins: [
     // ignore cloudflare:sockets imports
     new webpack.IgnorePlugin({

--- a/packages/pg-cloudflare/README.md
+++ b/packages/pg-cloudflare/README.md
@@ -19,7 +19,7 @@ config. For example:
   ```js
   export default {
     ...,
-    resolve: { conditionNames: [..., "cloudflare"] },
+    resolve: { conditionNames: [..., "workerd"] },
     plugins: [
       // ignore cloudflare:sockets imports
       new webpack.IgnorePlugin({
@@ -33,7 +33,7 @@ config. For example:
   export default defineConfig({
     ...,
     resolve: {
-      conditions: [..., "cloudflare"],
+      conditions: [..., "workerd"],
     },
     build: {
       ...,
@@ -48,7 +48,7 @@ config. For example:
   ```js
   export default defineConfig({
     ...,
-    plugins: [..., nodeResolve({ exportConditions: [..., 'cloudflare'] })],
+    plugins: [..., nodeResolve({ exportConditions: [..., 'workerd'] })],
     // don't try to bundle cloudflare:sockets
     external: [..., 'cloudflare:sockets'],
   })
@@ -57,7 +57,7 @@ config. For example:
   ```js
   await esbuild.build({
     ...,
-    conditions: [..., 'cloudflare'],
+    conditions: [..., 'workerd'],
   })
   ```
 

--- a/packages/pg-cloudflare/README.md
+++ b/packages/pg-cloudflare/README.md
@@ -29,6 +29,10 @@ config. For example:
   }
   ```
 - `vite.config.js`
+
+  > [!NOTE]
+  > If you are using the [Cloudflare Vite plugin](https://www.npmjs.com/package/@cloudflare/vite-plugin) then the following configuration is not necessary.
+
   ```js
   export default defineConfig({
     ...,
@@ -44,6 +48,7 @@ config. For example:
     },
   })
   ```
+
 - `rollup.config.js`
   ```js
   export default defineConfig({

--- a/packages/pg-cloudflare/package.json
+++ b/packages/pg-cloudflare/package.json
@@ -11,7 +11,7 @@
   },
   "exports": {
     ".": {
-      "cloudflare": {
+      "workerd": {
         "import": "./esm/index.mjs",
         "require": "./dist/index.js"
       },

--- a/packages/pg-esm-test/package.json
+++ b/packages/pg-esm-test/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "node --test --conditions=cloudflare"
+    "test": "node --test --conditions=workerd"
   },
   "keywords": [
     "postgres",


### PR DESCRIPTION
Fixes https://github.com/brianc/node-postgres/issues/3493
Fixes https://github.com/cloudflare/workers-sdk/issues/9668

This changes the export conditions for `pg-cloudflare` to use `workerd` instead of `cloudflare`. `workerd` is the standard export condition for Cloudflare Workers, as specified by WinterCG - https://runtime-keys.proposal.wintercg.org/#workerd. This will ensure compatibility with Wrangler and the Cloudflare Vite plugin.