### PR TITLE
feat!: remove support for a custom Promise implementation

### DIFF
--- a/packages/pg-cursor/index.js
+++ b/packages/pg-cursor/index.js
@@ -18,7 +18,6 @@ class Cursor extends EventEmitter {
     this._queue = []
     this.state = 'initialized'
     this._result = new Result(this._conf.rowMode, this._conf.types)
-    this._Promise = this._conf.Promise || global.Promise
     this._cb = null
     this._rows = null
     this._portal = null
@@ -212,7 +211,7 @@ class Cursor extends EventEmitter {
     let promise
 
     if (!cb) {
-      promise = new this._Promise((resolve, reject) => {
+      promise = new Promise((resolve, reject) => {
         cb = (err) => (err ? reject(err) : resolve())
       })
     }
@@ -235,7 +234,7 @@ class Cursor extends EventEmitter {
     let promise
 
     if (!cb) {
-      promise = new this._Promise((resolve, reject) => {
+      promise = new Promise((resolve, reject) => {
         cb = (err, rows) => (err ? reject(err) : resolve(rows))
       })
     }

--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -27,7 +27,7 @@ function throwOnDoubleRelease() {
   throw new Error('Release called on client which has already been released to the pool.')
 }
 
-function promisify(Promise, callback) {
+function promisify(callback) {
   if (callback) {
     return { callback: callback, result: undefined }
   }
@@ -93,7 +93,6 @@ class Pool extends EventEmitter {
     this.options.maxLifetimeSeconds = this.options.maxLifetimeSeconds || 0
     this.log = this.options.log || function () {}
     this.Client = this.options.Client || Client || require('pg').Client
-    this.Promise = this.options.Promise || global.Promise
 
     if (typeof this.options.idleTimeoutMillis === 'undefined') {
       this.options.idleTimeoutMillis = 10000
@@ -109,7 +108,6 @@ class Pool extends EventEmitter {
   }
 
   _promiseTry(f) {
-    const Promise = this.Promise
     if (typeof Promise.try === 'function') {
       return Promise.try(f)
     }
@@ -190,10 +188,10 @@ class Pool extends EventEmitter {
   connect(cb) {
     if (this.ending) {
       const err = new Error('Cannot use a pool after calling end on the pool')
-      return cb ? cb(err) : this.Promise.reject(err)
+      return cb ? cb(err) : Promise.reject(err)
     }
 
-    const response = promisify(this.Promise, cb)
+    const response = promisify(cb)
     const result = response.result
 
     // if we don't have to connect a new client, don't do so
@@ -431,7 +429,7 @@ class Pool extends EventEmitter {
   query(text, values, cb) {
     // guard clause against passing a function as the first parameter
     if (typeof text === 'function') {
-      const response = promisify(this.Promise, text)
+      const response = promisify(text)
       setImmediate(function () {
         return response.callback(new Error('Passing a function as the first parameter to pool.query is not supported'))
       })
@@ -443,7 +441,7 @@ class Pool extends EventEmitter {
       cb = values
       values = undefined
     }
-    const response = promisify(this.Promise, cb)
+    const response = promisify(cb)
     cb = response.callback
 
     this.connect((err, client) => {
@@ -489,10 +487,10 @@ class Pool extends EventEmitter {
     this.log('ending')
     if (this.ending) {
       const err = new Error('Called end on pool more than once')
-      return cb ? cb(err) : this.Promise.reject(err)
+      return cb ? cb(err) : Promise.reject(err)
     }
     this.ending = true
-    const promised = promisify(this.Promise, cb)
+    const promised = promisify(cb)
     this._endCallback = promised.callback
     this._pulseQueue()
     return promised.result

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -20,11 +20,6 @@ const queryQueueDeprecationNotice = nodeUtils.deprecate(
   'Client.queryQueue is deprecated and will be removed in pg@9.0.'
 )
 
-const byoPromiseDeprecationNotice = nodeUtils.deprecate(
-  () => {},
-  'Passing a custom Promise implementation to the Client/Pool constructor is deprecated and will be removed in pg@9.0.'
-)
-
 const queryQueueLengthDeprecationNotice = nodeUtils.deprecate(
   () => {},
   'Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0. Use async/await or an external async flow control mechanism instead.'
@@ -53,10 +48,6 @@ class Client extends EventEmitter {
 
     const c = config || {}
 
-    if (c.Promise) {
-      byoPromiseDeprecationNotice()
-    }
-    this._Promise = c.Promise || global.Promise
     this._types = new TypeOverrides(c.types)
     this._ending = false
     this._ended = false
@@ -205,7 +196,7 @@ class Client extends EventEmitter {
       return
     }
 
-    return new this._Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       this._connect((error) => {
         if (error) {
           reject(error)
@@ -247,8 +238,7 @@ class Client extends EventEmitter {
       return
     }
     const con = this.connection
-    this._Promise
-      .resolve()
+    Promise.resolve()
       .then(() => this.password(this.connectionParameters))
       .then((pass) => {
         if (pass !== undefined) {
@@ -604,7 +594,7 @@ class Client extends EventEmitter {
       readTimeout = config.query_timeout || this.connectionParameters.query_timeout
       query = new Query(config, values, callback)
       if (!query.callback) {
-        result = new this._Promise((resolve, reject) => {
+        result = new Promise((resolve, reject) => {
           query.callback = (err, res) => (err ? reject(err) : resolve(res))
         }).catch((err) => {
           // replace the stack trace that leads to `TCP.onStreamRead` with one that leads back to the
@@ -692,7 +682,7 @@ class Client extends EventEmitter {
       if (cb) {
         cb()
       } else {
-        return this._Promise.resolve()
+        return Promise.resolve()
       }
     }
 
@@ -707,7 +697,7 @@ class Client extends EventEmitter {
     if (cb) {
       this.connection.once('end', cb)
     } else {
-      return new this._Promise((resolve) => {
+      return new Promise((resolve) => {
         this.connection.once('end', resolve)
       })
     }

--- a/packages/pg/lib/native/client.js
+++ b/packages/pg/lib/native/client.js
@@ -24,7 +24,6 @@ const Client = (module.exports = function (config) {
   EventEmitter.call(this)
   config = config || {}
 
-  this._Promise = config.Promise || global.Promise
   this._types = new TypeOverrides(config.types)
 
   this.native = new Native({
@@ -134,7 +133,7 @@ Client.prototype.connect = function (callback) {
     return
   }
 
-  return new this._Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     this._connect((error) => {
       if (error) {
         reject(error)
@@ -176,7 +175,7 @@ Client.prototype.query = function (config, values, callback) {
     query = new NativeQuery(config, values, callback)
     if (!query.callback) {
       let resolveOut, rejectOut
-      result = new this._Promise((resolve, reject) => {
+      result = new Promise((resolve, reject) => {
         resolveOut = resolve
         rejectOut = reject
       }).catch((err) => {
@@ -254,7 +253,7 @@ Client.prototype.end = function (cb) {
   }
   let result
   if (!cb) {
-    result = new this._Promise(function (resolve, reject) {
+    result = new Promise(function (resolve, reject) {
       cb = (err) => (err ? reject(err) : resolve())
     })
   }

--- a/packages/pg/test/integration/client/query-as-promise-tests.js
+++ b/packages/pg/test/integration/client/query-as-promise-tests.js
@@ -1,5 +1,4 @@
 'use strict'
-const bluebird = require('bluebird')
 const helper = require('../test-helper')
 const pg = helper.pg
 const assert = require('assert')
@@ -33,15 +32,21 @@ suite.test('promise API', (cb) => {
   })
 })
 
-suite.test('promise API with configurable promise type', (cb) => {
-  const client = new pg.Client({ Promise: bluebird })
+// The `Promise` constructor option was removed in pg@9.0; a client always uses the global Promise
+// now, and passing one is ignored rather than honoured.
+suite.test('a supplied promise type is ignored', (cb) => {
+  class NotAPromise extends Promise {}
+
+  const client = new pg.Client({ Promise: NotAPromise })
   const connectPromise = client.connect()
-  assert(connectPromise instanceof bluebird, 'Client connect() returns configured promise')
+  assert(connectPromise instanceof Promise, 'Client connect() returns a promise')
+  assert(!(connectPromise instanceof NotAPromise), 'Client connect() ignores a supplied promise type')
 
   connectPromise
     .then(() => {
       const queryPromise = client.query('SELECT 1')
-      assert(queryPromise instanceof bluebird, 'Client query() returns configured promise')
+      assert(queryPromise instanceof Promise, 'Client query() returns a promise')
+      assert(!(queryPromise instanceof NotAPromise), 'Client query() ignores a supplied promise type')
 
       return queryPromise.then(() => {
         client.end(cb)


### PR DESCRIPTION
Closes #3631.

Removes the `Promise` constructor option. All four packages now use the global `Promise`.

| package | change |
| --- | --- |
| `pg/lib/client.js` | drop `byoPromiseDeprecationNotice`, its trigger and the `_Promise` field; 5 call sites |
| `pg/lib/native/client.js` | drop the field; 3 call sites |
| `pg-cursor/index.js` | drop the field; 2 call sites |
| `pg-pool/index.js` | drop `this.Promise`; 6 call sites, plus the first parameter of the private `promisify()` helper, which existed only to carry it |

## Open question — scope

I asked this on the issue and went ahead with the full removal so there's something concrete to look at, but I'm happy to cut it down.

`pg-pool` and `pg-cursor` are versioned separately from `pg`, so dropping their `Promise` option is a breaking change for those packages in their own right, not only for `pg@9.0`. If you'd rather they went out with a coordinated major of their own, say so and I'll drop those two files — it's a clean partial revert and the `pg` half stands on its own.

## Notes

- **An existing test asserted the old behaviour.** `test/integration/client/query-as-promise-tests.js` did `new pg.Client({ Promise: bluebird })` and asserted the returned promise *was* a bluebird. I inverted it to assert a supplied type is now ignored, using a local `class NotAPromise extends Promise` so the test no longer needs bluebird at all.
- **`Pool#_promiseTry` keeps its `Promise.try` fast path.** That method exists on Node 23+ but not on 16–22, which CI still covers, so the fallback has to stay. Now that the constructor is always the global one this could arguably be simplified when the minimum Node version rises.
- **`bluebird` is left in `devDependencies`** for `pg` and `pg-pool`, where it's now unused. Removing it desyncs `yarn.lock` and CI installs with `--frozen-lockfile`, so it seemed better as a follow-up than bundled into this. Happy to include it if you'd prefer, with the lockfile regenerated.
- The docs never documented the option, so there's nothing to update in `docs/`.

## Testing

`make test-unit` passes locally. I can't run `test-integration` or `test-native` here — Windows, no Postgres, and `libpq` won't build — so I leaned on CI for those. I did exercise the pg-pool paths directly, since `pool.end()` needs no database: `end()` returns a native promise, a second `end()` rejects through the `Promise.reject` path, `_promiseTry` resolves, and a supplied `Promise` is ignored.
