### PR TITLE
remove deprecated 'version' attribute from docker-compose.yml

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-version: '3.9'
 services:
   web:
     # Uncomment the next line to use a non-root user for all processes. You can also


### PR DESCRIPTION
Removes the warning:

```
WARN[0000] .../node-postgres/.devcontainer/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

The `version` attribute has been removed as of v2 of the docker compose plugin (https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete).