### PR TITLE
fix: avoid mutating query config

### DIFF
--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -143,7 +143,10 @@ function dateToStringUTC(date) {
 
 function normalizeQueryConfig(config, values, callback) {
   // can take in strings or config objects
-  config = typeof config === 'string' ? { text: config } : config
+  // the config object is caller-owned and must never be mutated -- copy it
+  // so callback/values assigned below don't leak into the caller's object
+  // and corrupt subsequent, unrelated invocations that reuse the same config
+  config = typeof config === 'string' ? { text: config } : { ...config }
   if (values) {
     if (typeof values === 'function') {
       config.callback = values

--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -143,9 +143,7 @@ function dateToStringUTC(date) {
 
 function normalizeQueryConfig(config, values, callback) {
   // can take in strings or config objects
-  // the config object is caller-owned and must never be mutated -- copy it
-  // so callback/values assigned below don't leak into the caller's object
-  // and corrupt subsequent, unrelated invocations that reuse the same config
+  // Copy config so normalization does not mutate the caller's object.
   config = typeof config === 'string' ? { text: config } : { ...config }
   if (values) {
     if (typeof values === 'function') {

--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -144,7 +144,7 @@ function dateToStringUTC(date) {
 function normalizeQueryConfig(config, values, callback) {
   // can take in strings or config objects
   // Copy config so normalization does not mutate the caller's object.
-  config = typeof config === 'string' ? { text: config } : { ...config }
+  config = typeof config === 'string' ? { text: config } : cloneQueryConfig(config)
   if (values) {
     if (typeof values === 'function') {
       config.callback = values
@@ -156,6 +156,13 @@ function normalizeQueryConfig(config, values, callback) {
     config.callback = callback
   }
   return config
+}
+
+function cloneQueryConfig(config) {
+  if (config == null) {
+    return config
+  }
+  return Object.defineProperties(Object.create(Object.getPrototypeOf(config)), Object.getOwnPropertyDescriptors(config))
 }
 
 // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c

--- a/packages/pg/test/unit/client/simple-query-tests.js
+++ b/packages/pg/test/unit/client/simple-query-tests.js
@@ -152,9 +152,7 @@ test('executing query', function () {
   })
 
   test('reusing a config object across calls', function () {
-    // Regression test for https://github.com/brianc/node-postgres/issues/2651
-    // Using a config object with a callback once must not leave it unusable
-    // for a later, promise-style call with the same object.
+    // Regression test for https://github.com/brianc/node-postgres/issues/2651.
     test('does not leak callback state into a later promise-style call', function () {
       const client = helper.client()
       const config = { text: 'SELECT $1', values: [1] }

--- a/packages/pg/test/unit/client/simple-query-tests.js
+++ b/packages/pg/test/unit/client/simple-query-tests.js
@@ -150,4 +150,20 @@ test('executing query', function () {
       )
     })
   })
+
+  test('reusing a config object across calls', function () {
+    // Regression test for https://github.com/brianc/node-postgres/issues/2651
+    // Using a config object with a callback once must not leave it unusable
+    // for a later, promise-style call with the same object.
+    test('does not leak callback state into a later promise-style call', function () {
+      const client = helper.client()
+      const config = { text: 'SELECT $1', values: [1] }
+
+      client.query(config, function () {})
+      const result = client.query(config)
+
+      assert.ok(result instanceof Promise, 'expected client.query() to return a Promise')
+      result.catch(() => {})
+    })
+  })
 })

--- a/packages/pg/test/unit/utils-tests.js
+++ b/packages/pg/test/unit/utils-tests.js
@@ -34,9 +34,7 @@ test('normalizing query configs', function () {
 })
 
 test('normalizeQueryConfig does not mutate the passed-in config object', function () {
-  // Regression test for https://github.com/brianc/node-postgres/issues/2651
-  // The config object is caller-owned; writing `callback`/`values` onto it
-  // leaks state into later, unrelated calls that reuse the same object.
+  // Regression test for https://github.com/brianc/node-postgres/issues/2651.
   const original = { text: 'TEXT' }
   const callback = function () {}
 

--- a/packages/pg/test/unit/utils-tests.js
+++ b/packages/pg/test/unit/utils-tests.js
@@ -33,6 +33,20 @@ test('normalizing query configs', function () {
   assert.deepEqual(config, { text: 'TEXT', values: [10], callback: callback })
 })
 
+test('normalizeQueryConfig does not mutate the passed-in config object', function () {
+  // Regression test for https://github.com/brianc/node-postgres/issues/2651
+  // The config object is caller-owned; writing `callback`/`values` onto it
+  // leaks state into later, unrelated calls that reuse the same object.
+  const original = { text: 'TEXT' }
+  const callback = function () {}
+
+  const normalized = utils.normalizeQueryConfig(original, [10], callback)
+
+  assert.equal(original.callback, undefined)
+  assert.equal(original.values, undefined)
+  assert.deepEqual(normalized, { text: 'TEXT', values: [10], callback: callback })
+})
+
 test('prepareValues: buffer prepared properly', function () {
   const buf = Buffer.from('quack')
   const out = utils.prepareValue(buf)

--- a/packages/pg/test/unit/utils-tests.js
+++ b/packages/pg/test/unit/utils-tests.js
@@ -45,6 +45,29 @@ test('normalizeQueryConfig does not mutate the passed-in config object', functio
   assert.deepEqual(normalized, { text: 'TEXT', values: [10], callback: callback })
 })
 
+test('normalizeQueryConfig preserves inherited config properties', function () {
+  class QueryConfig {
+    constructor() {
+      this._text = 'TEXT'
+    }
+
+    get text() {
+      return this._text
+    }
+  }
+
+  const original = new QueryConfig()
+  const callback = function () {}
+
+  const normalized = utils.normalizeQueryConfig(original, [10], callback)
+
+  assert.equal(original.callback, undefined)
+  assert.equal(original.values, undefined)
+  assert.equal(normalized.text, 'TEXT')
+  assert.deepEqual(normalized.values, [10])
+  assert.equal(normalized.callback, callback)
+})
+
 test('prepareValues: buffer prepared properly', function () {
   const buf = Buffer.from('quack')
   const out = utils.prepareValue(buf)


### PR DESCRIPTION
Fixes #2651

`client.query()` adds `callback` and `values` to config objects passed by the caller. Reusing the same object can make a later promise-style call return `undefined`.

Copy the config before normalizing it and add regression tests for config reuse and mutation.