### PR TITLE
fix: throw on invalid Date serialization instead of producing NaN string (#3318)

### DIFF
--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -54,6 +54,9 @@ const prepareValue = function (val, seen) {
       return Buffer.from(val.buffer, val.byteOffset, val.byteLength)
     }
     if (isDate(val)) {
+      if (isNaN(val.getTime())) {
+        throw new Error('Invalid Date value provided to query parameter')
+      }
       if (defaults.parseInputDatesAsUTC) {
         return dateToStringUTC(val)
       } else {

--- a/packages/pg/test/unit/utils-tests.js
+++ b/packages/pg/test/unit/utils-tests.js
@@ -78,6 +78,18 @@ test('prepareValues: BC date prepared properly', function () {
   helper.resetTimezoneOffset()
 })
 
+test('prepareValues: invalid date throws error', function () {
+  assert.throws(function () {
+    utils.prepareValue(new Date(undefined))
+  }, /Invalid Date/)
+  assert.throws(function () {
+    utils.prepareValue(new Date(NaN))
+  }, /Invalid Date/)
+  assert.throws(function () {
+    utils.prepareValue(new Date('not a date'))
+  }, /Invalid Date/)
+})
+
 test('prepareValues: 1 BC date prepared properly', function () {
   helper.setTimezoneOffset(-330)
 


### PR DESCRIPTION
## Description

`new Date(undefined)` (an invalid Date) was serialized as `"0NaN-NaN-NaNTNaN:NaN:NaN.NaN+NaN:NaN"` which is meaningless and harmful for Postgres queries.

## Changes

- Added `isNaN(val.getTime())` check in `prepareValue()` in `packages/pg/lib/utils.js` when handling Date objects
- Throws a clear `Error('Invalid Date value provided to query parameter')` when an invalid date is detected
- Added unit tests for invalid dates: `new Date(undefined)`, `new Date(NaN)`, `new Date('not a date')`

Valid dates continue to work as before.

Closes #3318
