### PR TITLE
feat(pg-native): pipeline mode

### DIFF
--- a/docs/pages/guides/_meta.js
+++ b/docs/pages/guides/_meta.js
@@ -3,4 +3,5 @@ export default {
   'async-express': 'Express with Async/Await',
   'pool-sizing': 'Pool Sizing',
   upgrading: 'Upgrading',
+  pgpass: 'Using .pgpass',
 }

--- a/docs/pages/guides/pgpass.md
+++ b/docs/pages/guides/pgpass.md
@@ -1,0 +1,39 @@
+---
+title: Using .pgpass
+---
+
+PostgreSQL supports a [.pgpass](https://www.postgresql.org/docs/current/libpq-pgpass.html) file for storing passwords. The file is located at `~/.pgpass` on Unix systems and `%APPDATA%\postgresql\pgpass.conf` on Windows. Each line in the file has the format:
+
+```
+hostname:port:database:username:password
+```
+
+You can use the [pgpass](https://www.npmjs.com/package/pgpass) module together with the `password` callback to look up passwords from your `.pgpass` file:
+
+```js
+import pg from 'pg'
+import pgpass from 'pgpass'
+
+const { Pool } = pg
+
+const pool = new Pool({
+  user: 'my-user',
+  host: 'localhost',
+  database: 'my-db',
+  password: (config) => {
+    return new Promise((resolve, reject) => {
+      const connection = {
+        host: config.host,
+        port: config.port,
+        database: config.database,
+        user: config.user,
+      }
+      pgpass(connection, (password) => {
+        resolve(password)
+      })
+    })
+  },
+})
+```
+
+The `password` option accepts an async function (or a function that returns a `Promise`). It is called with the connection parameters, so you can pass them directly to `pgpass` for lookup.

--- a/packages/pg-native/bench/index.js
+++ b/packages/pg-native/bench/index.js
@@ -1,52 +1,164 @@
 const pg = require('pg').native
 const Native = require('../')
 
-const warmup = function (fn, cb) {
-  let count = 0
-  const max = 10
-  const run = function (err) {
-    if (err) return cb(err)
+const queryText = 'SELECT generate_series(0, 1000) as X, generate_series(0, 1000) as Y, generate_series(0, 1000) as Z'
+const simpleQuery = 'SELECT 1'
 
-    if (max >= count++) {
-      return fn(run)
-    }
-
-    cb()
-  }
-  run()
+const promisify = (client, text) => {
+  return new Promise((resolve, reject) => {
+    client.query(text, (err, result) => {
+      if (err) reject(err)
+      else resolve(result)
+    })
+  })
 }
 
-const native = Native()
-native.connectSync()
-
-const queryText = 'SELECT generate_series(0, 1000) as X, generate_series(0, 1000) as Y, generate_series(0, 1000) as Z'
-const client = new pg.Client()
-client.connect(function () {
-  const pure = function (cb) {
-    client.query(queryText, function (err) {
-      if (err) throw err
-      cb(err)
-    })
+const bench = async (name, fn, durationMs) => {
+  const start = performance.now()
+  let count = 0
+  while (performance.now() - start < durationMs) {
+    await fn()
+    count++
   }
-  const nativeQuery = function (cb) {
-    native.query(queryText, function (err) {
-      if (err) throw err
-      cb(err)
-    })
+  const elapsed = performance.now() - start
+  const qps = Math.round((count / elapsed) * 1000)
+  return { name, count, elapsed, qps }
+}
+
+const run = async () => {
+  // Setup clients
+  const pureClient = new pg.Client()
+  await new Promise((resolve, reject) => {
+    pureClient.connect((err) => (err ? reject(err) : resolve()))
+  })
+
+  const native = Native()
+  native.connectSync()
+
+  const nativePipeline = Native({ pipelineMode: true })
+  nativePipeline.connectSync()
+  const pipelineSupported = nativePipeline._pipelineEnabled
+
+  console.log('='.repeat(60))
+  console.log('pg-native Benchmark')
+  console.log('='.repeat(60))
+  console.log(`Pipeline mode supported: ${pipelineSupported}`)
+  console.log('')
+
+  const results = {
+    simple: {},
+    complex: {},
   }
 
-  const run = function () {
-    console.time('pure')
-    warmup(pure, function () {
-      console.timeEnd('pure')
-      console.time('native')
-      warmup(nativeQuery, function () {
-        console.timeEnd('native')
-      })
-    })
+  const warmupMs = 1000
+  const benchMs = 5000
+  const iterations = 3
+
+  // Warmup
+  console.log('Warming up...')
+  await bench('warmup', () => promisify(pureClient, simpleQuery), warmupMs)
+  await bench('warmup', () => promisify(native, simpleQuery), warmupMs)
+  if (pipelineSupported) {
+    await bench('warmup', () => promisify(nativePipeline, simpleQuery), warmupMs)
+  }
+  console.log('Warmup complete.\n')
+
+  // Run benchmarks
+  for (let i = 0; i < iterations; i++) {
+    console.log(`--- Iteration ${i + 1}/${iterations} ---`)
+
+    // Simple query benchmarks
+    console.log('\nSimple query (SELECT 1):')
+
+    let result = await bench('pg.native', () => promisify(pureClient, simpleQuery), benchMs)
+    console.log(`  pg.native:         ${result.qps} qps (${result.count} queries in ${Math.round(result.elapsed)}ms)`)
+    results.simple['pg.native'] = results.simple['pg.native'] || []
+    results.simple['pg.native'].push(result.qps)
+
+    result = await bench('Native', () => promisify(native, simpleQuery), benchMs)
+    console.log(`  Native:            ${result.qps} qps (${result.count} queries in ${Math.round(result.elapsed)}ms)`)
+    results.simple['Native'] = results.simple['Native'] || []
+    results.simple['Native'].push(result.qps)
+
+    if (pipelineSupported) {
+      result = await bench('Native+Pipeline', () => promisify(nativePipeline, simpleQuery), benchMs)
+      console.log(`  Native+Pipeline:   ${result.qps} qps (${result.count} queries in ${Math.round(result.elapsed)}ms)`)
+      results.simple['Native+Pipeline'] = results.simple['Native+Pipeline'] || []
+      results.simple['Native+Pipeline'].push(result.qps)
+    }
+
+    // Complex query benchmarks
+    console.log('\nComplex query (generate_series):')
+
+    result = await bench('pg.native', () => promisify(pureClient, queryText), benchMs)
+    console.log(`  pg.native:         ${result.qps} qps (${result.count} queries in ${Math.round(result.elapsed)}ms)`)
+    results.complex['pg.native'] = results.complex['pg.native'] || []
+    results.complex['pg.native'].push(result.qps)
+
+    result = await bench('Native', () => promisify(native, queryText), benchMs)
+    console.log(`  Native:            ${result.qps} qps (${result.count} queries in ${Math.round(result.elapsed)}ms)`)
+    results.complex['Native'] = results.complex['Native'] || []
+    results.complex['Native'].push(result.qps)
+
+    if (pipelineSupported) {
+      result = await bench('Native+Pipeline', () => promisify(nativePipeline, queryText), benchMs)
+      console.log(`  Native+Pipeline:   ${result.qps} qps (${result.count} queries in ${Math.round(result.elapsed)}ms)`)
+      results.complex['Native+Pipeline'] = results.complex['Native+Pipeline'] || []
+      results.complex['Native+Pipeline'].push(result.qps)
+    }
+
+    console.log('')
   }
 
-  setInterval(function () {
-    run()
-  }, 500)
+  // Summary
+  console.log('='.repeat(60))
+  console.log('SUMMARY (average QPS over', iterations, 'iterations)')
+  console.log('='.repeat(60))
+
+  const avg = (arr) => Math.round(arr.reduce((a, b) => a + b, 0) / arr.length)
+
+  console.log('\nSimple query (SELECT 1):')
+  for (const [name, qps] of Object.entries(results.simple)) {
+    const avgQps = avg(qps)
+    const improvement =
+      name !== 'pg.native'
+        ? ` (${((avgQps / avg(results.simple['pg.native']) - 1) * 100).toFixed(1)}% vs pg.native)`
+        : ''
+    console.log(`  ${name.padEnd(18)} ${avgQps} qps${improvement}`)
+  }
+
+  console.log('\nComplex query (generate_series):')
+  for (const [name, qps] of Object.entries(results.complex)) {
+    const avgQps = avg(qps)
+    const improvement =
+      name !== 'pg.native'
+        ? ` (${((avgQps / avg(results.complex['pg.native']) - 1) * 100).toFixed(1)}% vs pg.native)`
+        : ''
+    console.log(`  ${name.padEnd(18)} ${avgQps} qps${improvement}`)
+  }
+
+  if (pipelineSupported) {
+    const pipelineVsNativeSimple = (
+      (avg(results.simple['Native+Pipeline']) / avg(results.simple['Native']) - 1) *
+      100
+    ).toFixed(1)
+    const pipelineVsNativeComplex = (
+      (avg(results.complex['Native+Pipeline']) / avg(results.complex['Native']) - 1) *
+      100
+    ).toFixed(1)
+    console.log('\nPipeline mode impact:')
+    console.log(`  Simple query:  ${pipelineVsNativeSimple}% vs Native without pipeline`)
+    console.log(`  Complex query: ${pipelineVsNativeComplex}% vs Native without pipeline`)
+  }
+
+  console.log('\n' + '='.repeat(60))
+
+  // Cleanup
+  await new Promise((resolve) => pureClient.end(resolve))
+  process.exit(0)
+}
+
+run().catch((e) => {
+  console.error(e)
+  process.exit(1)
 })

--- a/packages/pg-native/index.js
+++ b/packages/pg-native/index.js
@@ -390,6 +390,11 @@ Client.prototype._exitPipelineMode = function () {
   }
   const result = this.pq.exitPipelineMode()
   if (result) {
+    // Notify all pending callbacks with an error before clearing
+    const err = new Error('Pipeline mode exited with pending queries')
+    this._pipelineCallbacks.forEach((p) => p.cb && p.cb(err))
+    this._pipelineQueue.forEach((q) => q.cb && q.cb(err))
+
     this._pipelineEnabled = false
     this._pipelineQueue = []
     this._pipelinePendingCount = 0

--- a/packages/pg-native/index.js
+++ b/packages/pg-native/index.js
@@ -533,8 +533,13 @@ Client.prototype._readPipeline = function () {
     this._pipelineCallbacks.forEach((pending) => {
       if (pending.cb) pending.cb(err)
     })
+    // Also notify queued queries
+    this._pipelineQueue.forEach((queued) => {
+      if (queued.cb) queued.cb(err)
+    })
     this._pipelineCallbacks = []
     this._pipelinePendingCount = 0
+    this._pipelineQueue = []
     return
   }
 

--- a/packages/pg-native/index.js
+++ b/packages/pg-native/index.js
@@ -17,6 +17,7 @@ const Client = (module.exports = function (config) {
   this.pq = new Libpq()
   this._reading = false
   this._read = this._read.bind(this)
+  this._readPipeline = this._readPipeline.bind(this)
 
   // allow custom type conversion to be passed in
   this._types = config.types || types
@@ -27,6 +28,14 @@ const Client = (module.exports = function (config) {
   this._resultCount = 0
   this._rows = undefined
   this._results = undefined
+
+  // Pipeline mode configuration
+  this._pipelineMode = config.pipelineMode || false
+  this._pipelineMaxQueries = config.pipelineMaxQueries || 1000
+  this._pipelineEnabled = false
+  this._pipelineQueue = [] // Queue of pending queries with callbacks
+  this._pipelinePendingCount = 0 // Count of sent but not yet resolved queries
+  this._pipelineCallbacks = [] // Callbacks for sent queries awaiting results
 
   // lazy start the reader if notifications are listened for
   // this way if you only run sync queries you wont block
@@ -43,20 +52,46 @@ const Client = (module.exports = function (config) {
 util.inherits(Client, EventEmitter)
 
 Client.prototype.connect = function (params, cb) {
-  this.pq.connect(params, cb)
+  if (typeof params === 'function') {
+    cb = params
+    params = undefined
+  }
+
+  const self = this
+  this.pq.connect(params, function (err) {
+    if (err) return cb(err)
+
+    // enter pipeline mode if enabled and supported
+    if (self._pipelineMode && self._pipelineModeSupported()) {
+      self._enterPipelineMode()
+      self._startPipelineReading()
+    }
+
+    cb()
+  })
 }
 
 Client.prototype.connectSync = function (params) {
   this.pq.connectSync(params)
+
+  // enter pipeline mode if enabled and supported
+  if (this._pipelineMode && this._pipelineModeSupported()) {
+    this._enterPipelineMode()
+    this._startPipelineReading()
+  }
 }
 
 Client.prototype.query = function (text, values, cb) {
-  let queryFn
-
   if (typeof values === 'function') {
     cb = values
+    values = undefined
   }
 
+  if (this._pipelineMode) {
+    return this._pipelineQuery(text, values, cb)
+  }
+
+  let queryFn
   if (Array.isArray(values)) {
     queryFn = () => {
       return this.pq.sendQueryParams(text, values)
@@ -327,5 +362,289 @@ Client.prototype._onReadyForQuery = function () {
 
   if (cb) {
     cb(err, rows || [], results)
+  }
+}
+
+// Check if pipeline mode is supported
+Client.prototype._pipelineModeSupported = function () {
+  return this.pq.pipelineModeSupported()
+}
+
+// Enter pipeline mode - allows sending multiple queries without waiting for results
+Client.prototype._enterPipelineMode = function () {
+  if (!this._pipelineModeSupported()) {
+    throw new Error('Pipeline mode is not supported. Requires PostgreSQL 14+')
+  }
+  const result = this.pq.enterPipelineMode()
+  if (result) {
+    this._pipelineEnabled = true
+    this.pq.setNonBlocking(true)
+  }
+  return result
+}
+
+// Exit pipeline mode
+Client.prototype._exitPipelineMode = function () {
+  if (!this._pipelineEnabled) {
+    return true
+  }
+  const result = this.pq.exitPipelineMode()
+  if (result) {
+    this._pipelineEnabled = false
+    this._pipelineQueue = []
+    this._pipelinePendingCount = 0
+    this._pipelineCallbacks = []
+  }
+  return result
+}
+
+// Get current pipeline status (0=off, 1=on, 2=aborted)
+Client.prototype._pipelineStatus = function () {
+  return this.pq.pipelineStatus()
+}
+
+// Send a sync point in the pipeline to trigger result delivery
+Client.prototype._pipelineSync = function () {
+  return this.pq.pipelineSync()
+}
+
+// Execute a query in pipeline mode
+// Called by query() when pipelineMode is enabled
+Client.prototype._pipelineQuery = function (text, values, cb) {
+  // if pipeline mode is not enabled but was configured, auto-enter
+  if (this._pipelineMode && !this._pipelineEnabled) {
+    this._enterPipelineMode()
+    this._startPipelineReading()
+  }
+
+  if (!this._pipelineEnabled) {
+    const err = new Error('Pipeline mode is not enabled. Set pipelineMode: true in config.')
+    if (cb) return setImmediate(() => cb(err))
+    return Promise.reject(err)
+  }
+
+  // Check if we need to apply backpressure
+  if (this._pipelinePendingCount >= this._pipelineMaxQueries) {
+    // Queue the query for later execution
+    const queued = { text, values, cb }
+    this._pipelineQueue.push(queued)
+
+    if (!cb) {
+      return new Promise((resolve, reject) => {
+        queued.cb = (err, rows, result) => {
+          if (err) reject(err)
+          else resolve(rows)
+        }
+      })
+    }
+    return
+  }
+
+  // Send the query - always use sendQueryParams in pipeline mode
+  // (sendQuery is not allowed in pipeline mode)
+  const params = Array.isArray(values) ? values : []
+  const sent = this.pq.sendQueryParams(text, params)
+
+  if (!sent) {
+    const err = new Error(this.pq.errorMessage() || 'Failed to send query in pipeline mode')
+    if (cb) return setImmediate(() => cb(err))
+    return Promise.reject(err)
+  }
+
+  this._pipelinePendingCount++
+
+  // Send sync to mark this query and trigger result delivery
+  this._pipelineSync()
+
+  // Flush to ensure the query and sync are sent
+  this.pq.flush()
+
+  if (cb) {
+    this._pipelineCallbacks.push({ cb, resultCount: 0, rows: undefined, results: undefined, error: undefined })
+    return
+  }
+
+  return new Promise((resolve, reject) => {
+    this._pipelineCallbacks.push({
+      cb: (err, rows, result) => {
+        if (err) reject(err)
+        else resolve(rows)
+      },
+      resultCount: 0,
+      rows: undefined,
+      results: undefined,
+      error: undefined,
+    })
+  })
+}
+
+// Flush and wait for all pending pipeline queries to complete
+Client.prototype._pipelineFlush = function (cb) {
+  if (!this._pipelineEnabled) {
+    if (cb) return setImmediate(cb)
+    return Promise.resolve()
+  }
+
+  // Send sync to mark end of current batch
+  this._pipelineSync()
+  this.pq.flush()
+
+  // Add a sync callback marker
+  if (cb) {
+    this._pipelineCallbacks.push({ cb, isSync: true })
+    return
+  }
+
+  return new Promise((resolve, reject) => {
+    this._pipelineCallbacks.push({
+      cb: (err) => {
+        if (err) reject(err)
+        else resolve()
+      },
+      isSync: true,
+    })
+  })
+}
+
+// Start reading for pipeline mode
+Client.prototype._startPipelineReading = function () {
+  if (this._reading) return
+  this._reading = true
+  this.pq.on('readable', this._readPipeline)
+  this.pq.startReader()
+}
+
+// Stop reading for pipeline mode
+Client.prototype._stopPipelineReading = function () {
+  if (!this._reading) return
+  this._reading = false
+  this.pq.stopReader()
+  this.pq.removeListener('readable', this._readPipeline)
+}
+
+// Read handler specificaly for pipeline mode
+Client.prototype._readPipeline = function () {
+  const pq = this.pq
+
+  // Read waiting data from the socket
+  if (!pq.consumeInput()) {
+    // Read error and notify all pending callbacks
+    const err = new Error(pq.errorMessage())
+    this._pipelineCallbacks.forEach((pending) => {
+      if (pending.cb) pending.cb(err)
+    })
+    this._pipelineCallbacks = []
+    this._pipelinePendingCount = 0
+    return
+  }
+
+  // Process all available results
+  // In pipeline mode, getResult() returns false for NULL markers between results
+  // We should only break when isBusy() becomes true
+  let loopCount = 0
+  const maxLoops = 1000 // Safety limit
+  while (!pq.isBusy() && loopCount < maxLoops) {
+    loopCount++
+    const hasResult = pq.getResult()
+    if (!hasResult) {
+      // NULL result - this is normal between query results and sync markers
+      // Check if there are more pending callbacks, if so try again
+      if (this._pipelineCallbacks.length === 0) {
+        break
+      }
+      // Try one more time in case there's another result
+      continue
+    }
+
+    const status = pq.resultStatus()
+
+    // Handle pipeline sync point
+    if (status === 'PGRES_PIPELINE_SYNC') {
+      // Find and call the sync callback
+      const idx = this._pipelineCallbacks.findIndex((p) => p.isSync)
+      if (idx !== -1) {
+        const syncCb = this._pipelineCallbacks.splice(idx, 1)[0]
+        if (syncCb.cb) syncCb.cb()
+      }
+      continue
+    }
+
+    // Get the next pending callbacks
+    if (this._pipelineCallbacks.length === 0) {
+      continue
+    }
+
+    const pending = this._pipelineCallbacks[0]
+    if (pending.isSync) {
+      continue
+    }
+
+    if (status === 'PGRES_FATAL_ERROR') {
+      pending.error = new Error(pq.resultErrorMessage())
+    } else if (status === 'PGRES_TUPLES_OK' || status === 'PGRES_COMMAND_OK' || status === 'PGRES_EMPTY_QUERY') {
+      const result = this._consumeQueryResults(pq)
+      if (pending.resultCount === 0) {
+        pending.rows = result.rows
+        pending.results = result
+      } else if (pending.resultCount === 1) {
+        pending.rows = [pending.rows, result.rows]
+        pending.results = [pending.results, result]
+      } else {
+        pending.rows.push(result.rows)
+        pending.results.push(result)
+      }
+      pending.resultCount++
+    }
+
+    // Check if we need to get more results for this query (null result marks end)
+    // For pipeline mode, each query gets exactly one result set typically
+    // We complete the callback and move to the next one
+    this._pipelineCallbacks.shift()
+    this._pipelinePendingCount--
+
+    if (pending.cb) {
+      pending.cb(pending.error, pending.rows || [], pending.results)
+    }
+
+    // Process queued queries now that we have room
+    this._processQueuedPipelineQueries()
+  }
+
+  // Check for notifications
+  let notice = pq.notifies()
+  while (notice) {
+    this.emit('notification', notice)
+    notice = pq.notifies()
+  }
+}
+
+// Process queued pipeline queries when there's room
+Client.prototype._processQueuedPipelineQueries = function () {
+  while (this._pipelineQueue.length > 0 && this._pipelinePendingCount < this._pipelineMaxQueries) {
+    const queued = this._pipelineQueue.shift()
+
+    // Always use sendQueryParams in pipeline mode
+    const params = Array.isArray(queued.values) ? queued.values : []
+    const sent = this.pq.sendQueryParams(queued.text, params)
+
+    if (!sent) {
+      const err = new Error(this.pq.errorMessage() || 'Failed to send queued query in pipeline mode')
+      if (queued.cb) queued.cb(err)
+      continue
+    }
+
+    this._pipelinePendingCount++
+
+    // Send sync to trigger result delivery
+    this._pipelineSync()
+    this.pq.flush()
+
+    this._pipelineCallbacks.push({
+      cb: queued.cb,
+      resultCount: 0,
+      rows: undefined,
+      results: undefined,
+      error: undefined,
+    })
   }
 }

--- a/packages/pg-native/index.js
+++ b/packages/pg-native/index.js
@@ -615,6 +615,10 @@ Client.prototype._readPipeline = function () {
     this._processQueuedPipelineQueries()
   }
 
+  if (loopCount >= maxLoops) {
+    this.emit('error', new Error('Pipeline read loop exceeded max iterations - possible infinite loop detected'))
+  }
+
   // Check for notifications
   let notice = pq.notifies()
   while (notice) {

--- a/packages/pg-native/package.json
+++ b/packages/pg-native/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/brianc/node-postgres/tree/master/packages/pg-native",
   "dependencies": {
-    "libpq": "^1.8.15",
+    "libpq": "^1.9.0",
     "pg-types": "2.2.0"
   },
   "devDependencies": {

--- a/packages/pg-native/test/pipeline-mode.js
+++ b/packages/pg-native/test/pipeline-mode.js
@@ -1,0 +1,233 @@
+const Client = require('../')
+const assert = require('assert')
+
+describe('pipeline mode', function () {
+  this.timeout(10000)
+
+  describe('pipeline configuration options', function () {
+    it('accepts pipelineMode option', function () {
+      const client = new Client({ pipelineMode: true })
+      assert.strictEqual(client._pipelineMode, true)
+    })
+
+    it('accepts pipelineMaxQueries option', function () {
+      const client = new Client({ pipelineMaxQueries: 100 })
+      assert.strictEqual(client._pipelineMaxQueries, 100)
+    })
+
+    it('defaults pipelineMaxQueries to 1000', function () {
+      const client = new Client()
+      assert.strictEqual(client._pipelineMaxQueries, 1000)
+    })
+
+    it('defaults pipelineMode to false', function () {
+      const client = new Client()
+      assert.strictEqual(client._pipelineMode, false)
+    })
+  })
+
+  describe('pipeline operations', function () {
+    let client
+
+    before(function (done) {
+      client = new Client({ pipelineMode: true })
+      client.connectSync()
+
+      // Check if pipeline mode was successfully enabled
+      if (!client._pipelineEnabled) {
+        console.log('Pipeline mode not supported. Skipping pipeline tests.')
+        client.end()
+        this.skip()
+        return done()
+      }
+
+      done()
+    })
+
+    after(function (done) {
+      if (client && client.pq.connected) {
+        client.end(done)
+      } else {
+        done()
+      }
+    })
+
+    describe('query with callbacks', function () {
+      it('can execute a single query in pipeline mode', function (done) {
+        client.query('SELECT 1 as num', function (err, rows) {
+          if (err) return done(err)
+          assert.strictEqual(rows[0].num, 1)
+          done()
+        })
+      })
+
+      it('can execute a parameterized query in pipeline mode', function (done) {
+        client.query('SELECT $1::int as num', [42], function (err, rows) {
+          if (err) return done(err)
+          assert.strictEqual(rows[0].num, 42)
+          done()
+        })
+      })
+
+      it('can execute multiple queries in pipeline mode', function (done) {
+        let completed = 0
+        const results = []
+
+        const checkComplete = function () {
+          completed++
+          if (completed === 3) {
+            assert.deepStrictEqual(results, [1, 2, 3])
+            done()
+          }
+        }
+
+        client.query('SELECT 1 as num', function (err, rows) {
+          if (err) return done(err)
+          results.push(rows[0].num)
+          checkComplete()
+        })
+
+        client.query('SELECT 2 as num', function (err, rows) {
+          if (err) return done(err)
+          results.push(rows[0].num)
+          checkComplete()
+        })
+
+        client.query('SELECT 3 as num', function (err, rows) {
+          if (err) return done(err)
+          results.push(rows[0].num)
+          checkComplete()
+        })
+      })
+
+      it('handles query errors in pipeline mode', function (done) {
+        client.query('SELECT invalid_column FROM nonexistent_table', function (err) {
+          assert(err instanceof Error, 'Should return an error')
+          done()
+        })
+      })
+    })
+
+    describe('query with promises', function () {
+      it('returns a promise when no callback provided', async function () {
+        const rows = await client.query('SELECT 1 as num')
+        assert.strictEqual(rows[0].num, 1)
+      })
+
+      it('can execute parameterized queries with promises', async function () {
+        const rows = await client.query('SELECT $1::text as name', ['test'])
+        assert.strictEqual(rows[0].name, 'test')
+      })
+
+      it('rejects promise on query error', async function () {
+        try {
+          await client.query('SELECT invalid')
+          assert.fail('Should have thrown an error')
+        } catch (err) {
+          assert(err instanceof Error)
+        }
+      })
+    })
+  })
+
+  describe('backpressure', function () {
+    let client
+
+    before(function (done) {
+      client = new Client({ pipelineMode: true, pipelineMaxQueries: 5 })
+      client.connectSync()
+
+      if (!client._pipelineEnabled) {
+        client.end()
+        this.skip()
+        return done()
+      }
+
+      done()
+    })
+
+    after(function (done) {
+      if (client && client.pq.connected) {
+        client.end(done)
+      } else {
+        done()
+      }
+    })
+
+    it('queues queries when exceeding pipelineMaxQueries', async function () {
+      // With pipelineMaxQueries=5, sending 10 queries should queue 5
+      const promises = []
+      for (let i = 1; i <= 10; i++) {
+        promises.push(client.query('SELECT $1::int as num', [i]))
+      }
+
+      const results = await Promise.all(promises)
+
+      assert.strictEqual(results.length, 10)
+      for (let i = 0; i < 10; i++) {
+        assert.strictEqual(results[i][0].num, i + 1)
+      }
+    })
+
+    it('correctly tracks pending query count', async function () {
+      // Start fresh - exit and re-enter pipeline mode
+      client._exitPipelineMode()
+      client._enterPipelineMode()
+      client._startPipelineReading()
+
+      assert.strictEqual(client._pipelinePendingCount, 0)
+      assert.strictEqual(client._pipelineQueue.length, 0)
+
+      // Send 3 queries (under the limit of 5)
+      const p1 = client.query('SELECT 1')
+      const p2 = client.query('SELECT 2')
+      const p3 = client.query('SELECT 3')
+
+      // All should be sent, none queued
+      assert.strictEqual(client._pipelinePendingCount, 3)
+      assert.strictEqual(client._pipelineQueue.length, 0)
+
+      await Promise.all([p1, p2, p3])
+    })
+  })
+
+  describe('comparison with non-pipeline mode', function () {
+    it('standard client works without pipeline mode', function (done) {
+      const standardClient = new Client()
+      standardClient.connectSync()
+
+      standardClient.query('SELECT 1 as num', function (err, rows) {
+        if (err) {
+          standardClient.end()
+          return done(err)
+        }
+        assert.strictEqual(rows[0].num, 1)
+        standardClient.end(done)
+      })
+    })
+
+    it('pipeline mode client can execute many queries faster', async function () {
+      this.timeout(20000)
+
+      const pipelineClient = new Client({ pipelineMode: true })
+      pipelineClient.connectSync()
+
+      if (!pipelineClient._pipelineEnabled) {
+        pipelineClient.end()
+        this.skip()
+        return
+      }
+
+      const count = 100
+      const promises = []
+      for (let i = 0; i < count; i++) {
+        promises.push(pipelineClient.query('SELECT $1::int as num', [i]))
+      }
+
+      const results = await Promise.all(promises)
+      assert.strictEqual(results.length, count)
+
+      pipelineClient.end()
+    })
+  })
+})

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -20,12 +20,6 @@ const queryQueueDeprecationNotice = nodeUtils.deprecate(
   'Client.queryQueue is deprecated and will be removed in pg@9.0.'
 )
 
-const pgPassDeprecationNotice = nodeUtils.deprecate(
-  () => {},
-  'pgpass support is deprecated and will be removed in pg@9.0. ' +
-    'You can provide an async function as the password property to the Client/Pool constructor that returns a password instead. Within this function you can call the pgpass module in your own code.'
-)
-
 const byoPromiseDeprecationNotice = nodeUtils.deprecate(
   () => {},
   'Passing a custom Promise implementation to the Client/Pool constructor is deprecated and will be removed in pg@9.0.'
@@ -248,42 +242,29 @@ class Client extends EventEmitter {
   }
 
   _getPassword(cb) {
-    const con = this.connection
-    if (typeof this.password === 'function') {
-      this._Promise
-        .resolve()
-        .then(() => this.password(this.connectionParameters))
-        .then((pass) => {
-          if (pass !== undefined) {
-            if (typeof pass !== 'string') {
-              con.emit('error', new TypeError('Password must be a string'))
-              return
-            }
-            this.connectionParameters.password = this.password = pass
-          } else {
-            this.connectionParameters.password = this.password = null
-          }
-          cb()
-        })
-        .catch((err) => {
-          con.emit('error', err)
-        })
-    } else if (this.password !== null) {
+    if (typeof this.password !== 'function') {
       cb()
-    } else {
-      try {
-        const pgPass = require('pgpass')
-        pgPass(this.connectionParameters, (pass) => {
-          if (undefined !== pass) {
-            pgPassDeprecationNotice()
-            this.connectionParameters.password = this.password = pass
-          }
-          cb()
-        })
-      } catch (e) {
-        this.emit('error', e)
-      }
+      return
     }
+    const con = this.connection
+    this._Promise
+      .resolve()
+      .then(() => this.password(this.connectionParameters))
+      .then((pass) => {
+        if (pass !== undefined) {
+          if (typeof pass !== 'string') {
+            con.emit('error', new TypeError('Password must be a string'))
+            return
+          }
+          this.connectionParameters.password = this.password = pass
+        } else {
+          this.connectionParameters.password = this.password = null
+        }
+        cb()
+      })
+      .catch((err) => {
+        con.emit('error', err)
+      })
   }
 
   _handleAuthCleartextPassword(msg) {

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -35,8 +35,7 @@
     "pg-connection-string": "^2.12.0",
     "pg-pool": "^3.13.0",
     "pg-protocol": "^1.13.0",
-    "pg-types": "2.2.0",
-    "pgpass": "1.0.5"
+    "pg-types": "2.2.0"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "0.8.23",
@@ -44,6 +43,7 @@
     "async": "2.6.4",
     "bluebird": "3.7.2",
     "co": "4.6.0",
+    "pgpass": "1.0.5",
     "pg-copy-streams": "0.3.0",
     "typescript": "^4.0.3",
     "vitest": "~3.0.9",


### PR DESCRIPTION
same as https://github.com/brianc/node-postgres/pull/3591 but for pg-native (complete https://github.com/brianc/node-postgres/pull/3592)

```js
const Client = require('pg-native')

const client = new Client({
  pipelineMode: true,
  pipelineMaxQueries: 100  // default: 1000
})

client.connectSync() // or: client.connect(callback)

client.query('SELECT $1::int as num', [1], (err, rows) => {
  console.log(rows)
}) // or: await client.query('SELECT 1 as num')
```

# Benchmark
```
node index.js
============================================================
pg-native Benchmark
============================================================
Pipeline mode supported: true

Warming up...
Warmup complete.

--- Iteration 1/3 ---

Simple query (SELECT 1):
  pg.native:         5263 qps (26314 queries in 5000ms)
  Native:            6858 qps (34290 queries in 5000ms)
  Native+Pipeline:   5866 qps (29328 queries in 5000ms)

Complex query (generate_series):
  pg.native:         1074 qps (5368 queries in 5000ms)
  Native:            1035 qps (5174 queries in 5000ms)
  Native+Pipeline:   1117 qps (5586 queries in 5000ms)

Concurrent queries (10 queries in parallel):
  pg.native:         6873 qps (34370 queries in 5001ms)
  Native:            N/A (concurrent queries not supported without pipeline)
  Native+Pipeline:   20363 qps (101820 queries in 5000ms)

--- Iteration 2/3 ---

Simple query (SELECT 1):
  pg.native:         6538 qps (32693 queries in 5000ms)
  Native:            6990 qps (34952 queries in 5000ms)
  Native+Pipeline:   6255 qps (31277 queries in 5000ms)

Complex query (generate_series):
  pg.native:         928 qps (4642 queries in 5001ms)
  Native:            771 qps (3858 queries in 5001ms)
  Native+Pipeline:   687 qps (3435 queries in 5000ms)

Concurrent queries (10 queries in parallel):
  pg.native:         6582 qps (32920 queries in 5001ms)
  Native:            N/A (concurrent queries not supported without pipeline)
  Native+Pipeline:   19832 qps (99160 queries in 5000ms)

--- Iteration 3/3 ---

Simple query (SELECT 1):
  pg.native:         6560 qps (32799 queries in 5000ms)
  Native:            6891 qps (34458 queries in 5000ms)
  Native+Pipeline:   6447 qps (32234 queries in 5000ms)

Complex query (generate_series):
  pg.native:         1050 qps (5248 queries in 5000ms)
  Native:            1043 qps (5217 queries in 5000ms)
  Native+Pipeline:   1014 qps (5073 queries in 5001ms)

Concurrent queries (10 queries in parallel):
  pg.native:         6664 qps (33320 queries in 5000ms)
  Native:            N/A (concurrent queries not supported without pipeline)
  Native+Pipeline:   19603 qps (98020 queries in 5000ms)

============================================================
SUMMARY (average QPS over 3 iterations)
============================================================

Simple query (SELECT 1):
  pg.native          6120 qps
  Native             6913 qps (13.0% vs pg.native)
  Native+Pipeline    6189 qps (1.1% vs pg.native)

Complex query (generate_series):
  pg.native          1017 qps
  Native             950 qps (-6.6% vs pg.native)
  Native+Pipeline    939 qps (-7.7% vs pg.native)

Concurrent queries (10 in parallel):
  pg.native          6706 qps
  Native+Pipeline    19933 qps (197.2% vs pg.native)
  Native             N/A (not supported)

Pipeline mode impact (vs Native without pipeline):
  Simple query:       -10.5%
  Complex query:      -1.2%
  Concurrent queries: 197.2% (vs pg.native, Native N/A)
```