### PR TITLE
Remove testAsync - its redundant

### DIFF
--- a/packages/pg/test/integration/client/async-stack-trace-tests.js
+++ b/packages/pg/test/integration/client/async-stack-trace-tests.js
@@ -12,7 +12,7 @@ const suite = new helper.Suite()
 // these tests will only work for if --async-stack-traces is on, which is the default starting in node 16.
 const NODE_MAJOR_VERSION = +process.versions.node.split('.')[0]
 if (NODE_MAJOR_VERSION >= 16) {
-  suite.testAsync('promise API async stack trace in pool', async function outerFunction() {
+  suite.test('promise API async stack trace in pool', async function outerFunction() {
     async function innerFunction() {
       const pool = new pg.Pool()
       await pool.query('SELECT test from nonexistent')
@@ -28,7 +28,7 @@ if (NODE_MAJOR_VERSION >= 16) {
     }
   })
 
-  suite.testAsync('promise API async stack trace in client', async function outerFunction() {
+  suite.test('promise API async stack trace in client', async function outerFunction() {
     async function innerFunction() {
       const client = new pg.Client()
       await client.connect()

--- a/packages/pg/test/integration/client/error-handling-tests.js
+++ b/packages/pg/test/integration/client/error-handling-tests.js
@@ -47,7 +47,7 @@ suite.test('re-using connections results in error callback', (done) => {
   })
 })
 
-suite.testAsync('re-using connections results in promise rejection', () => {
+suite.test('re-using connections results in promise rejection', () => {
   const client = new Client()
   return client.connect().then(() => {
     return helper.rejection(client.connect()).then((err) => {

--- a/packages/pg/test/integration/client/prepared-statement-tests.js
+++ b/packages/pg/test/integration/client/prepared-statement-tests.js
@@ -174,7 +174,7 @@ const suite = new helper.Suite()
     checkForResults(query)
   })
 
-  suite.testAsync('with no data response and rows', async function () {
+  suite.test('with no data response and rows', async function () {
     const result = await client.query({
       name: 'some insert',
       text: '',

--- a/packages/pg/test/integration/client/sasl-scram-tests.js
+++ b/packages/pg/test/integration/client/sasl-scram-tests.js
@@ -37,15 +37,15 @@ const config = {
 }
 
 if (native) {
-  suite.testAsync('skipping SCRAM tests (on native)', () => {})
+  suite.test('skipping SCRAM tests (on native)', () => {})
   return
 }
 if (!config.user || !config.password) {
-  suite.testAsync('skipping SCRAM tests (missing env)', () => {})
+  suite.test('skipping SCRAM tests (missing env)', () => {})
   return
 }
 
-suite.testAsync('can connect using sasl/scram with channel binding enabled (if using SSL)', async () => {
+suite.test('can connect using sasl/scram with channel binding enabled (if using SSL)', async () => {
   const client = new pg.Client({ ...config, enableChannelBinding: true })
   let usingChannelBinding = false
   let hasPeerCert = false
@@ -58,7 +58,7 @@ suite.testAsync('can connect using sasl/scram with channel binding enabled (if u
   await client.end()
 })
 
-suite.testAsync('can connect using sasl/scram with channel binding disabled', async () => {
+suite.test('can connect using sasl/scram with channel binding disabled', async () => {
   const client = new pg.Client({ ...config, enableChannelBinding: false })
   let usingSASLWithoutChannelBinding = false
   client.connection.once('authenticationSASLContinue', () => {
@@ -69,7 +69,7 @@ suite.testAsync('can connect using sasl/scram with channel binding disabled', as
   await client.end()
 })
 
-suite.testAsync('sasl/scram fails when password is wrong', async () => {
+suite.test('sasl/scram fails when password is wrong', async () => {
   const client = new pg.Client({
     ...config,
     password: config.password + 'append-something-to-make-it-bad',
@@ -88,7 +88,7 @@ suite.testAsync('sasl/scram fails when password is wrong', async () => {
   assert.ok(usingSasl, 'Should be using SASL for authentication')
 })
 
-suite.testAsync('sasl/scram fails when password is empty', async () => {
+suite.test('sasl/scram fails when password is empty', async () => {
   const client = new pg.Client({
     ...config,
     // We use a password function here so the connection defaults do not

--- a/packages/pg/test/integration/client/timezone-tests.js
+++ b/packages/pg/test/integration/client/timezone-tests.js
@@ -21,7 +21,7 @@ pool.connect(function (err, client, done) {
     })
   })
 
-  suite.testAsync('date comes out as a date', async function () {
+  suite.test('date comes out as a date', async function () {
     const { rows } = await client.query('SELECT NOW()::DATE AS date')
     assert(rows[0].date instanceof Date)
   })

--- a/packages/pg/test/integration/connection-pool/connection-pool-size-tests.js
+++ b/packages/pg/test/integration/connection-pool/connection-pool-size-tests.js
@@ -5,7 +5,7 @@ const assert = require('assert')
 const suite = new helper.Suite()
 
 const testPoolSize = function (max) {
-  suite.testAsync(`test ${max} queries executed on a pool rapidly`, async () => {
+  suite.test(`test ${max} queries executed on a pool rapidly`, async () => {
     const pool = new helper.pg.Pool({ max: 10 })
 
     let count = 0

--- a/packages/pg/test/integration/connection-pool/tls-tests.js
+++ b/packages/pg/test/integration/connection-pool/tls-tests.js
@@ -8,7 +8,7 @@ const pg = helper.pg
 const suite = new helper.Suite()
 
 if (process.env.PG_CLIENT_CERT_TEST) {
-  suite.testAsync('client certificate', async () => {
+  suite.test('client certificate', async () => {
     const pool = new pg.Pool({
       ssl: {
         ca: fs.readFileSync(process.env.PGSSLROOTCERT),

--- a/packages/pg/test/integration/gh-issues/1105-tests.js
+++ b/packages/pg/test/integration/gh-issues/1105-tests.js
@@ -1,7 +1,7 @@
 const helper = require('../test-helper')
 const suite = new helper.Suite()
 
-suite.testAsync('timeout causing query crashes', async () => {
+suite.test('timeout causing query crashes', async () => {
   const client = new helper.Client()
   await client.connect()
   await client.query('CREATE TEMP TABLE foobar( name TEXT NOT NULL, id SERIAL)')

--- a/packages/pg/test/integration/gh-issues/1542-tests.js
+++ b/packages/pg/test/integration/gh-issues/1542-tests.js
@@ -4,7 +4,7 @@ const assert = require('assert')
 
 const suite = new helper.Suite()
 
-suite.testAsync('BoundPool can be subclassed', async () => {
+suite.test('BoundPool can be subclassed', async () => {
   const Pool = helper.pg.Pool
   class SubPool extends Pool {}
   const subPool = new SubPool()

--- a/packages/pg/test/integration/gh-issues/2085-tests.js
+++ b/packages/pg/test/integration/gh-issues/2085-tests.js
@@ -10,7 +10,7 @@ if (process.env.PGTESTNOSSL) {
   return
 }
 
-suite.testAsync('it should connect over ssl', async () => {
+suite.test('it should connect over ssl', async () => {
   const ssl = helper.args.native
     ? 'require'
     : {
@@ -23,7 +23,7 @@ suite.testAsync('it should connect over ssl', async () => {
   await client.end()
 })
 
-suite.testAsync('it should fail with self-signed cert error w/o rejectUnauthorized being passed', async () => {
+suite.test('it should fail with self-signed cert error w/o rejectUnauthorized being passed', async () => {
   const ssl = helper.args.native ? 'verify-ca' : {}
   const client = new helper.pg.Client({ ssl })
   try {

--- a/packages/pg/test/integration/gh-issues/2108-tests.js
+++ b/packages/pg/test/integration/gh-issues/2108-tests.js
@@ -7,7 +7,7 @@ suite.test('Closing an unconnected client calls callback', (done) => {
   client.end(done)
 })
 
-suite.testAsync('Closing an unconnected client resolves promise', () => {
+suite.test('Closing an unconnected client resolves promise', () => {
   const client = new helper.pg.Client()
   return client.end()
 })

--- a/packages/pg/test/integration/gh-issues/2416-tests.js
+++ b/packages/pg/test/integration/gh-issues/2416-tests.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 
 const suite = new helper.Suite()
 
-suite.testAsync('it sets search_path on connection', async () => {
+suite.test('it sets search_path on connection', async () => {
   const client = new helper.pg.Client({
     options: '--search_path=foo',
   })

--- a/packages/pg/test/integration/gh-issues/2716-tests.js
+++ b/packages/pg/test/integration/gh-issues/2716-tests.js
@@ -4,7 +4,7 @@ const helper = require('../test-helper')
 const suite = new helper.Suite()
 
 // https://github.com/brianc/node-postgres/issues/2716
-suite.testAsync('client.end() should resolve if already ended', async () => {
+suite.test('client.end() should resolve if already ended', async () => {
   const client = new helper.pg.Client()
   await client.connect()
 

--- a/packages/pg/test/integration/gh-issues/2862-tests.js
+++ b/packages/pg/test/integration/gh-issues/2862-tests.js
@@ -6,7 +6,7 @@ const vm = require('vm')
 
 const suite = new helper.Suite()
 
-suite.testAsync('Handle date objects as Date', async () => {
+suite.test('Handle date objects as Date', async () => {
   const crossRealmDate = await vm.runInNewContext('new Date()')
   assert(!(crossRealmDate instanceof Date))
   const date = new Date(crossRealmDate.getTime())

--- a/packages/pg/test/integration/gh-issues/3062-tests.js
+++ b/packages/pg/test/integration/gh-issues/3062-tests.js
@@ -4,7 +4,7 @@ const assert = require('assert')
 const suite = new helper.Suite()
 
 // https://github.com/brianc/node-postgres/issues/3062
-suite.testAsync('result fields with the same name should pick the last value', async () => {
+suite.test('result fields with the same name should pick the last value', async () => {
   const client = new helper.pg.Client()
   await client.connect()
 

--- a/packages/pg/test/integration/gh-issues/3174-tests.js
+++ b/packages/pg/test/integration/gh-issues/3174-tests.js
@@ -85,7 +85,7 @@ const delay = (ms) =>
   })
 
 const testErrorBuffer = (bufferName, errorBuffer) => {
-  suite.testAsync(`Out of order ${bufferName} on simple query is catchable`, async () => {
+  suite.test(`Out of order ${bufferName} on simple query is catchable`, async () => {
     const closeServer = await new Promise((resolve, reject) => {
       return startMockServer(options.port, errorBuffer, (closeServer) => resolve(closeServer))
     })
@@ -110,7 +110,7 @@ const testErrorBuffer = (bufferName, errorBuffer) => {
     await closeServer()
   })
 
-  suite.testAsync(`Out of order ${bufferName} on extended query is catchable`, async () => {
+  suite.test(`Out of order ${bufferName} on extended query is catchable`, async () => {
     const closeServer = await new Promise((resolve, reject) => {
       return startMockServer(options.port, errorBuffer, (closeServer) => resolve(closeServer))
     })
@@ -137,7 +137,7 @@ const testErrorBuffer = (bufferName, errorBuffer) => {
     await closeServer()
   })
 
-  suite.testAsync(`Out of order ${bufferName} on pool is catchable`, async () => {
+  suite.test(`Out of order ${bufferName} on pool is catchable`, async () => {
     const closeServer = await new Promise((resolve, reject) => {
       return startMockServer(options.port, errorBuffer, (closeServer) => resolve(closeServer))
     })

--- a/packages/pg/test/integration/gh-issues/3487-tests.js
+++ b/packages/pg/test/integration/gh-issues/3487-tests.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 
 const suite = new helper.Suite()
 
-suite.testAsync('allows you to switch between format modes for arrays', async () => {
+suite.test('allows you to switch between format modes for arrays', async () => {
   const client = new helper.pg.Client()
   await client.connect()
 

--- a/packages/pg/test/suite.js
+++ b/packages/pg/test/suite.js
@@ -1,6 +1,11 @@
 'use strict'
 
 const async = require('async')
+const { deprecate } = require('util')
+
+const deprecatedTestAsync = deprecate(function (name, cb) {
+  this.test(name, cb)
+}, 'Suite#testAsync is deprecated. Use Suite#test instead - it handles promises & async functions just fine.')
 
 class Test {
   constructor(name, cb) {
@@ -29,7 +34,7 @@ class Test {
       }
       result.then(() => cb()).catch((err) => cb(err || new Error('Unhandled promise rejection')))
     } else {
-      this.action.call(this, cb)
+      this.action(cb)
     }
   }
 }
@@ -71,18 +76,8 @@ class Suite {
     this._queue.push(test)
   }
 
-  /**
-   * Run an async test that can return a Promise. If the Promise resolves
-   * successfully then the test will pass. If the Promise rejects with an
-   * error then the test will be considered failed.
-   */
-  testAsync(name, action) {
-    const test = new Test(name, (cb) => {
-      Promise.resolve()
-        .then(action)
-        .then(() => cb(null), cb)
-    })
-    this._queue.push(test)
+  testAsync(name, cb) {
+    return deprecatedTestAsync.call(this, name, cb)
   }
 }
 

--- a/packages/pg/test/unit/client/sasl-scram-tests.js
+++ b/packages/pg/test/unit/client/sasl-scram-tests.js
@@ -58,7 +58,7 @@ suite.test('sasl/scram', function () {
   })
 
   suite.test('continueSession', function () {
-    suite.testAsync('fails when last session message was not SASLInitialResponse', async function () {
+    suite.test('fails when last session message was not SASLInitialResponse', async function () {
       assert.rejects(
         function () {
           return sasl.continueSession({}, '', '')
@@ -69,7 +69,7 @@ suite.test('sasl/scram', function () {
       )
     })
 
-    suite.testAsync('fails when nonce is missing in server message', function () {
+    suite.test('fails when nonce is missing in server message', function () {
       assert.rejects(
         function () {
           return sasl.continueSession(
@@ -86,7 +86,7 @@ suite.test('sasl/scram', function () {
       )
     })
 
-    suite.testAsync('fails when salt is missing in server message', function () {
+    suite.test('fails when salt is missing in server message', function () {
       assert.rejects(
         function () {
           return sasl.continueSession(
@@ -103,7 +103,7 @@ suite.test('sasl/scram', function () {
       )
     })
 
-    suite.testAsync('fails when client password is not a string', function () {
+    suite.test('fails when client password is not a string', function () {
       for (const badPasswordValue of [null, undefined, 123, new Date(), {}]) {
         assert.rejects(
           function () {
@@ -123,7 +123,7 @@ suite.test('sasl/scram', function () {
       }
     })
 
-    suite.testAsync('fails when client password is an empty string', function () {
+    suite.test('fails when client password is an empty string', function () {
       assert.rejects(
         function () {
           return sasl.continueSession(
@@ -141,7 +141,7 @@ suite.test('sasl/scram', function () {
       )
     })
 
-    suite.testAsync('fails when iteration is missing in server message', function () {
+    suite.test('fails when iteration is missing in server message', function () {
       assert.rejects(
         function () {
           return sasl.continueSession(
@@ -158,7 +158,7 @@ suite.test('sasl/scram', function () {
       )
     })
 
-    suite.testAsync('fails when server nonce does not start with client nonce', function () {
+    suite.test('fails when server nonce does not start with client nonce', function () {
       assert.rejects(
         function () {
           return sasl.continueSession(
@@ -176,7 +176,7 @@ suite.test('sasl/scram', function () {
       )
     })
 
-    suite.testAsync('sets expected session data (SCRAM-SHA-256)', async function () {
+    suite.test('sets expected session data (SCRAM-SHA-256)', async function () {
       const session = {
         message: 'SASLInitialResponse',
         clientNonce: 'a',
@@ -190,7 +190,7 @@ suite.test('sasl/scram', function () {
       assert.equal(session.response, 'c=biws,r=ab,p=mU8grLfTjDrJer9ITsdHk0igMRDejG10EJPFbIBL3D0=')
     })
 
-    suite.testAsync('sets expected session data (SCRAM-SHA-256, channel binding enabled)', async function () {
+    suite.test('sets expected session data (SCRAM-SHA-256, channel binding enabled)', async function () {
       const session = {
         message: 'SASLInitialResponse',
         clientNonce: 'a',
@@ -204,7 +204,7 @@ suite.test('sasl/scram', function () {
       assert.equal(session.response, 'c=eSws,r=ab,p=YVTEOwOD7khu/NulscjFegHrZoTXJBFI/7L61AN9khc=')
     })
 
-    suite.testAsync('sets expected session data (SCRAM-SHA-256-PLUS)', async function () {
+    suite.test('sets expected session data (SCRAM-SHA-256-PLUS)', async function () {
       const session = {
         message: 'SASLInitialResponse',
         mechanism: 'SCRAM-SHA-256-PLUS',

--- a/packages/pg/test/unit/connection-parameters/creation-tests.js
+++ b/packages/pg/test/unit/connection-parameters/creation-tests.js
@@ -163,7 +163,7 @@ const getDNSHost = async function (host) {
   })
 }
 
-suite.testAsync('builds simple string', async function () {
+suite.test('builds simple string', async function () {
   const config = {
     user: 'brian',
     password: 'xyz',


### PR DESCRIPTION
`testAsync` and `test` do the same thing, so just removing `testAsync`. Didn't actually delete the function to not break old pull requests, but will delete it soonish. I just want to do some test cleanup before i start working on a pg@9.0 plan.