### PR TITLE
Update bugs and homepage links for pg-pool

### DIFF
--- a/packages/pg-pool/package.json
+++ b/packages/pg-pool/package.json
@@ -30,9 +30,9 @@
   "author": "Brian M. Carlson",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/brianc/node-pg-pool/issues"
+    "url": "https://github.com/brianc/node-postgres/issues"
   },
-  "homepage": "https://github.com/brianc/node-pg-pool#readme",
+  "homepage": "https://github.com/brianc/node-postgres/tree/master/packages/pg-pool#readme",
   "devDependencies": {
     "bluebird": "3.7.2",
     "co": "4.6.0",


### PR DESCRIPTION
This updates some of the links that show up on the NPM page for `pg-pool` since they were out-of-date.