### PR TITLE
fix(pg-cloudflare): safely end closed sockets

### DIFF
--- a/packages/pg-cloudflare/src/index.ts
+++ b/packages/pg-cloudflare/src/index.ts
@@ -107,7 +107,7 @@ export class CloudflareSocket extends EventEmitter {
   end(data = Buffer.alloc(0), encoding: BufferEncoding = 'utf8', callback: (...args: unknown[]) => void = () => {}) {
     log('ending CF socket')
     this.write(data, encoding, (err) => {
-      this._cfSocket!.close()
+      this._cfSocket?.close()
       if (callback) callback(err)
     })
     return this

--- a/packages/pg-esm-test/pg-cloudflare.test.js
+++ b/packages/pg-esm-test/pg-cloudflare.test.js
@@ -6,4 +6,16 @@ describe('pg-cloudflare', () => {
   it('should export CloudflareSocket constructor', () => {
     assert.ok(new CloudflareSocket())
   })
+
+  it('should safely end after the underlying socket has closed', async () => {
+    const socket = new CloudflareSocket()
+    const underlyingSocket = { closed: Promise.resolve() }
+    socket._cfSocket = underlyingSocket
+    socket._addClosedHandler()
+
+    await underlyingSocket.closed
+    assert.equal(socket._cfSocket, null)
+
+    assert.doesNotThrow(() => socket.end())
+  })
 })


### PR DESCRIPTION
Closes #3689.

`CloudflareSocket._addClosedHandler()` clears `_cfSocket` when the underlying socket closes. A later pool cleanup calls `end()`/`destroy()`, which currently dereferences the cleared socket and throws.

Use optional chaining so closing an already-closed socket is a no-op. The regression test drives the close handler, verifies the internal socket has been cleared, and confirms `end()` no longer throws.

Validation:
- `node --test --conditions=workerd packages/pg-esm-test/pg-cloudflare.test.js`
- `yarn eslint packages/pg-cloudflare/src/index.ts packages/pg-esm-test/pg-cloudflare.test.js`
- `yarn build`
- `git diff --check`