### PR TITLE
fix(pg-pool): maintain min connections after maxUses/error retirement

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -56,7 +56,7 @@ function makeIdleListener(pool, client) {
     client.on('error', () => {
       pool.log('additional client error after disconnection due to error', err)
     })
-    pool._remove(client)
+    pool._remove(client, pool._pulseQueue.bind(pool))
     // TODO - document that once the pool emits an error
     // the client has already been closed & purged and is unusable
     pool.emit('error', err, client)
@@ -124,6 +124,16 @@ class Pool extends EventEmitter {
     return this._clients.length > this.options.min
   }
 
+  _ensureMinimum() {
+    if (this.ending || this.ended) return
+    const needed = this.options.min - this._clients.length
+    for (let i = 0; i < needed; i++) {
+      this.newClient(new PendingItem((err, client, clientRelease) => {
+        if (!err) clientRelease()
+      }))
+    }
+  }
+
   _pulseQueue() {
     this.log('pulse queue')
     if (this.ended) {
@@ -177,6 +187,7 @@ class Pool extends EventEmitter {
     }
 
     this._clients = this._clients.filter((c) => c !== client)
+    this._ensureMinimum()
     const context = this
     client.end(() => {
       context.emit('remove', client)

--- a/packages/pg-pool/test/min-connections.js
+++ b/packages/pg-pool/test/min-connections.js
@@ -1,0 +1,166 @@
+'use strict'
+const EventEmitter = require('events').EventEmitter
+const expect = require('expect.js')
+const co = require('co')
+
+const describe = require('mocha').describe
+const it = require('mocha').it
+
+const Pool = require('../')
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Minimal mock client that connects immediately without a real database
+class MockClient extends EventEmitter {
+  constructor() {
+    super()
+    this._queryable = true
+    this._ending = false
+  }
+
+  connect(cb) {
+    process.nextTick(() => cb(null))
+  }
+
+  end(cb) {
+    this._ending = true
+    process.nextTick(() => {
+      this.emit('end')
+      if (cb) cb()
+    })
+  }
+
+  query(text, values, cb) {
+    if (typeof values === 'function') {
+      cb = values
+    }
+    process.nextTick(() => cb && cb(null, { rows: [] }))
+  }
+}
+
+describe('min connections maintenance', () => {
+  describe('refills to min after maxUses retirement', () => {
+    it(
+      'creates replacement connections when clients are retired due to maxUses',
+      co.wrap(function* () {
+        const pool = new Pool({ min: 2, max: 5, maxUses: 2, Client: MockClient })
+
+        // Acquire 2 clients and exhaust them (2 uses each with maxUses=2)
+        const c1 = yield pool.connect()
+        const c2 = yield pool.connect()
+        c1.release()
+        c2.release()
+
+        yield wait(10)
+
+        // Second acquisition returns the same clients
+        const c1b = yield pool.connect()
+        const c2b = yield pool.connect()
+        // On release, both hit maxUses=2 and are retired
+        c1b.release()
+        c2b.release()
+
+        // _ensureMinimum should schedule 2 replacement connections
+        yield wait(50)
+
+        expect(pool.totalCount).to.equal(2)
+        expect(pool.idleCount).to.equal(2)
+
+        return pool.end()
+      })
+    )
+
+    it(
+      'does not exceed min when multiple retirements happen simultaneously',
+      co.wrap(function* () {
+        const pool = new Pool({ min: 2, max: 10, maxUses: 2, Client: MockClient })
+
+        // Exhaust 5 clients simultaneously
+        const clients = []
+        for (let i = 0; i < 5; i++) {
+          clients.push(yield pool.connect())
+        }
+        for (const c of clients) c.release()
+
+        yield wait(10)
+
+        const clients2 = []
+        for (let i = 0; i < 5; i++) {
+          clients2.push(yield pool.connect())
+        }
+        for (const c of clients2) c.release()
+
+        yield wait(50)
+
+        // Should refill to exactly min, not more
+        expect(pool.totalCount).to.equal(2)
+
+        return pool.end()
+      })
+    )
+  })
+
+  describe('refills to min after idle client background errors', () => {
+    it(
+      'creates a replacement when an idle client emits an error',
+      co.wrap(function* () {
+        const pool = new Pool({ min: 2, max: 5, Client: MockClient })
+
+        // Build up 2 idle connections
+        const c1 = yield pool.connect()
+        const c2 = yield pool.connect()
+        c1.release()
+        c2.release()
+
+        yield wait(10)
+        expect(pool.totalCount).to.equal(2)
+        expect(pool.idleCount).to.equal(2)
+
+        // Suppress pool-level error event to prevent unhandled rejection
+        pool.on('error', () => {})
+
+        // Background error on one idle client
+        c1.emit('error', new Error('connection reset'))
+
+        yield wait(50)
+
+        // Pool should have refilled back to min=2
+        expect(pool.totalCount).to.equal(2)
+
+        return pool.end()
+      })
+    )
+  })
+
+  describe('serves pending requests after idle client error (makeIdleListener fix)', () => {
+    it(
+      'serves a queued connect after the only idle client errors',
+      co.wrap(function* () {
+        const pool = new Pool({ max: 1, Client: MockClient })
+
+        // Place the single client into idle
+        const c1 = yield pool.connect()
+        c1.release()
+
+        yield wait(10)
+        expect(pool.idleCount).to.equal(1)
+
+        pool.on('error', () => {})
+
+        // Queue a pending connect while the client is idle
+        const connectPromise = pool.connect()
+        expect(pool.waitingCount).to.equal(1)
+
+        // Error destroys the only idle client
+        c1.emit('error', new Error('connection reset'))
+
+        // The pending request must be served by a new connection
+        const c2 = yield connectPromise
+        expect(c2).not.to.equal(c1)
+        c2.release()
+
+        return pool.end()
+      })
+    )
+  })
+})

--- a/packages/pg-pool/test/sizing.js
+++ b/packages/pg-pool/test/sizing.js
@@ -81,13 +81,16 @@ describe('pool size of 1', () => {
   )
 
   it(
-    'does remove clients when at or below min if maxLifetimeSeconds is reached',
+    'retires and replaces clients at or below min when maxLifetimeSeconds is reached',
     co.wrap(function* () {
       const pool = new Pool({ max: 1, min: 1, idleTimeoutMillis: 10, maxLifetimeSeconds: 1 })
       const client = yield pool.connect()
       client.release()
-      yield new Promise((resolve) => setTimeout(resolve, 1020))
-      expect(pool.idleCount).to.equal(0)
+      // Wait long enough for the original client to expire and a replacement to connect
+      yield new Promise((resolve) => setTimeout(resolve, 1500))
+      // Original client was retired; pool refills to min with a fresh connection
+      expect(pool.totalCount).to.equal(1)
+      expect(pool.idleCount).to.equal(1)
       return yield pool.end()
     })
   )


### PR DESCRIPTION
## Problem

The \`min\` pool option does not maintain a minimum number of live connections. It only prevents the *idle timeout* from evicting connections when at or below \`min\`. When connections are retired for other reasons — \`maxUses\`, \`maxLifetimeSeconds\`, or background errors — the pool shrinks below \`min\` and never refills unless a new query arrives.

Concretely, with \`min: 15, max: 15, maxUses: <N>\`, a low-traffic window causes the pool to drain nearly to zero as each connection exhausts its use count and is removed without replacement.

There are two root causes:

### 1. \`_pulseQueue\` only refills for queued requests

\`_pulseQueue\` (called after every retirement via \`_remove\`'s callback) only creates new connections when \`_pendingQueue\` is non-empty. An idle pool with no waiting callers therefore never gets a refill.

### 2. \`makeIdleListener\` does not call \`_pulseQueue\`

When an idle client emits a background error, \`makeIdleListener\` called:

\`\`\`js
pool._remove(client)   // no callback — _pulseQueue is never called
\`\`\`

This meant:
- The pool dropped below \`min\` with no refill
- Any \`connect()\` calls waiting in \`_pendingQueue\` were stuck indefinitely

## Fix

**\`_ensureMinimum()\`** — a new method that synchronously schedules \`newClient\` calls for however many connections are needed to reach \`options.min\`:

\`\`\`js
_ensureMinimum() {
  if (this.ending || this.ended) return
  const needed = this.options.min - this._clients.length
  for (let i = 0; i < needed; i++) {
    this.newClient(new PendingItem((err, client, clientRelease) => {
      if (!err) clientRelease()
    }))
  }
}
\`\`\`

Because \`newClient\` pushes to \`_clients\` immediately (before \`connect()\` resolves), the loop naturally caps at exactly \`min\` even when called multiple times concurrently.

**Called from \`_remove\`** immediately after the retiring client is spliced from \`_clients\`, covering every removal path: \`maxUses\`, \`maxLifetimeSeconds\`, and errors.

**\`makeIdleListener\` now passes \`_pulseQueue\` as the \`_remove\` callback**, so queued \`connect()\` callers are unblocked after an idle client errors out.

## Tests

\`test/min-connections.js\` — new file using a mock \`Client\` (no real PG needed) with four scenarios:

| Test | What it verifies |
|---|---|
| maxUses retirement → refill | Pool reaches \`totalCount == min\` after clients exhaust \`maxUses\` |
| Concurrent retirements → does not exceed min | \`_ensureMinimum\` does not overshoot \`min\` when multiple clients retire simultaneously |
| Idle-error → refill | Pool creates a replacement after a background error on an idle client |
| Idle-error → serves pending request | A queued \`connect()\` is resolved after the only idle client errors out |

\`test/sizing.js\` — the existing \`maxLifetimeSeconds\` test that asserted \`idleCount === 0\` after expiry is updated: the correct new behaviour is that the pool refills to \`min\`, so the test now asserts \`totalCount === 1\` and \`idleCount === 1\` after the replacement connects.

## Behaviour notes

- \`pool.end()\` is unaffected: \`_ensureMinimum\` returns immediately when \`this.ending\` is set, so teardown is clean.
- \`maxUses: 1\` with \`min > 0\` causes a continuous rolling churn of connections (each maintenance connection is used once and immediately replaced). This is technically correct — callers who want warm idle connections with \`maxUses: 1\` pay that cost — but it is worth noting in docs.