### PR TITLE
fix(pg): throw on invalid Date instead of serializing NaN string

### DIFF
--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -64,6 +64,9 @@ const prepareValue = function (val, seen) {
       return buf.slice(val.byteOffset, val.byteOffset + val.byteLength) // Node.js v4 does not support those Buffer.from params
     }
     if (isDate(val)) {
+      if (isNaN(val.getTime())) {
+        throw new Error('date is invalid')
+      }
       if (defaults.parseInputDatesAsUTC) {
         return dateToStringUTC(val)
       } else {

--- a/packages/pg/test/unit/utils-tests.js
+++ b/packages/pg/test/unit/utils-tests.js
@@ -94,6 +94,22 @@ test('prepareValues: undefined prepared properly', function () {
   assert.strictEqual(out, null)
 })
 
+test('prepareValues: invalid date throws an error', function () {
+  const invalidDate = new Date(undefined)
+  assert.throws(
+    () => utils.prepareValue(invalidDate),
+    /date is invalid/
+  )
+})
+
+test('prepareValues: invalid date (NaN) does not produce NaN string', function () {
+  const invalidDate = new Date('not a date')
+  assert.throws(
+    () => utils.prepareValue(invalidDate),
+    /date is invalid/
+  )
+})
+
 test('prepareValue: null prepared properly', function () {
   const out = utils.prepareValue(null)
   assert.strictEqual(out, null)


### PR DESCRIPTION
## Summary

Fixes #3318

## Problem

Passing an invalid Date (e.g. 
ew Date(undefined) or 
ew Date('not a date')) to a query currently produces the string \'0NaN-NaN-NaNTNaN:NaN:NaN.NaN+NaN:NaN'\ which Postgres cannot parse in any useful way, resulting in a confusing server-side error far from the real problem.

\\\js
// before
client.query('SELECT \::timestamptz', [new Date(undefined)])
// → sends literal string '0NaN-NaN-NaNTNaN:NaN:NaN.NaN+NaN:NaN' to Postgres
\\\

## Root cause

In \packages/pg/lib/utils.js\, \prepareValue()\ detects \Date\ objects via \isDate(val)\ and immediately passes them to \dateToString()\ / \dateToStringUTC()\. Those functions call \date.getFullYear()\, \date.getMonth()\, etc., which all return \NaN\ for an invalid Date. \String(NaN).padStart(2, '0')\ produces \'NaN'\, so the resulting timestamp string is garbage.

## Fix

Add an \isNaN(val.getTime())\ guard at the top of the \isDate\ branch and throw a clear error:

\\\js
if (isDate(val)) {
  if (isNaN(val.getTime())) {
    throw new Error('date is invalid')
  }
  // ...
}
\\\

\\\js
// after
client.query('SELECT \::timestamptz', [new Date(undefined)])
// → throws Error: date is invalid  ← caught immediately in JS
\\\

## Tests

Added two tests to \packages/pg/test/unit/utils-tests.js\:
- \prepareValues: invalid date throws an error\ — covers \
ew Date(undefined)\
- \prepareValues: invalid date (NaN) does not produce NaN string\ — covers \
ew Date('not a date')\

All existing date tests continue to pass.