### PR TITLE
Expand CI matrix of PG versions and add direct SSL test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,6 @@ jobs:
           - '22'
           - '24'
           - '26'
-        os:
-          - ubuntu-latest
     name: Node.js ${{ matrix.node }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,26 +25,39 @@ jobs:
     needs: lint
     services:
       postgres:
-        image: ghcr.io/railwayapp-templates/postgres-ssl
+        image: ghcr.io/railwayapp-templates/postgres-ssl:${{ matrix.postgres }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST_AUTH_METHOD: 'md5'
           POSTGRES_DB: ci_db_test
+          # PostgreSQL 18's official image defaults PGDATA to a versioned
+          # subdirectory (/var/lib/postgresql/18/docker), but the
+          # railwayapp-templates/postgres-ssl entrypoint requires PGDATA to
+          # start with /var/lib/postgresql/data so we pin it explicitly. This is
+          # also the default for the older images, so it is a no-op there.
+          PGDATA: /var/lib/postgresql/data
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       fail-fast: false
       matrix:
-        node:
-          - '16'
-          - '18'
-          - '20'
-          - '22'
-          - '24'
-          - '26'
-    name: Node.js ${{ matrix.node }}
+        include:
+          # Historical Node.js versions tested against a single PostgreSQL version
+          - { node: '16', postgres: &stable_postgres '18' }
+          - { node: '18', postgres: *stable_postgres }
+          - { node: '20', postgres: *stable_postgres }
+          - { node: '22', postgres: *stable_postgres }
+          - { node: '24', postgres: *stable_postgres }
+          # Latest Node.js version tested against multiple PostgreSQL versions
+          - { node: &latest_node '26', postgres: '13' }
+          - { node: *latest_node, postgres: '14' }
+          - { node: *latest_node, postgres: '15' }
+          - { node: *latest_node, postgres: '16' }
+          - { node: *latest_node, postgres: '17' }
+          - { node: *latest_node, postgres: '18' }
+    name: Node.js ${{ matrix.node }} x PostgreSQL ${{ matrix.postgres }}
     runs-on: ubuntu-latest
     env:
       PGUSER: postgres

--- a/packages/pg/test/integration/client/ssl-tests.js
+++ b/packages/pg/test/integration/client/ssl-tests.js
@@ -22,3 +22,58 @@ suite.test('can connect with ssl', function (done) {
     })
   )
 })
+
+async function getServerVersionNum() {
+  const client = new helper.pg.Client(helper.config)
+  await client.connect()
+  try {
+    const {
+      rows: [row],
+    } = await client.query('SHOW server_version_num')
+    return parseInt(row.server_version_num, 10)
+  } finally {
+    await client.end()
+  }
+}
+
+// The native client forwards sslnegotiation=direct to libpq, whose support
+// for direct SSL depends on the linked libpq version (17+) rather than on
+// this library. It also does not expose the underlying TLS socket, so the
+// direct-negotiation check below is impossible. So we only test the pure-JS client.
+if (!helper.args.native) {
+  suite.test('can connect with direct SSL negotiation', async () => {
+    // Direct SSL negotiation (sslnegotiation=direct) is only supported by
+    // PostgreSQL 17 and newer servers. Probe the server version first and skip
+    // on older servers rather than failing the test.
+    const serverVersionNum = await getServerVersionNum()
+    if (serverVersionNum < 170000) {
+      console.log(`(skipped: direct SSL requires PostgreSQL 17+, server_version_num=${serverVersionNum}) `)
+      return
+    }
+
+    const config = {
+      ...helper.config,
+      ssl: { rejectUnauthorized: false },
+      sslnegotiation: 'direct',
+    }
+    const client = new helper.pg.Client(config)
+    await client.connect()
+    const { rows } = await client.query('SELECT NOW()')
+    assert.strictEqual(rows.length, 1)
+
+    // Verify the connection actually used direct SSL negotiation rather than
+    // silently falling back to the traditional SSLRequest handshake. pg only
+    // sends the 'postgresql' ALPN protocol on a direct SSL handshake (see
+    // Connection#upgradeToSSL), and a PostgreSQL 17+ server echoes it back, so
+    // its presence on the negotiated TLS socket confirms direct negotiation.
+    const tlsSocket = client.connection.stream
+    assert.ok(tlsSocket.encrypted, 'expected the connection to be upgraded to a TLS socket')
+    assert.strictEqual(
+      tlsSocket.alpnProtocol,
+      'postgresql',
+      'expected direct SSL negotiation to select the "postgresql" ALPN protocol'
+    )
+
+    await client.end()
+  })
+}


### PR DESCRIPTION
First commit removes the `os` block from the GHA matrix. It's not actually used as we always run on `ubuntu-latest`. I think it may be left over from when we thought we were running on Windows / MacOS but actually were not.

Second updates the CI matrix to test against multiple PG versions. The original matrix of nodes versions is only tested against v18. But the latest node version is tested against v12 to v18. Uses some YAML anchors so we only have to update the latest node / PG versions in one place too.

<img width="269" height="389" alt="image" src="https://github.com/user-attachments/assets/73f5e55f-cc66-4d4b-aeb7-b592bfc7d523" />

RE: #3690, figure if we're going to say the driver supports older versions we should test them out too. It doesn't go all the way back till v8.4 though as the container images for `ghcr.io/railwayapp-templates/postgres-ssl` only go to v13. We'd have to switch back to the "official" docker hub postgres images without SSL for older versions. Might be worth doing but left it out for now (I think we could do it by just having the image name, and not just the version, in the matrix).

Finally last commit adds a test for direct SSL negotiation. It only runs in the pure JS driver against server v17+ (the min version its available). The test checks `client.connection.stream.alpnProtocol` to verify how we're connected.

RE: the server matrix, a while back I got a JSON endpoint added to the postgresql website that lists out the latest server versions in a machine readable JSON response: https://www.postgresql.org/versions.json Was going to make this all dynamic based on that version list (i.e. something like pick versions >= X) but I like it being explicit in the CI matrix. Makes it a bit easier to reason about what's actually being tested and we'd run into issues if the latest version does not have working containers yet. So best to keep it manual.