### PR TITLE
Deprecate Client's internal query queue

### DIFF
--- a/packages/pg-cursor/test/close.js
+++ b/packages/pg-cursor/test/close.js
@@ -16,11 +16,11 @@ describe('close', function () {
   it('can close a finished cursor without a callback', function (done) {
     const cursor = new Cursor(text)
     this.client.query(cursor)
-    this.client.query('SELECT NOW()', done)
     cursor.read(100, function (err) {
       assert.ifError(err)
       cursor.close()
     })
+    this.client.once('drain', done)
   })
 
   it('can close a finished cursor a promise', function (done) {
@@ -37,11 +37,11 @@ describe('close', function () {
   it('closes cursor early', function (done) {
     const cursor = new Cursor(text)
     this.client.query(cursor)
-    this.client.query('SELECT NOW()', done)
     cursor.read(25, function (err) {
       assert.ifError(err)
       cursor.close()
     })
+    this.client.once('drain', done)
   })
 
   it('works with callback style', function (done) {

--- a/packages/pg-pool/test/lifetime-timeout.js
+++ b/packages/pg-pool/test/lifetime-timeout.js
@@ -12,7 +12,6 @@ describe('lifetime timeout', () => {
     const pool = new Pool({ maxLifetimeSeconds: 1 })
     pool.query('SELECT NOW()')
     pool.on('remove', () => {
-      console.log('expired while idle - on-remove event')
       expect(pool.expiredCount).to.equal(0)
       expect(pool.totalCount).to.equal(0)
       done()
@@ -22,7 +21,6 @@ describe('lifetime timeout', () => {
     const pool = new Pool({ maxLifetimeSeconds: 1 })
     pool.query('SELECT pg_sleep(1.4)')
     pool.on('remove', () => {
-      console.log('expired while busy - on-remove event')
       expect(pool.expiredCount).to.equal(0)
       expect(pool.totalCount).to.equal(0)
       done()

--- a/packages/pg-protocol/src/buffer-reader.ts
+++ b/packages/pg-protocol/src/buffer-reader.ts
@@ -1,7 +1,5 @@
-const emptyBuffer = Buffer.allocUnsafe(0)
-
 export class BufferReader {
-  private buffer: Buffer = emptyBuffer
+  private buffer: Buffer = Buffer.allocUnsafe(0)
 
   // TODO(bmc): support non-utf8 encoding?
   private encoding: string = 'utf-8'

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const EventEmitter = require('events').EventEmitter
 const utils = require('./utils')
 const nodeUtils = require('util')
@@ -14,23 +12,28 @@ const crypto = require('./crypto/utils')
 
 const activeQueryDeprecationNotice = nodeUtils.deprecate(
   () => {},
-  'Client.activeQuery is deprecated and will be removed in a future version.'
+  'Client.activeQuery is deprecated and will be removed in pg@9.0'
 )
 
 const queryQueueDeprecationNotice = nodeUtils.deprecate(
   () => {},
-  'Client.queryQueue is deprecated and will be removed in a future version.'
+  'Client.queryQueue is deprecated and will be removed in pg@9.0.'
 )
 
 const pgPassDeprecationNotice = nodeUtils.deprecate(
   () => {},
-  'pgpass support is deprecated and will be removed in a future version. ' +
+  'pgpass support is deprecated and will be removed in pg@9.0. ' +
     'You can provide an async function as the password property to the Client/Pool constructor that returns a password instead. Within this funciton you can call the pgpass module in your own code.'
 )
 
 const byoPromiseDeprecationNotice = nodeUtils.deprecate(
   () => {},
-  'Passing a custom Promise implementation to the Client/Pool constructor is deprecated and will be removed in a future version.'
+  'Passing a custom Promise implementation to the Client/Pool constructor is deprecated and will be removed in pg@9.0.'
+)
+
+const queryQueueLengthDeprecationNotice = nodeUtils.deprecate(
+  () => {},
+  'Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0. Use asycn/await or an external async flow control mechanism instead.'
 )
 
 class Client extends EventEmitter {
@@ -680,6 +683,9 @@ class Client extends EventEmitter {
       return result
     }
 
+    if (this._queryQueue.length > 0) {
+      queryQueueLengthDeprecationNotice()
+    }
     this._queryQueue.push(query)
     this._pulseQueryQueue()
     return result

--- a/packages/pg/lib/native/client.js
+++ b/packages/pg/lib/native/client.js
@@ -1,5 +1,4 @@
-'use strict'
-
+const nodeUtils = require('util')
 // eslint-disable-next-line
 var Native
 // eslint-disable-next-line no-useless-catch
@@ -15,6 +14,11 @@ const util = require('util')
 const ConnectionParameters = require('../connection-parameters')
 
 const NativeQuery = require('./query')
+
+const queryQueueLengthDeprecationNotice = nodeUtils.deprecate(
+  () => {},
+  'Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0. Use asycn/await or an external async flow control mechanism instead.'
+)
 
 const Client = (module.exports = function (config) {
   EventEmitter.call(this)
@@ -228,6 +232,10 @@ Client.prototype.query = function (config, values, callback) {
       query.handleError(new Error('Client was closed and is not queryable'))
     })
     return result
+  }
+
+  if (this._queryQueue.length > 0) {
+    queryQueueLengthDeprecationNotice()
   }
 
   this._queryQueue.push(query)

--- a/packages/pg/test/integration/client/results-as-array-tests.js
+++ b/packages/pg/test/integration/client/results-as-array-tests.js
@@ -11,7 +11,7 @@ const conInfo = helper.config
 suite.test('returns results as array', function () {
   const client = new Client(conInfo)
   const checkRow = function (row) {
-    assert(util.isArray(row), 'row should be an array')
+    assert(Array.isArray(row), 'row should be an array')
     assert.equal(row.length, 4)
     assert.equal(row[0].getFullYear(), new Date().getFullYear())
     assert.strictEqual(row[1], 1)

--- a/packages/pg/test/integration/client/results-as-array-tests.js
+++ b/packages/pg/test/integration/client/results-as-array-tests.js
@@ -1,5 +1,4 @@
 'use strict'
-const util = require('util')
 const helper = require('./test-helper')
 const assert = require('assert')
 const suite = new helper.Suite()


### PR DESCRIPTION
The internal query queue was a left over from a long ago API decision. In my experience its not used on purpose as nearly everyone is using a flow control library or async/await. It clutters up the internals of the client implementation, makes certain features like pipelining & error handling more difficult, and is a bad & confusing API, so we're removing it in 9.x.