### PR TITLE
Export QueryStreamConfig interface

### DIFF
--- a/packages/pg-query-stream/src/index.ts
+++ b/packages/pg-query-stream/src/index.ts
@@ -2,7 +2,7 @@ import { Readable } from 'stream'
 import { Submittable, Connection } from 'pg'
 import Cursor from 'pg-cursor'
 
-interface QueryStreamConfig {
+export interface QueryStreamConfig {
   batchSize?: number
   highWaterMark?: number
   rowMode?: 'array'

--- a/packages/pg-query-stream/src/index.ts
+++ b/packages/pg-query-stream/src/index.ts
@@ -2,7 +2,7 @@ import { Readable } from 'stream'
 import { Submittable, Connection } from 'pg'
 import Cursor from 'pg-cursor'
 
-export interface QueryStreamConfig {
+interface QueryStreamConfig {
   batchSize?: number
   highWaterMark?: number
   rowMode?: 'array'
@@ -70,6 +70,10 @@ class QueryStream extends Readable implements Submittable {
       }
     })
   }
+}
+
+namespace QueryStream {
+  export type Config = QueryStreamConfig
 }
 
 export = QueryStream


### PR DESCRIPTION
`QueryStreamConfig` is part of the public constructor API but is not currently exported.

Exporting the interface allows TypeScript users to reference the configuration type without redefining it. This change does not affect runtime behavior.