### PR TITLE
Node JS 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           - '20'
           - '22'
           - '24'
-          - '25'
+          - '26'
         os:
           - ubuntu-latest
     name: Node.js ${{ matrix.node }}

--- a/packages/pg-native/package.json
+++ b/packages/pg-native/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/brianc/node-postgres/tree/master/packages/pg-native",
   "dependencies": {
-    "libpq": "^1.8.15",
+    "libpq": "^1.11.0",
     "pg-types": "2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- update libpq to 1.11.0 for pg-native on nodejs 26
- add node 26 into test CI (and remove node 25)