### PR TITLE
fix(pg): throw on invalid Date instead of serializing NaN string

### DIFF
--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -64,6 +64,9 @@ const prepareValue = function (val, seen) {
       return buf.slice(val.byteOffset, val.byteOffset + val.byteLength) // Node.js v4 does not support those Buffer.from params
     }
     if (isDate(val)) {
+      if (isNaN(val.getTime())) {
+        throw new Error('date is invalid')
+      }
       if (defaults.parseInputDatesAsUTC) {
         return dateToStringUTC(val)
       } else {

--- a/packages/pg/test/unit/utils-tests.js
+++ b/packages/pg/test/unit/utils-tests.js
@@ -94,6 +94,22 @@ test('prepareValues: undefined prepared properly', function () {
   assert.strictEqual(out, null)
 })
 
+test('prepareValues: invalid date throws an error', function () {
+  const invalidDate = new Date(undefined)
+  assert.throws(
+    () => utils.prepareValue(invalidDate),
+    /date is invalid/
+  )
+})
+
+test('prepareValues: invalid date (NaN) does not produce NaN string', function () {
+  const invalidDate = new Date('not a date')
+  assert.throws(
+    () => utils.prepareValue(invalidDate),
+    /date is invalid/
+  )
+})
+
 test('prepareValue: null prepared properly', function () {
   const out = utils.prepareValue(null)
   assert.strictEqual(out, null)


### PR DESCRIPTION
## Problem

`new Date(undefined)` and `new Date('not a date')` produce an invalid `Date` object whose `.getTime()` returns `NaN`. Previously `prepareValue()` would pass such a date straight through to `dateToString()` / `dateToStringUTC()`, which format each `NaN` time component with `padStart()`, producing the meaningless string:

```
0NaN-NaN-NaNTNaN:NaN:NaN.NaN+NaN:NaN
```

Postgres cannot parse that and responds with a cryptic server-side error. The bug is especially hard to track down because the garbled string originates silently in JavaScript — the user has no indication that an invalid `Date` was passed in the first place.

Fixes #3318.

## Fix

Add an `isNaN(val.getTime())` guard in the `isDate` branch of `prepareValue()` and throw an informative error immediately:

```js
if (isDate(val)) {
  if (isNaN(val.getTime())) {
    throw new Error('date is invalid')
  }
  // ... existing serialization
}
```

The error surfaces at the JavaScript call site, making the root cause immediately obvious.

## Tests

Added two unit tests in `packages/pg/test/unit/utils-tests.js`:

- `new Date(undefined)` → throws `/date is invalid/`
- `new Date('not a date')` → throws `/date is invalid/`
