### PR TITLE
feat(types): expose QueryStream.Config

### DIFF
--- a/packages/pg-query-stream/src/index.ts
+++ b/packages/pg-query-stream/src/index.ts
@@ -72,4 +72,8 @@ class QueryStream extends Readable implements Submittable {
   }
 }
 
+namespace QueryStream {
+  export type Config = QueryStreamConfig
+}
+
 export = QueryStream


### PR DESCRIPTION
`QueryStreamConfig` is part of the public constructor API but is not currently exported.

This PR exposes it as `QueryStream.Config` using namespace merging, preserving the existing CommonJS export style.