### PR TITLE
Typo fix in PgPass deprecation (funciton)

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -25,7 +25,7 @@ const queryQueueDeprecationNotice = nodeUtils.deprecate(
 const pgPassDeprecationNotice = nodeUtils.deprecate(
   () => {},
   'pgpass support is deprecated and will be removed in a future version. ' +
-    'You can provide an async function as the password property to the Client/Pool constructor that returns a password instead. Within this funciton you can call the pgpass module in your own code.'
+    'You can provide an async function as the password property to the Client/Pool constructor that returns a password instead. Within this function you can call the pgpass module in your own code.'
 )
 
 const byoPromiseDeprecationNotice = nodeUtils.deprecate(


### PR DESCRIPTION
Just a really simple typo fix in a deprecation warning:

```
(node:1065439) DeprecationWarning: pgpass support is deprecated and will be removed in a future version. You can provide an async function as the password property to the Client/Pool constructor that returns a password instead. Within this funciton you can call the pgpass module in your own code.
```

(Note `funciton`)
