### PR TITLE
fix(pg): throw on invalid Date instead of serializing NaN string

### DIFF
--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -64,6 +64,9 @@ const prepareValue = function (val, seen) {
       return buf.slice(val.byteOffset, val.byteOffset + val.byteLength) // Node.js v4 does not support those Buffer.from params
     }
     if (isDate(val)) {
+      if (isNaN(val.getTime())) {
+        throw new Error('date is invalid')
+      }
       if (defaults.parseInputDatesAsUTC) {
         return dateToStringUTC(val)
       } else {

--- a/packages/pg/test/unit/utils-tests.js
+++ b/packages/pg/test/unit/utils-tests.js
@@ -94,6 +94,22 @@ test('prepareValues: undefined prepared properly', function () {
   assert.strictEqual(out, null)
 })
 
+test('prepareValues: invalid date throws an error', function () {
+  const invalidDate = new Date(undefined)
+  assert.throws(
+    () => utils.prepareValue(invalidDate),
+    /date is invalid/
+  )
+})
+
+test('prepareValues: invalid date (NaN) does not produce NaN string', function () {
+  const invalidDate = new Date('not a date')
+  assert.throws(
+    () => utils.prepareValue(invalidDate),
+    /date is invalid/
+  )
+})
+
 test('prepareValue: null prepared properly', function () {
   const out = utils.prepareValue(null)
   assert.strictEqual(out, null)


### PR DESCRIPTION
Fixes #3318

When prepareValue() receives an invalid Date (e.g. 
ew Date(undefined) or 
ew Date('invalid')), getTime() returns NaN. The existing code passes such a Date straight to dateToString() / dateToStringUTC(), which formats each NaN component with padStart(), producing the meaningless string  NaN-NaN-NaNTNaN:NaN:NaN.NaN+NaN:NaN that Postgres cannot parse.

## Fix

Add an isNaN(val.getTime()) guard in the isDate branch of prepareValue() and throw an informative error immediately, so callers discover the bug at the JS level rather than receiving a cryptic Postgres error.

## Changes

- packages/pg/lib/utils.js: add isNaN guard and throw TypeError
- packages/pg/test/unit/utils-tests.js: add two unit test cases for invalid Date
