### PR TITLE
  perf(pg-pool): cut per-query allocations in the acquire/release path

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -106,6 +106,9 @@ class Pool extends EventEmitter {
     this._endCallback = undefined
     this.ending = false
     this.ended = false
+    // bound once so the hot acquire/release paths reuse it instead of allocating
+    // a fresh closure/bound function per query (nextTick scheduling, _remove cbs)
+    this._pulseQueueBound = this._pulseQueue.bind(this)
   }
 
   _promiseTry(f) {
@@ -200,7 +203,7 @@ class Pool extends EventEmitter {
     if (this._isFull() || this._idle.length) {
       // if we have idle clients schedule a pulse immediately
       if (this._idle.length) {
-        process.nextTick(() => this._pulseQueue())
+        process.nextTick(this._pulseQueueBound)
       }
 
       if (!this.options.connectionTimeoutMillis) {
@@ -394,14 +397,14 @@ class Pool extends EventEmitter {
         this.log('remove expended client')
       }
 
-      return this._remove(client, this._pulseQueue.bind(this))
+      return this._remove(client, this._pulseQueueBound)
     }
 
     const isExpired = this._expired.has(client)
     if (isExpired) {
       this.log('remove expired client')
       this._expired.delete(client)
-      return this._remove(client, this._pulseQueue.bind(this))
+      return this._remove(client, this._pulseQueueBound)
     }
 
     // idle timeout
@@ -410,7 +413,7 @@ class Pool extends EventEmitter {
       tid = setTimeout(() => {
         if (this._isAboveMin()) {
           this.log('remove idle client')
-          this._remove(client, this._pulseQueue.bind(this))
+          this._remove(client, this._pulseQueueBound)
         }
       }, this.options.idleTimeoutMillis)
 
@@ -461,7 +464,10 @@ class Pool extends EventEmitter {
         cb(err)
       }
 
-      client.once('error', onError)
+      // `on` rather than `once`: the query callback below always removes this
+      // listener, and `onError` self-guards via `clientReleased`, so we don't
+      // need `once`'s wrapper allocation per query.
+      client.on('error', onError)
       this.log('dispatching query')
       try {
         client.query(text, values, (err, res) => {


### PR DESCRIPTION
## What

Two small allocation reductions in the pool's hot acquire/release path, with no behavior or API change:

1. Register the per-query error listener with `client.on('error', onError)` instead of `client.once(...)`. The query result callback already removes the listener on completion, and `onError` self-guards via the `clientReleased` flag, so `once`'s per-query wrapper allocation was unnecessary.
2. Bind `_pulseQueue` once in the constructor (`this._pulseQueueBound`) and reuse that reference for the connect-path `process.nextTick` and the three `_remove` callbacks, instead of allocating a fresh bound function on every acquire/release.

## Why

`pool.query()` is on the hot path for most applications. These changes remove one closure allocation per query (the `once` wrapper) and one bound-function allocation per acquire/release, lowering per-query GC pressure with no change to behavior.

## Correctness

The `once` to `on` switch cannot double-fire or leak a listener:

- On success, the query callback calls `client.removeListener('error', onError)` before resolving.
- `onError` flips `clientReleased` to true on its first call and returns early on any later call, so it can release and call back at most once.
- On the error path the client is released with the error and removed from the pool, so no listener accumulates on a reused client.

No public API or observable behavior changes. `waitingCount` and all emitted events are unchanged.

## Benchmark

Measured with a mock-client microbenchmark (no network, so it isolates the pool's own per-query overhead), alternating between this branch and base each round to cancel thermal drift. At concurrency 50 this change is about +2 to +3% queries/sec, with all three alternating rounds favoring it.

This is the allocation portion only. A separate change (O(1) pending-queue dequeue) adds more at high concurrency.

## Testing

The full `pg-pool` suite passes (85 passing). The one failure in my environment is the unrelated `pg-native` bindings test, which requires a local `libpq` build.