### PR TITLE
fix(lint): support TypeScript declaration merging

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,6 +71,8 @@ export default defineConfig([
 
     rules: {
       'no-undef': 'off',
+      'no-redeclare': 'off',
+      '@typescript-eslint/no-redeclare': 'error',
     },
   },
 ])


### PR DESCRIPTION
## Summary

- Use the TypeScript-aware `@typescript-eslint/no-redeclare` rule for
  TypeScript files.
- Preserve `no-redeclare` checks for JavaScript files.

## Rationale

[`brianc/node-postgres#3714`](https://github.com/brianc/node-postgres/pull/3714)
updates the lint job to run on Node.js 22, which allows ESLint 10 to run
correctly.

That change exposed a `no-redeclare` error in `pg-query-stream`. The error is
a false positive from ESLint's core rule: `QueryStream` intentionally uses a
class/namespace declaration merge to expose the public `QueryStream.Config`
type.

This replaces the core rule with TypeScript ESLint's equivalent rule for
TypeScript files, which understands declaration merging.

## Validation

- `yarn lint`
- `yarn build`