### PR TITLE
perf: no need to create a new array and new anonymous function

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -124,11 +124,9 @@ class Pool extends EventEmitter {
     }
     if (this.ending) {
       this.log('pulse queue on ending')
-      if (this._idle.length) {
-        for (let i = this._idle.length - 1; i >= 0; i--) {
-          const item = this._idle[i]
-          this._remove(item.client)
-        }
+      for (let i = this._idle.length - 1; i >= 0; i--) {
+        const item = this._idle[i]
+        this._remove(item.client)
       }
       if (!this._clients.length) {
         this.ended = true


### PR DESCRIPTION
`this._idle.slice().map( ... )` create a new array and new anonymous function every time