### PR TITLE
fix(pg-protocol): read ParameterDescription type OIDs as unsigned

### DIFF
--- a/packages/pg-protocol/src/inbound-parser.test.ts
+++ b/packages/pg-protocol/src/inbound-parser.test.ts
@@ -161,6 +161,8 @@ const oneParameterDescBuf = buffers.parameterDescription([1111])
 
 const twoParameterDescBuf = buffers.parameterDescription([2222, 3333])
 
+const bigOidParameterDescBuf = buffers.parameterDescription([3000000003])
+
 const expectedEmptyParameterDescriptionMessage = {
   name: 'parameterDescription',
   length: 6,
@@ -180,6 +182,13 @@ const expectedTwoParameterMessage = {
   length: 14,
   parameterCount: 2,
   dataTypeIDs: [2222, 3333],
+}
+
+const expectedBigOidParameterMessage = {
+  name: 'parameterDescription',
+  length: 10,
+  parameterCount: 1,
+  dataTypeIDs: [3000000003],
 }
 
 const testForMessage = function (buffer: Buffer, expectedMessage: any) {
@@ -288,6 +297,7 @@ describe('PgPacketStream', function () {
     testForMessage(emptyParameterDescriptionBuffer, expectedEmptyParameterDescriptionMessage)
     testForMessage(oneParameterDescBuf, expectedOneParameterMessage)
     testForMessage(twoParameterDescBuf, expectedTwoParameterMessage)
+    testForMessage(bigOidParameterDescBuf, expectedBigOidParameterMessage)
   })
 
   describe('parsing rows', function () {

--- a/packages/pg-protocol/src/parser.ts
+++ b/packages/pg-protocol/src/parser.ts
@@ -300,7 +300,8 @@ const parseParameterDescriptionMessage = (reader: BufferReader) => {
   const parameterCount = reader.int16()
   const message = new ParameterDescriptionMessage(LATEINIT_LENGTH, parameterCount)
   for (let i = 0; i < parameterCount; i++) {
-    message.dataTypeIDs[i] = reader.int32()
+    // OIDs are unsigned, same as dataTypeID in parseField above
+    message.dataTypeIDs[i] = reader.uint32()
   }
   return message
 }


### PR DESCRIPTION
While digging into #2974 (custom-type OIDs above the int4 range not parsing correctly), I found that path is actually already fixed — `parseField()` in `pg-protocol`'s parser reads `dataTypeID` with `reader.uint32()`, and there's already a regression test (`bigOidDescBuff`/`expectedBigOidMessage`) covering an OID over 2^31-1 in RowDescription.

`parseParameterDescriptionMessage()` never got the same fix though. It still reads each entry in `dataTypeIDs` with the signed `reader.int32()`, so a prepared statement parameter whose type OID exceeds 2^31-1 (custom extension types can get OIDs that high) comes back as a negative number instead of the real OID.

This mirrors the RowDescription fix exactly: swap `int32()` for `uint32()`, and add the same kind of big-OID regression test for ParameterDescription that already exists for RowDescription. Confirmed the new test fails on the old code (asserts a negative dataTypeID) and passes with the fix; full `pg-protocol` suite (78 tests) is green.