### PR TITLE
fix: send Sync on error during rows-limited (portal) queries

### DIFF
--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -125,6 +125,12 @@ class Query extends EventEmitter {
       err = this._canceledDueToError
       this._canceledDueToError = false
     }
+    // send sync to unstick the connection after an error during
+    // a rows-limited (portal suspension) query; without this,
+    // the server waits for Sync and ReadyForQuery never arrives.
+    if (this.rows) {
+      connection.sync()
+    }
     // if callback supplied do not emit error event as uncaught error
     // events will bubble up to node process
     if (this.callback) {


### PR DESCRIPTION
## Problem

When a query with the `rows` option (portal suspension mode) encounters an `ErrorResponse` from the server, `handleError` returns the error to the caller but **never sends `Sync`**. The server stays in an extended-query subtransaction waiting for `Sync`, `ReadyForQuery` never arrives, and the connection is permanently wedged — every subsequent query on that client queues forever.

This was reported in #3707: "Error during a `rows`-limited query permanently wedges the connection — `handleError` sends no Sync".

## Fix

`handleCommandComplete` already has the `connection.sync()` call for the `rows` path (line 93–94). `handleError` was simply missing the same check. This PR adds it.

## Prior art

The `pg-cursor` package handles this correctly in its own error path. The main `pg` packages `rows` feature uses a different internal path and was overlooked.

## Testing

`pg-cursor` already has error-handling tests that verify the connection recovers after a cursor error. The main packages `rows` path should have the same coverage — this fix brings it in line with cursor behaviour.