### PR TITLE
fix: preserve query string in config.options when parsing connection URL

### DIFF
--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -41,7 +41,7 @@ function parse(str, options = {}) {
     config[entry[0]] = entry[1]
   }
   if (result.search) {
-    config.options = result.search.slice(1)  // slice off the leading '?'
+    config.options = result.search.slice(1) 
   }
 
   config.user = config.user || decodeURIComponent(result.username)

--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -40,6 +40,9 @@ function parse(str, options = {}) {
   for (const entry of result.searchParams.entries()) {
     config[entry[0]] = entry[1]
   }
+  if (result.search) {
+    config.options = result.search.slice(1)  // slice off the leading '?'
+  }
 
   config.user = config.user || decodeURIComponent(result.username)
   config.password = config.password || decodeURIComponent(result.password)

--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -41,7 +41,7 @@ function parse(str, options = {}) {
     config[entry[0]] = entry[1]
   }
   if (result.search) {
-    config.options = result.search.slice(1) 
+    config.options = result.search.slice(1)
   }
 
   config.user = config.user || decodeURIComponent(result.username)


### PR DESCRIPTION
## Problem
When parsing a PostgreSQL connection URL with query parameters 
(e.g. `?schema=public&ssl=true`), the parser spreads each param 
directly onto the config object but never preserves the raw query 
string in `config.options`.

This breaks code that expects `config.options` to contain the 
original query string — for example, when reconstructing connection 
URLs or implementing SSH tunneling.

Fixes #3418

## Solution
After parsing search params, save the raw query string to 
`config.options` if it exists:

```js
if (result.search) {
  config.options = result.search.slice(1)
}
```

## Test
Manually verified that parsing a URL with query params now 
correctly populates `config.options`.