### PR TITLE
Handle SASL SCRAM server error responses

### DIFF
--- a/packages/pg/lib/crypto/sasl.js
+++ b/packages/pg/lib/crypto/sasl.js
@@ -178,7 +178,13 @@ function parseServerFirstMessage(data) {
 
 function parseServerFinalMessage(serverData) {
   const attrPairs = parseAttributePairs(serverData)
+  const error = attrPairs.get('e')
   const serverSignature = attrPairs.get('v')
+
+  if (error) {
+    throw new Error(`SASL: SCRAM-SERVER-FINAL-MESSAGE: server returned error: "${error}"`)
+  }
+
   if (!serverSignature) {
     throw new Error('SASL: SCRAM-SERVER-FINAL-MESSAGE: server signature is missing')
   } else if (!isBase64(serverSignature)) {

--- a/packages/pg/test/unit/client/sasl-scram-tests.js
+++ b/packages/pg/test/unit/client/sasl-scram-tests.js
@@ -284,6 +284,23 @@ suite.test('sasl/scram', function () {
       )
     })
 
+    suite.test('fails when server returns an error', function () {
+      assert.throws(
+        function () {
+          sasl.finalizeSession(
+            {
+              message: 'SASLResponse',
+              serverSignature: 'abcd',
+            },
+            'e=no-resources'
+          )
+        },
+        {
+          message: 'SASL: SCRAM-SERVER-FINAL-MESSAGE: server returned error: "no-resources"',
+        }
+      )
+    })
+
     suite.test('fails when server signature does not match', function () {
       assert.throws(
         function () {


### PR DESCRIPTION
Add proper error handling for SCRAM-SERVER-FINAL-MESSAGE error attribute. The SCRAM specification allows servers to return error messages via the 'e' attribute in the server final message. Currently, these errors are ignored and authentication fails later during signature verification.

Postgres typically doesn't return this error (see [here](https://github.com/postgres/postgres/blob/2047ad068139f0b8c6da73d0b845ca9ba30fb33d/src/backend/libpq/auth-scram.c#L423) on why), but poolers, or other applications using the postgres protocol might, and it's part of the SCRAM spec, so it probably makes sense for node-postgres to handle it.

Aligns behaviour with psql, postgrex, and somewhat with pgJDBC (pgJDBC is stricter with scram errors).

For reference:

- libpq handling it: https://github.com/postgres/postgres/blob/2047ad068139f0b8c6da73d0b845ca9ba30fb33d/src/interfaces/libpq/fe-auth-scram.c#L708
