### PR TITLE
fix: correct spelling mistakes across codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ We do not include break-fix version release in this file.
 
 ## pg@8.19.0
 
-- [Deprecate interal query queue](https://github.com/brianc/node-postgres/pull/3603).
+- [Deprecate internal query queue](https://github.com/brianc/node-postgres/pull/3603).
 - Pass connection parameters [to password callback](https://github.com/brianc/node-postgres/pull/3602).
 
 ## pg@8.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ We do not include break-fix version release in this file.
 
 ## pg@8.19.0
 
-- [Deprecate internal query queue](https://github.com/brianc/node-postgres/pull/3603).
+- [Deprecate interal query queue](https://github.com/brianc/node-postgres/pull/3603).
 - Pass connection parameters [to password callback](https://github.com/brianc/node-postgres/pull/3602).
 
 ## pg@8.18.0

--- a/packages/pg-connection-string/README.md
+++ b/packages/pg-connection-string/README.md
@@ -3,7 +3,7 @@ pg-connection-string
 
 [![NPM](https://nodei.co/npm/pg-connection-string.png?compact=true)](https://nodei.co/npm/pg-connection-string/)
 
-Functions for dealing with a PostgresSQL connection string
+Functions for dealing with a PostgreSQL connection string
 
 `parse` method taken from [node-postgres](https://github.com/brianc/node-postgres.git)
 Copyright (c) 2010-2014 Brian Carlson (brian.m.carlson@gmail.com)

--- a/packages/pg-connection-string/package.json
+++ b/packages/pg-connection-string/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pg-connection-string",
   "version": "2.13.0",
-  "description": "Functions for dealing with a PostgresSQL connection string",
+  "description": "Functions for dealing with a PostgreSQL connection string",
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {

--- a/packages/pg-protocol/src/parser.ts
+++ b/packages/pg-protocol/src/parser.ts
@@ -28,7 +28,7 @@ import {
 } from './messages'
 import { BufferReader } from './buffer-reader'
 
-// every message is prefixed with a single bye
+// every message is prefixed with a single byte
 const CODE_LENGTH = 1
 // every message has an int32 length which includes itself but does
 // NOT include the code in the length

--- a/packages/pg/test/integration/client/network-partition-tests.js
+++ b/packages/pg/test/integration/client/network-partition-tests.js
@@ -14,8 +14,8 @@ const Server = function (response) {
 
 Server.prototype.start = function (cb) {
   // this is our fake postgres server
-  // it responds with our specified response immediatley after receiving every buffer
-  // this is sufficient into convincing the client its connectet to a valid backend
+  // it responds with our specified response immediately after receiving every buffer
+  // this is sufficient into convincing the client its connected to a valid backend
   // if we respond with a readyForQuery message
   this.server = net.createServer(
     function (socket) {


### PR DESCRIPTION
## Summary
Fixed 5 spelling mistakes found throughout the codebase:

- `bye` → `byte` in parser.ts comment
- `interal` → `internal` in CHANGELOG.md
- `PostgresSQL` → `PostgreSQL` in pg-connection-string package.json and README.md
- `immediatley` → `immediately` in network-partition-tests.js
- `connectet` → `connected` in network-partition-tests.js

## Note on CHANGELOG.md
The CHANGELOG.md fix (`interal` → `internal`) was included in the initial commit `7cc57c1d` but reverted in 144ef9a6 , as CHANGELOG is a historical record of past releases and should not be modified retroactively.