### PR TITLE
fix(pg-pool): honor connectionTimeoutMillis and don't leak timed-out connections

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -249,14 +249,26 @@ class Pool extends EventEmitter {
     let timeoutHit = false
     if (this.options.connectionTimeoutMillis) {
       tid = setTimeout(() => {
+        this.log('ending client due to timeout')
+        timeoutHit = true
+        // Reject the checkout at the deadline and stop tracking this client
+        // immediately, so a connect that hangs (or never calls back) can neither
+        // delay the timeout past connectionTimeoutMillis nor leak into _clients.
+        this._clients = this._clients.filter((c) => c !== client)
+        if (!pendingItem.timedOut) {
+          pendingItem.timedOut = true
+          pendingItem.callback(new Error('Connection terminated due to connection timeout'), undefined, NOOP)
+        }
+        this._pulseQueue()
+        // Tear the half-open connection down cleanly (send a Terminate rather
+        // than ripping out the local socket) in the background, and silence the
+        // dying client's errors so they don't surface as an unhandled 'error'
+        // (which can crash the process, e.g. with pg-native).
+        client.removeAllListeners('error')
+        client.on('error', () => {})
         if (client.connection) {
-          this.log('ending client due to timeout')
-          timeoutHit = true
-          client.connection.stream.destroy()
+          client.connection.end()
         } else if (!client.isConnected()) {
-          this.log('ending client due to timeout')
-          timeoutHit = true
-          // force kill the node driver, and let libpq do its teardown
           client.end()
         }
       }, this.options.connectionTimeoutMillis)
@@ -282,6 +294,14 @@ class Pool extends EventEmitter {
         if (!pendingItem.timedOut) {
           pendingItem.callback(err, undefined, NOOP)
         }
+      } else if (timeoutHit) {
+        // Race: the connection finished establishing after the timeout already
+        // rejected the checkout and removed this client. Just close the
+        // late-completing connection cleanly so no backend is leaked.
+        this.log('client connected after timeout, discarding')
+        client.removeAllListeners('error')
+        client.on('error', () => {})
+        client.end()
       } else {
         this.log('new client connected')
 

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -249,26 +249,24 @@ class Pool extends EventEmitter {
     let timeoutHit = false
     if (this.options.connectionTimeoutMillis) {
       tid = setTimeout(() => {
+        // the native client reports itself connected before its connect callback fires
+        if (!client.connection && client.isConnected()) {
+          return
+        }
+
         this.log('ending client due to timeout')
         timeoutHit = true
-        // Reject the checkout at the deadline and stop tracking this client
-        // immediately, so a connect that hangs (or never calls back) can neither
-        // delay the timeout past connectionTimeoutMillis nor leak into _clients.
         this._clients = this._clients.filter((c) => c !== client)
         if (!pendingItem.timedOut) {
           pendingItem.timedOut = true
           pendingItem.callback(new Error('Connection terminated due to connection timeout'), undefined, NOOP)
         }
         this._pulseQueue()
-        // Tear the half-open connection down cleanly (send a Terminate rather
-        // than ripping out the local socket) in the background, and silence the
-        // dying client's errors so they don't surface as an unhandled 'error'
-        // (which can crash the process, e.g. with pg-native).
         client.removeAllListeners('error')
         client.on('error', () => {})
         if (client.connection) {
           client.connection.end()
-        } else if (!client.isConnected()) {
+        } else {
           client.end()
         }
       }, this.options.connectionTimeoutMillis)
@@ -295,9 +293,6 @@ class Pool extends EventEmitter {
           pendingItem.callback(err, undefined, NOOP)
         }
       } else if (timeoutHit) {
-        // Race: the connection finished establishing after the timeout already
-        // rejected the checkout and removed this client. Just close the
-        // late-completing connection cleanly so no backend is leaked.
         this.log('client connected after timeout, discarding')
         client.removeAllListeners('error')
         client.on('error', () => {})

--- a/packages/pg-pool/test/connection-timeout.js
+++ b/packages/pg-pool/test/connection-timeout.js
@@ -227,6 +227,35 @@ describe('connection timeout', () => {
     })
   })
 
+  it('does not retain a connection that establishes after the timeout (#3543)', (done) => {
+    const Client = require('pg').Client
+    const orgConnect = Client.prototype.connect
+
+    // Force the first connection to finish establishing only *after* the
+    // connection timeout has already fired (200ms > 100ms).
+    let first = true
+    Client.prototype.connect = function (cb) {
+      if (first) {
+        first = false
+        return setTimeout(() => orgConnect.call(this, cb), 200)
+      }
+      return orgConnect.call(this, cb)
+    }
+
+    const pool = new Pool({ connectionTimeoutMillis: 100, max: 1 })
+    pool.connect((err, client) => {
+      Client.prototype.connect = orgConnect
+      // The checkout must fail with a timeout rather than silently resolving
+      // ~200ms later, and the timed-out connection must not be retained.
+      expect(err).to.be.an(Error)
+      expect(err.message).to.contain('timeout')
+      expect(client).to.be(undefined)
+      expect(pool.totalCount).to.equal(0)
+      expect(pool.idleCount).to.equal(0)
+      pool.end(done)
+    })
+  })
+
   it('should connect if timeout is passed, but native client in connected state', (done) => {
     const Client = require('pg').native.Client
 


### PR DESCRIPTION
Fixes #3543.

`newClient()` sets a `connectionTimeoutMillis` timer, but the `client.connect()` success path never checks whether it fired. A connection that finishes establishing after the deadline is handed to the caller anyway — silently exceeding the timeout — and kept in the pool.

The timeout now rejects the checkout at the deadline, drops the client, and ends the connection cleanly rather than destroying the socket. A connection that completes after the timeout is closed instead of handed back. A client that reports `isConnected()` with no `connection` object (the native client) is still exempt, as before.
