### PR TITLE
Add package.json export to `pg-cloudflare`

### DIFF
--- a/packages/pg-cloudflare/package.json
+++ b/packages/pg-cloudflare/package.json
@@ -15,7 +15,7 @@
         "import": "./esm/index.mjs",
         "require": "./dist/index.js"
       },
-      "default": "./dist/empty.js",
+      "default": "./dist/empty.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/pg-cloudflare/package.json
+++ b/packages/pg-cloudflare/package.json
@@ -16,8 +16,8 @@
         "require": "./dist/index.js"
       },
       "default": "./dist/empty.js",
-      "package.json": "./package.json"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/pg-cloudflare/package.json
+++ b/packages/pg-cloudflare/package.json
@@ -15,7 +15,8 @@
         "import": "./esm/index.mjs",
         "require": "./dist/index.js"
       },
-      "default": "./dist/empty.js"
+      "default": "./dist/empty.js",
+      "package.json": "./package.json"
     }
   },
   "scripts": {


### PR DESCRIPTION
Similar to #3488 

I currently use the `require.resolve(${package}/package.json)` to resolve the location of packages, not having package.json exported breaks this kind of tools