### PR TITLE
Explicit Resource Management for pg pool client

### DIFF
--- a/docs/pages/apis/pool.mdx
+++ b/docs/pages/apis/pool.mdx
@@ -207,8 +207,8 @@ const pool = new Pool()
 
 {
   // check out a single client
-  using client = await pool.connnect()
-  client.destroyOnDispose = true;
+  using client = await pool.connect()
+  client.destroyOnDispose = true
 
   // client.release(true) implicitly called at the end of scope
 }

--- a/docs/pages/apis/pool.mdx
+++ b/docs/pages/apis/pool.mdx
@@ -187,6 +187,10 @@ assert(pool.idleCount === 0)
 assert(pool.totalCount === 0)
 ```
 
+`client.destroyOnDispose: boolean`
+
+`client[Symbol.dispose]() => void`
+
 Alternatively, pool clients support [Explicit Resource Management](https://tc39.es/proposal-explicit-resource-management/), which means you can use the `using` syntax to release them if your runtime supports it.
 
 ```js
@@ -195,13 +199,22 @@ import { Pool } from 'pg'
 
 const pool = new Pool()
 {
-
   // check out a single client
   using client = await pool.connect()
 
   // client.release() implicitly called at the end of scope
 }
+
+{
+  // check out a single client
+  using client = await pool.connnect()
+  client.destroyOnDispose = true;
+
+  // client.release(true) implicitly called at the end of scope
+}
 ```
+
+If you want the client to be destroyed instead of being returned to the pool at the end of the scope, (i.e. calling `client.release(true)` at the end of the scope), set the `destroyOnRelease` property to `true`.
 
 <Alert>
   <div>

--- a/docs/pages/apis/pool.mdx
+++ b/docs/pages/apis/pool.mdx
@@ -187,6 +187,22 @@ assert(pool.idleCount === 0)
 assert(pool.totalCount === 0)
 ```
 
+Alternatively, pool clients support [Explicit Resource Management](https://tc39.es/proposal-explicit-resource-management/), which means you can use the `using` syntax to release them if your runtime supports it.
+
+```js
+
+import { Pool } from 'pg'
+
+const pool = new Pool()
+{
+
+  // check out a single client
+  using client = await pool.connect()
+
+  // client.release() implicitly called at the end of scope
+}
+```
+
 <Alert>
   <div>
     You <strong>must</strong> release a client when you are finished with it.

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -341,6 +341,12 @@ class Pool extends EventEmitter {
 
     client.release = this._releaseOnce(client, idleListener)
 
+    if (Symbol.dispose) {
+      client[Symbol.dispose] = function () {
+        this.release()
+      }
+    }
+
     client.removeListener('error', idleListener)
 
     if (!pendingItem.timedOut) {

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -342,8 +342,9 @@ class Pool extends EventEmitter {
     client.release = this._releaseOnce(client, idleListener)
 
     if (Symbol.dispose) {
+      client.destroyOnDispose = false
       client[Symbol.dispose] = function () {
-        this.release()
+        this.release(this.destroyOnDispose)
       }
     }
 

--- a/packages/pg-pool/test/disposable-clients.js
+++ b/packages/pg-pool/test/disposable-clients.js
@@ -7,7 +7,7 @@ describe('disposable clients', () => {
     const pool = new Pool({ max: 1 })
     const client = await pool.connect()
 
-    if (Symbol?.dispose) {
+    if (Symbol.dispose) {
       expect(client[Symbol.dispose]).to.be.a('function')
     }
 

--- a/packages/pg-pool/test/disposable-clients.js
+++ b/packages/pg-pool/test/disposable-clients.js
@@ -1,0 +1,25 @@
+const Pool = require('../')
+
+const expect = require('expect.js')
+
+describe('disposable clients', () => {
+  it('defines a callable [Symbol.dispose]() when symbol is present', async () => {
+    const pool = new Pool({ max: 1 })
+    const client = await pool.connect()
+
+    if (Symbol?.dispose) {
+      expect(client[Symbol.dispose]).to.be.a('function')
+    }
+
+    // ensure we don't define an `undefined` function when Symbol.dispose
+    // doesn't exist
+    expect(client).not.to.have.property('undefined')
+
+    client.release()
+    await pool.end()
+  })
+
+  if (process.version.slice(1).split('.')[0] >= 24) {
+    require('./disposable-clients/using.js')
+  }
+})

--- a/packages/pg-pool/test/disposable-clients/using.js
+++ b/packages/pg-pool/test/disposable-clients/using.js
@@ -18,3 +18,21 @@ it('supports releasing clients via `using`', async () => {
 
   await pool.end()
 })
+
+it('supports destroying clients via `using`', async () => {
+  const pool = new Pool({ max: 1 })
+  expect(pool.totalCount).to.eql(0)
+
+  {
+    using client = await pool.connect()
+    client.destroyOnDispose = true
+    expect(pool.totalCount).to.eql(1)
+    expect(pool.idleCount).to.eql(0)
+    await client.query('SELECT NOW()')
+  }
+
+  expect(pool.totalCount).to.eql(0)
+  expect(pool.idleCount).to.eql(0)
+
+  await pool.end()
+})

--- a/packages/pg-pool/test/disposable-clients/using.js
+++ b/packages/pg-pool/test/disposable-clients/using.js
@@ -1,0 +1,20 @@
+const Pool = require('../..')
+
+const expect = require('expect.js')
+
+it('supports releasing clients via `using`', async () => {
+  const pool = new Pool({ max: 1 })
+  expect(pool.totalCount).to.eql(0)
+
+  {
+    using client = await pool.connect()
+    expect(pool.totalCount).to.eql(1)
+    expect(pool.idleCount).to.eql(0)
+    await client.query('SELECT NOW()')
+  }
+
+  expect(pool.totalCount).to.eql(1)
+  expect(pool.idleCount).to.eql(1)
+
+  await pool.end()
+})


### PR DESCRIPTION
Add support for [Explicit Resource Management](https://tc39.es/proposal-explicit-resource-management/) for `pg.Pool` clients.

This is implemented using `[Symbol.dispose]` instead of `[Symbol.asyncDispose]` because `client.release()` is a synchronous function, not async.

Additionally, add a second property `client.destroyOnDispose` so that `Symbol.dispose` supports calling `client.release(true)`. This is useful for a usecase that changes connection parameters in a way that is troublesome to reset upon release to the pool, e.g.

```js
const pool = new Pool({
    database: 'foo',
    user: 'foo',
    password: 'foo',
    port: 5432,

    statement_timeout: 10_000,
});

async function getSlowClient() {
    const client = await pool.connect();
    await client.query("SET statement_timeout = 0");
    client.destroyOnDispose = true;
}

async function performReallySlowQuery() {
    using client = await getSlowClient();

    client.query(`select pg_sleep_for('30 minutes')`);
}
```

Fixes: #3515

Note: This PR has been rebased on top of https://github.com/brianc/node-postgres/pull/3662, so there are some irrelevant commits until that PR is merged.