### PR TITLE
Add error handling for non-function callback

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -402,7 +402,7 @@ class Pool extends EventEmitter {
       return response.result
     }
 
-    // allow plain text query without values
+    // allow plain text query without values, but callback
     if (typeof values === 'function') {
       cb = values
       values = undefined

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -588,6 +588,10 @@ class Client extends EventEmitter {
           Error.captureStackTrace(err)
           throw err
         })
+      } else {
+        if(!(typeof values === 'function')){
+          throw new Error('callback is not a function')
+        }
       }
     }
 

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -589,7 +589,7 @@ class Client extends EventEmitter {
           throw err
         })
       } else {
-        if( !(typeof values === 'function') ){
+        if (!(typeof values === 'function')) {
           throw new Error('callback is not a function')
         }
       }

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -589,7 +589,7 @@ class Client extends EventEmitter {
           throw err
         })
       } else {
-        if(!(typeof values === 'function')){
+        if( !(typeof values === 'function') ){
           throw new Error('callback is not a function')
         }
       }

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -589,7 +589,7 @@ class Client extends EventEmitter {
           throw err
         })
       } else {
-        if (!(typeof values === 'function')) {
+        if (!(typeof query.callback === 'function')) {
           throw new Error('callback is not a function')
         }
       }

--- a/packages/pg/test/unit/client/simple-query-tests.js
+++ b/packages/pg/test/unit/client/simple-query-tests.js
@@ -140,5 +140,17 @@ test('executing query', function () {
         )
       }
     })
+
+    test('throws an error when callback is not a function', function () {
+      try {
+        client.query('SELECT $1', [1], 'notafunction')
+      } catch (error) {
+        assert.equal(
+          error.message,
+          'callback is not a function',
+          'Should have thrown an Error for non function callback'
+        )
+      }
+    })
   })
 })


### PR DESCRIPTION
catch callback not a function earlier to get a proper callstack. later when executing the callback the stack may be wrong/insufficient.