### PR TITLE
perf: Copy less when serializing `Bind` messages

### DIFF
--- a/packages/pg-protocol/src/buffer-writer.ts
+++ b/packages/pg-protocol/src/buffer-writer.ts
@@ -1,7 +1,7 @@
 //binary data writer tuned for encoding binary specific to the postgres binary protocol
 
 export class Writer {
-  private buffer: Buffer
+  public buffer: Buffer
   private offset: number = 5
   private headerPosition: number = 0
   constructor(private size = 256) {
@@ -83,6 +83,16 @@ export class Writer {
     otherBuffer.copy(this.buffer, this.offset)
     this.offset += otherBuffer.length
     return this
+  }
+
+  /**
+   * Appends an uninitialized block of {@link size} bytes to the buffer and returns its offset.
+   */
+  public reserveUnsafe(size: number): number {
+    const offset = this.offset
+    this.ensure(size)
+    this.offset += size
+    return offset
   }
 
   private join(code?: number): Buffer {

--- a/packages/pg-protocol/src/buffer-writer.ts
+++ b/packages/pg-protocol/src/buffer-writer.ts
@@ -16,7 +16,7 @@ export class Writer {
       // https://stackoverflow.com/questions/2269063/buffer-growth-strategy
       const newSize = oldBuffer.length + (oldBuffer.length >> 1) + size
       this.buffer = Buffer.allocUnsafe(newSize)
-      oldBuffer.copy(this.buffer)
+      oldBuffer.copy(this.buffer, 0, 0, this.offset)
     }
   }
 

--- a/packages/pg-protocol/src/serializer.ts
+++ b/packages/pg-protocol/src/serializer.ts
@@ -117,7 +117,8 @@ const enum ParamType {
 }
 
 const writeValues = function (values: any[], valueMapper: ValueMapper | undefined, formatsOffset: number): void {
-  for (let i = 0; i < values.length; i++) {
+  const len = values.length
+  for (let i = 0; i < len; i++) {
     const mappedVal = valueMapper ? valueMapper(values[i], i) : values[i]
     let formatByte = ParamType.STRING
 

--- a/packages/pg-protocol/src/serializer.ts
+++ b/packages/pg-protocol/src/serializer.ts
@@ -110,34 +110,35 @@ type BindOpts = {
   valueMapper?: ValueMapper
 }
 
-const paramWriter = new Writer()
-
 // make this a const enum so typescript will inline the value
 const enum ParamType {
   STRING = 0,
   BINARY = 1,
 }
 
-const writeValues = function (values: any[], valueMapper?: ValueMapper): void {
+const writeValues = function (values: any[], valueMapper: ValueMapper | undefined, formatsOffset: number): void {
   for (let i = 0; i < values.length; i++) {
     const mappedVal = valueMapper ? valueMapper(values[i], i) : values[i]
+    let formatByte = ParamType.STRING
+
     if (mappedVal == null) {
-      // add the param type (string) to the writer
-      writer.addInt16(ParamType.STRING)
-      // write -1 to the param writer to indicate null
-      paramWriter.addInt32(-1)
+      // write -1 to indicate null
+      writer.addInt32(-1)
     } else if (mappedVal instanceof Buffer) {
-      // add the param type (binary) to the writer
-      writer.addInt16(ParamType.BINARY)
+      formatByte = ParamType.BINARY
+
       // add the buffer to the param writer
-      paramWriter.addInt32(mappedVal.length)
-      paramWriter.add(mappedVal)
+      writer.addInt32(mappedVal.length)
+      writer.add(mappedVal)
     } else {
-      // add the param type (string) to the writer
-      writer.addInt16(ParamType.STRING)
       // length prefix + UTF-8 bytes in one pass (Buffer.byteLength computed once)
-      paramWriter.addInt32PrefixedString(mappedVal)
+      writer.addInt32PrefixedString(mappedVal)
     }
+
+    // beware: `writer` operations can replace `writer.buffer` with a new buffer
+    const buf = writer.buffer
+    buf[formatsOffset++] = 0
+    buf[formatsOffset++] = formatByte
   }
 }
 
@@ -150,18 +151,22 @@ const bind = (config: BindOpts = {}): Buffer => {
   const len = values.length
 
   writer.addCString(portal).addCString(statement)
+
+  // number of parameter format codes
+  writer.addInt16(len)
+
+  // space for those codes, filled by `writeValues`
+  const formatsOffset = writer.reserveUnsafe(len * 2)
+
+  // number of parameter values
   writer.addInt16(len)
 
   try {
-    writeValues(values, config.valueMapper)
+    writeValues(values, config.valueMapper, formatsOffset)
   } catch (err) {
     writer.clear()
-    paramWriter.clear()
     throw err
   }
-
-  writer.addInt16(len)
-  writer.add(paramWriter.flush())
 
   // all results use the same format code
   writer.addInt16(1)


### PR DESCRIPTION
Takes about 15–30% less time on some parameter values in my measurements. Performance here could still be improved by a lot, but many other improvements also need interface changes, so I separated out this patch that was fully backwards-compatible.