### PR TITLE
ci: run lint on Node.js 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn lint


### PR DESCRIPTION
## Summary

- Update the Node.js version used by the lint job from 18 to 22.

## Rationale

The repository uses ESLint 10.2.1, which requires Node.js
`^20.19.0 || ^22.13.0 || >=24`.

The lint job was still running on Node.js 18 and failed before reporting lint
results because `util.styleText` is unavailable in that runtime.

## Follow-up

Running lint with Node.js 22 exposed an existing TypeScript lint issue:

```text
packages/pg-query-stream/src/index.ts:75
'QueryStream' is already defined  no-redeclare
```
It is caused by the intentional QueryStream class/namespace declaration merge used to expose
QueryStream.Config.
This will be addressed in a separate follow-up PR.