### PR TITLE
Stop cstring reading on any falsy value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 /.eslintcache
 .vscode/
 manually-test-on-heroku.js
+tsconfig.tsbuildinfo

--- a/packages/pg-protocol/src/buffer-reader.ts
+++ b/packages/pg-protocol/src/buffer-reader.ts
@@ -45,7 +45,7 @@ export class BufferReader {
     const start = this.offset
     let end = start
     // eslint-disable-next-line no-empty
-    while (this.buffer[end++] !== 0) {}
+    while (this.buffer[end++]) {}
     this.offset = end
     return this.buffer.toString(this.encoding, start, end - 1)
   }


### PR DESCRIPTION
I got a massive, obviously LLM generated security vuln report generated about a potential MITM attack where if you connect pg to a compromised backend or a malicious MITM and the cstring buffer does not have a null terminator anywhere in it it will cause your process to infinite loop.  Pretty unlikely to happen in practice and honestly you're probably in more trouble than just that if your db connection is being tampered with maliciously, but I figure its still worth fixing since the fix itself is very straight forward. 