### PR TITLE
test: Replace dead row length check with similar shape check

### DIFF
--- a/packages/pg/test/integration/client/simple-query-tests.js
+++ b/packages/pg/test/integration/client/simple-query-tests.js
@@ -19,15 +19,8 @@ test('simple query interface', function () {
     rows.push(row['name'])
   })
   query.once('row', function (row) {
-    test('Can iterate through columns', function () {
-      const columnCount = Object.keys(row).length
-      if ('length' in row) {
-        assert.lengthIs(
-          row,
-          columnCount,
-          'Iterating through the columns gives a different length from calling .length.'
-        )
-      }
+    test('returned right columns', function () {
+      assert.deepStrictEqual(row, { name: row.name })
     })
   })
 


### PR DESCRIPTION
These object-mode rows don’t include a `length`. Dead code since 721cf56eb331bd35243c1425095b98cf09adf814 (“Rows are now associative arrays rather than straight arrays.”)?