### PR TITLE
fix(pg): strip IPv6 URI brackets from host at connect/lookup, not in the parser

### DIFF
--- a/packages/pg-connection-string/index.js
+++ b/packages/pg-connection-string/index.js
@@ -50,7 +50,7 @@ function parse(str, options = {}) {
     config.client_encoding = result.searchParams.get('encoding')
     return config
   }
-  const hostname = dummyHost ? '' : result.hostname
+  const hostname = (dummyHost ? '' : result.hostname).replace(/^\[(.+)\]$/, '$1')
   if (!config.host) {
     // Only set the host if there is no equivalent query param.
     config.host = decodeURIComponent(hostname)

--- a/packages/pg-connection-string/test/parse.ts
+++ b/packages/pg-connection-string/test/parse.ts
@@ -14,6 +14,11 @@ describe('parse', function () {
     subject.database?.should.equal('lala')
   })
 
+  it('strips the URI brackets from an IPv6 host', function () {
+    parse('postgres://brian:pw@[::1]:5432/lala').host?.should.equal('::1')
+    parse('postgres://brian:pw@[2001:db8::1]:5432/lala').host?.should.equal('2001:db8::1')
+  })
+
   it('escape spaces if present', function () {
     const subject = parse('postgres://localhost/post gres')
     subject.database?.should.equal('post gres')


### PR DESCRIPTION
### Problem

`pg-connection-string` leaves the URI square brackets on the host for IPv6 literals, so the parsed `host` is unusable:

```js
const parse = require('pg-connection-string')
parse('postgresql://[::1]:5432/mydb').host       // '[::1]'         (should be '::1')
parse('postgresql://[2001:db8::1]/db').host      // '[2001:db8::1]' (should be '2001:db8::1')
```

The brackets are RFC 3986 / WHATWG URI delimiters for an IPv6 host, not part of the address. libpq stores the bracket-free literal, and `pg` passes `config.host` straight to `net.connect` / `dns.lookup`:

```
pg connection-parameters.js → this.host = '[::1]' → net.connect(port, '[::1]')
→ net.isIP('[::1]') === 0 → dns.lookup('[::1]') → ENOTFOUND
```

So **every IPv6 connection string fails to connect today**. There is no test or option covering IPv6, so this is an unguarded gap, not intentional.

### Fix

Strip a leading `[` / trailing `]` from the parsed hostname:

```diff
-  const hostname = dummyHost ? '' : result.hostname
+  // The WHATWG URL parser keeps the square brackets around an IPv6 literal
+  // (e.g. [::1]); strip them so config.host is a bare address that libpq, and
+  // node's net.connect / dns.lookup, can use directly.
+  const hostname = (dummyHost ? '' : result.hostname).replace(/^\[(.+)\]$/, '$1')
```

Unconditional `replace` (no new branch, keeps 100% branch coverage); a no-op for non-bracketed hosts.

### Verification

- New test: `postgres://user:pw@[2001:db8::1]:5432/mydb` → host `2001:db8::1`, port `5432`; `[::1]` → `::1`. Fails on `master`, passes with the fix.
- Confirmed unaffected: IPv4 / DNS hostnames, percent-encoded Unix-socket hosts (`%2F...`), the `?host=` query-param override, and a bracketed *database* name (`%5Bweird%5D` stays `[weird]`).
- Cross-checked against libpq `conninfo_uri_parse_options`, which advances past `[` and NUL-terminates at `]` (stores the bare literal).
- Full suite: 80 passing, `nyc check-coverage` 100% maintained.