### PR TITLE
Fix #3513 - throw the right error

### DIFF
--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -35,6 +35,7 @@ function parse(str, options = {}) {
   } catch (err) {
     // Remove the input from the error message to avoid leaking sensitive information
     err.input && (err.input = '*****REDACTED*****')
+    throw err
   }
 
   // We'd like to use Object.fromEntries() here but Node.js 10 does not support it

--- a/packages/pg-connection-string/test/parse.ts
+++ b/packages/pg-connection-string/test/parse.ts
@@ -330,6 +330,7 @@ describe('parse', function () {
       parse(connectionString)
     } catch (err: unknown) {
       expect(JSON.stringify(err)).to.not.include(password, 'Password should not be in the error message')
+      expect(JSON.stringify(err)).to.include('REDACTED', 'The thrown error should contain the redacted URL')
       return
     }
     throw new Error('Expected an error to be thrown')


### PR DESCRIPTION
Due to a recent change, the thrown error for invalid URLs was not the excepted error, but another error, which made the problem hard to understand.
This PR re-throws the original error (with redacted password).
The existing test was updated to make sure the right error is thrown.