### PR TITLE
fix(query): send Sync after an error in a rows-limited query

### DIFF
--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -30,6 +30,7 @@ class Query extends EventEmitter {
     // potential for multiple results
     this._results = this._result
     this._canceledDueToError = false
+    this._hasSentSync = false
   }
 
   requiresPreparation() {
@@ -104,9 +105,7 @@ class Query extends EventEmitter {
     this._result.addCommandComplete(msg)
     // need to sync after each command complete of a prepared statement
     // if we were using a row count which results in multiple calls to _getRows
-    if (this.rows) {
-      connection.sync()
-    }
+    this._syncRows(connection)
   }
 
   // if a named prepared statement is created with empty query text
@@ -114,13 +113,12 @@ class Query extends EventEmitter {
   // since we pipeline sync immediately after execute we don't need to do anything here
   // unless we have rows specified, in which case we did not pipeline the initial sync call
   handleEmptyQuery(connection) {
-    if (this.rows) {
-      connection.sync()
-    }
+    this._syncRows(connection)
   }
 
   handleError(err, connection) {
     // need to sync after error during a prepared statement
+    this._syncRows(connection)
     if (this._canceledDueToError) {
       err = this._canceledDueToError
       this._canceledDueToError = false
@@ -147,6 +145,13 @@ class Query extends EventEmitter {
       }
     }
     this.emit('end', this._results)
+  }
+
+  _syncRows(connection) {
+    if (this.rows && !this._hasSentSync) {
+      this._hasSentSync = true
+      connection.sync()
+    }
   }
 
   submit(connection) {
@@ -231,6 +236,7 @@ class Query extends EventEmitter {
       // we should close parse to avoid leaking connections
       connection.close({ type: 'S', name: this.name })
       connection.sync()
+      this._hasSentSync = true
 
       this.handleError(err, connection)
       return

--- a/packages/pg/test/integration/gh-issues/3707-tests.js
+++ b/packages/pg/test/integration/gh-issues/3707-tests.js
@@ -1,0 +1,38 @@
+'use strict'
+const helper = require('./../test-helper')
+const assert = require('assert')
+
+const suite = new helper.Suite()
+
+suite.test('recovers after an error in a rows-limited query', async function () {
+  const client = new helper.pg.Client()
+
+  await client.connect()
+
+  try {
+    const error = await client
+      .query({
+        text: 'select 10 / (5 - i) as v from generate_series(1, 7) g(i)',
+        rows: 2,
+      })
+      .catch((err) => err)
+
+    assert.strictEqual(error.code, '22012')
+
+    const followUp = client.query('select 1').then(
+      () => 'follow-up resolved',
+      (err) => `follow-up rejected: ${err.message}`
+    )
+    let timeout
+    const hung = new Promise((resolve) => {
+      timeout = setTimeout(resolve, 4000, 'follow-up hung')
+    })
+
+    const result = await Promise.race([followUp, hung])
+    clearTimeout(timeout)
+
+    assert.strictEqual(result, 'follow-up resolved')
+  } finally {
+    await client.end()
+  }
+})

--- a/packages/pg/test/unit/client/throw-in-bind-tests.js
+++ b/packages/pg/test/unit/client/throw-in-bind-tests.js
@@ -69,6 +69,23 @@ suite.test('emits error event when bind throws (no callback)', function (done) {
   client.query(query)
 })
 
+suite.test('calls sync once when bind throws for rows-limited query', function (done) {
+  const { client, con, calls } = setupClient()
+  con.emit('readyForQuery')
+  client.query(
+    new Query({
+      text: 'select $1',
+      values: ['x'],
+      rows: 1,
+      callback: function (err) {
+        assert.equal(err, bindError)
+        assert.equal(calls.sync, 1, 'sync should be called once')
+        done()
+      },
+    })
+  )
+})
+
 suite.test('send close when bind throws', function (done) {
   const { client, con, calls } = setupClient()
   con.emit('readyForQuery')


### PR DESCRIPTION
Fixes #3707.

## Problem

Running a `rows`-limited query (`client.query({ text, rows: N })`, which paginates results via repeated Execute+Flush) permanently wedges the connection if a Postgres error occurs partway through fetching. The erroring query itself rejects correctly, but every subsequent query on that same client hangs forever with no error and no timeout.

## Root cause

`rows`-limited queries use the extended query protocol's Execute+Flush cycle to fetch pages of results. If Postgres reports an `ErrorResponse` mid-fetch, it waits for a `Sync` message before sending `ReadyForQuery`. `Query#handleError()` never sent `Sync` for the `rows` case (only `handleCommandComplete()`/`handleEmptyQuery()` did, on the success path) — so after an error, the connection was left with `readyForQuery` permanently `false`, and the next query queued internally forever.

## Fix

- Extracted the existing `if (this.rows) { connection.sync() }` call sites (`handleCommandComplete`, `handleEmptyQuery`) into a shared `_syncRows(connection)` helper.
- Call `_syncRows(connection)` from `handleError()` too, so the error path now sends `Sync` just like the success path already did.
- Added a `_hasSentSync` flag so `_syncRows` is a no-op if a `Sync` was already sent for this query. This matters for one existing path: `prepare()`'s bind-throw handler already sent its own `connection.sync()` before calling `handleError()` — without the flag, that would now send a duplicate `Sync`.

## Testing

- New integration test (`test/integration/gh-issues/3707-tests.js`): runs a `rows: 2` query that hits a real division-by-zero error partway through (`generate_series` with a `10 / (5 - i)` expression), then races a follow-up `select 1` against a 4s timer. This test fails with `'follow-up hung'` (not a CI-hanging timeout - it fails fast within the 4s window) on code before this fix, and passes after.
- New unit test (`test/unit/client/throw-in-bind-tests.js`): asserts `Sync` is sent exactly once (not twice) when a bind throws for a `rows`-limited query, covering the `_hasSentSync` de-duplication path specifically.
- Ran the full `test-unit` suite (271 assertions) and the `test-integration` suite locally against a real Postgres instance - both clean aside from two pre-existing failures in my local environment unrelated to this change (missing SSL cert setup for `2085-tests.js`, missing `psql` CLI for `130-tests.js`).
