### PR TITLE
fix(pg): deprecate preparing Invalid Date values

### DIFF
--- a/packages/pg/lib/utils.js
+++ b/packages/pg/lib/utils.js
@@ -1,8 +1,16 @@
 'use strict'
 
 const defaults = require('./defaults')
+const nodeUtils = require('util')
 
 const { isDate } = require('util/types')
+
+// Invalid Date values serialize to nonsense like "0NaN-NaN-NaNTNaN:..." today.
+// Warn in pg@8; pg@9 will reject them with an error. See #3318.
+const invalidDateDeprecationNotice = nodeUtils.deprecate(
+  () => {},
+  'Passing an Invalid Date to pg is deprecated and will throw in pg@9.0'
+)
 
 function escapeElement(elementRepresentation) {
   const escaped = elementRepresentation.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
@@ -54,6 +62,9 @@ const prepareValue = function (val, seen) {
       return Buffer.from(val.buffer, val.byteOffset, val.byteLength)
     }
     if (isDate(val)) {
+      if (Number.isNaN(val.getTime())) {
+        invalidDateDeprecationNotice()
+      }
       if (defaults.parseInputDatesAsUTC) {
         return dateToStringUTC(val)
       } else {

--- a/packages/pg/test/unit/utils-tests.js
+++ b/packages/pg/test/unit/utils-tests.js
@@ -89,6 +89,45 @@ test('prepareValues: 1 BC date prepared properly', function () {
   helper.resetTimezoneOffset()
 })
 
+test('prepareValues: invalid date emits deprecation warning', function (done) {
+  const warnings = []
+  const onWarning = (warning) => {
+    warnings.push(warning)
+  }
+  process.on('warning', onWarning)
+
+  let out
+  try {
+    out = utils.prepareValue(new Date(NaN))
+    // pg@8 keeps the historical (nonsensical) serialization; pg@9 will throw instead
+    assert.strictEqual(typeof out, 'string')
+    assert.ok(out.includes('NaN'))
+  } catch (err) {
+    process.removeListener('warning', onWarning)
+    return done(err)
+  }
+
+  // process.emitWarning is delivered on nextTick
+  process.nextTick(function () {
+    process.removeListener('warning', onWarning)
+    try {
+      assert.ok(
+        warnings.some(
+          (w) =>
+            w.name === 'DeprecationWarning' &&
+            typeof w.message === 'string' &&
+            w.message.includes('Invalid Date') &&
+            w.message.includes('pg@9.0')
+        ),
+        'expected DeprecationWarning about Invalid Date'
+      )
+      done()
+    } catch (err) {
+      done(err)
+    }
+  })
+})
+
 test('prepareValues: undefined prepared properly', function () {
   const out = utils.prepareValue(void 0)
   assert.strictEqual(out, null)


### PR DESCRIPTION
## Summary
- Detect `Invalid Date` in `prepareValue` and emit a `DeprecationWarning` (pg@8 keeps current serialization; pg@9 will throw).
- Add a unit regression test for the warning path.

Fixes #3318

## Test plan
- [x] Unit test `prepareValues: invalid date emits deprecation warning`
- [x] Manual `prepareValue(new Date(NaN))` shows deprecation and NaN string