### PR TITLE
fix: make prepared statement caches prototypeless

### DIFF
--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -22,7 +22,9 @@ class Connection extends EventEmitter {
 
     this._keepAlive = config.keepAlive
     this._keepAliveInitialDelayMillis = config.keepAliveInitialDelayMillis
-    this.parsedStatements = {}
+    // prototypeless so a statement named after an inherited property
+    // (`constructor`, `__proto__`, …) cannot be mistaken for one already parsed
+    this.parsedStatements = Object.create(null)
     this.ssl = config.ssl || false
     this._ending = false
     this._emitMessage = false

--- a/packages/pg/lib/native/client.js
+++ b/packages/pg/lib/native/client.js
@@ -55,8 +55,9 @@ const Client = (module.exports = function (config) {
   this.host = cp.host
   this.port = cp.port
 
-  // a hash to hold named queries
-  this.namedQueries = {}
+  // a hash to hold named queries, prototypeless so a query named after an inherited
+  // property (`constructor`, `__proto__`, …) cannot be mistaken for one already prepared
+  this.namedQueries = Object.create(null)
 })
 
 Client.Query = NativeQuery

--- a/packages/pg/test/native/named-query-prototype-tests.js
+++ b/packages/pg/test/native/named-query-prototype-tests.js
@@ -1,0 +1,73 @@
+'use strict'
+const helper = require('./../test-helper')
+const Client = require('./../../lib/native')
+const suite = new helper.Suite()
+const assert = require('assert')
+
+// `namedQueries` is keyed by user-supplied statement name. Before it was made prototypeless a name
+// matching a property of Object.prototype was truthy on a client that had prepared nothing, so the
+// query was either rejected as a duplicate or handed to PQexecPrepared without ever being prepared.
+// This mirrors the pure-JS coverage in test/unit/client/parsed-statements-prototype-tests.js.
+const inheritedNames = ['constructor', 'toString', 'valueOf', 'hasOwnProperty', 'isPrototypeOf', '__proto__']
+
+// Queries run one at a time: issuing them concurrently would queue them on the client and trip the
+// pg@9.0 deprecation notice for querying while another query is in flight. `end` is only ever
+// called from inside a query callback, because ending before the connection is established makes
+// `Client.prototype.end` both defer and proceed, invoking its callback twice.
+suite.test('a statement named after an inherited property is prepared and executed', function (done) {
+  const client = new Client(helper.config)
+  client.connect()
+
+  // the cache is built in the constructor, so it can be inspected before anything is prepared
+  for (const name of inheritedNames) {
+    assert.strictEqual(client.namedQueries[name], undefined, `'${name}' should not resolve on a fresh client`)
+  }
+  assert.strictEqual(Object.getPrototypeOf(client.namedQueries), null)
+
+  const runNext = function (i) {
+    if (i === inheritedNames.length) {
+      return client.end(done)
+    }
+    const name = inheritedNames[i]
+
+    // first use: nothing is cached under this name, so it must be prepared before it can run
+    client.query(
+      { name: name, text: 'SELECT $1::int as num', values: [i] },
+      assert.calls(function (err, result) {
+        assert(!err, `preparing '${name}' failed: ${err && err.message}`)
+        assert.equal(result.rows[0].num, i)
+        assert.strictEqual(client.namedQueries[name], 'SELECT $1::int as num')
+
+        // second use supplies no text, so it can only work if the first call cached the statement
+        client.query(
+          { name: name, values: [i + 1] },
+          assert.calls(function (err, result) {
+            assert(!err, `re-executing '${name}' failed: ${err && err.message}`)
+            assert.equal(result.rows[0].num, i + 1)
+            runNext(i + 1)
+          })
+        )
+      })
+    )
+  }
+
+  runNext(0)
+})
+
+suite.test('reusing a statement name for different text is still an error', function (done) {
+  const client = new Client(helper.config)
+  client.connect()
+
+  client.query(
+    { name: 'constructor', text: 'SELECT 1 as num' },
+    assert.calls(function (err) {
+      assert(!err, `preparing 'constructor' failed: ${err && err.message}`)
+
+      client.query({ name: 'constructor', text: 'SELECT 2 as num' }, function (err) {
+        assert(err instanceof Error, 'expected a duplicate statement name to be rejected')
+        assert.ok(/must be unique/.test(err.message), `unexpected message: ${err.message}`)
+        client.end(done)
+      })
+    })
+  )
+})

--- a/packages/pg/test/unit/client/parsed-statements-prototype-tests.js
+++ b/packages/pg/test/unit/client/parsed-statements-prototype-tests.js
@@ -1,0 +1,101 @@
+'use strict'
+const helper = require('./test-helper')
+const Connection = require('../../../lib/connection')
+const Query = require('../../../lib/query')
+const assert = require('assert')
+const suite = new helper.Suite()
+const test = suite.test.bind(suite)
+
+// Properties every plain object inherits from Object.prototype. A prepared statement may
+// legitimately be named any of these, and before `parsedStatements` was made prototypeless
+// a lookup for one of them was truthy on a connection that had parsed nothing at all.
+const inheritedNames = ['constructor', 'toString', 'valueOf', 'hasOwnProperty', 'isPrototypeOf', '__proto__']
+
+// `submit` writes to the wire through these, so stub them out. The assertions below are all
+// synchronous, so there is no need to emit the responses that would drive the query to 'end'.
+const stubConnection = function () {
+  const connection = new Connection({ stream: 'no' })
+  connection.parsed = []
+  connection.parse = function (arg) {
+    connection.parsed.push(arg.name)
+  }
+  connection.bind = function () {}
+  connection.describe = function () {}
+  connection.execute = function () {}
+  connection.flush = function () {}
+  connection.sync = function () {}
+  return connection
+}
+
+test('parsedStatements does not inherit from Object.prototype', function () {
+  const connection = new Connection({ stream: 'no' })
+  // asserted before getPrototypeOf because the inspected form of Object.prototype is itself
+  // rendered `[Object: null prototype] {}`, which makes the bare prototype check hard to read
+  for (const name of inheritedNames) {
+    assert.strictEqual(
+      connection.parsedStatements[name],
+      undefined,
+      `'${name}' should not resolve on a fresh connection`
+    )
+  }
+  assert.strictEqual(Object.getPrototypeOf(connection.parsedStatements), null)
+})
+
+test('a statement named after an inherited property has not been parsed', function () {
+  const connection = new Connection({ stream: 'no' })
+  for (const name of inheritedNames) {
+    const query = new Query({ text: 'select 1', name: name })
+    assert.ok(!query.hasBeenParsed(connection), `expected '${name}' to be unparsed on a fresh connection`)
+  }
+})
+
+test('a statement named after an inherited property is parsed rather than bound blind', function () {
+  for (const name of inheritedNames) {
+    const connection = stubConnection()
+    const query = new Query({ text: 'select 1', name: name })
+
+    assert.strictEqual(query.submit(connection), null, `expected '${name}' to be accepted`)
+    assert.deepStrictEqual(connection.parsed, [name], `expected '${name}' to be sent to the backend for parsing`)
+  }
+})
+
+// A query carrying only a name is the "execute the statement I prepared earlier" form. It skips
+// the uniqueness check in submit() (which is guarded on `this.text`) and reaches hasBeenParsed,
+// so it fails differently: the Parse is silently omitted and the backend is sent a Bind naming a
+// statement it never prepared.
+test('an inherited name with no text is treated like any other unknown name', function () {
+  const ordinary = stubConnection()
+  assert.strictEqual(new Query({ name: 'ordinary_name' }).submit(ordinary), null)
+
+  for (const name of inheritedNames) {
+    const inherited = stubConnection()
+    assert.strictEqual(new Query({ name: name }).submit(inherited), null, `expected '${name}' to be accepted`)
+    assert.deepStrictEqual(
+      inherited.parsed,
+      ordinary.parsed.length ? [name] : [],
+      `'${name}' diverged from an ordinary name`
+    )
+  }
+})
+
+test('a statement named after an inherited property is recorded once parsed', function () {
+  const connection = stubConnection()
+  connection.parsedStatements['constructor'] = 'select 1'
+
+  const query = new Query({ text: 'select 1', name: 'constructor' })
+  assert.ok(query.hasBeenParsed(connection))
+
+  assert.strictEqual(query.submit(connection), null)
+  assert.deepStrictEqual(connection.parsed, [], 'expected an already-parsed statement not to be parsed again')
+})
+
+test('reusing a statement name for different text is still an error', function () {
+  const connection = stubConnection()
+  connection.parsedStatements['constructor'] = 'select 1'
+
+  const query = new Query({ text: 'select 2', name: 'constructor' })
+  const err = query.submit(connection)
+
+  assert.ok(err instanceof Error)
+  assert.ok(/must be unique/.test(err.message), `unexpected message: ${err.message}`)
+})


### PR DESCRIPTION
Closes #3625.

`Connection.parsedStatements` and the native client's `namedQueries` become `Object.create(null)`.

## Why it's user-visible

While writing tests for this I found it surfaces two different ways, depending on whether the query carries text:

**With text** — `submit()` finds a truthy `previous` and rejects the *first ever* use of the name:

```js
await client.query({ name: 'constructor', text: 'select 1', values: [] })
// Error: Prepared statements must be unique - 'constructor' was used for a different statement
```

**Without text** (the "execute the statement I prepared earlier" form) — that check is guarded on `this.text` and so is skipped, but `hasBeenParsed()` is truthy, so the Parse is omitted and the backend receives a Bind naming a statement it never prepared.

Same for `toString`, `valueOf`, `hasOwnProperty`, `isPrototypeOf` and `__proto__`. `__proto__` is the worst of them: the write in `client.js` is silently swallowed rather than stored, so the statement is never cached even once it has been parsed.

## Scope

Every read and write of both objects is a plain index access — `connection.parsedStatements[name]`, `client.namedQueries[self.name] = self.text` — across `lib/query.js`, `lib/client.js` and `lib/native/query.js`. Nothing calls `hasOwnProperty()` on them, spreads them, or passes them to `Object.keys`/`JSON.stringify`, and no type declaration references them, so dropping the prototype needs no other changes.

As noted in the issue this is technically breaking for anyone reaching into `client.connection.parsedStatements` and calling an inherited method on it, hence the `pg@9.0` target.

## Tests

Six cases in `packages/pg/test/unit/client/parsed-statements-prototype-tests.js`, covering both failure paths above, that the cache still works once a statement is parsed, and that genuine duplicate-name detection still errors. They're synchronous against a stubbed connection, so there's nothing to time out.

`make test-unit` passes. I could not run `test-integration` or `test-native` — I'm on Windows without a Postgres instance, and `libpq` won't build here — so the `namedQueries` half of the change is unexercised by anything I ran. Worth a look from someone who can run the native suite.

## Base branch

Based on `9.0` since that's where the milestone points. Happy to retarget to `master` if you'd rather — neither file has diverged, so it's a clean cherry-pick.
