### PR TITLE
fix: preserve row mode in native pipelines

### DIFF
--- a/packages/pg-native/index.js
+++ b/packages/pg-native/index.js
@@ -174,8 +174,8 @@ Client.prototype._stopReading = function () {
   this.pq.removeListener('readable', this._read)
 }
 
-Client.prototype._consumeQueryResults = function (pq) {
-  return buildResult(pq, this._types, this.arrayMode)
+Client.prototype._consumeQueryResults = function (pq, arrayMode = this.arrayMode) {
+  return buildResult(pq, this._types, arrayMode)
 }
 
 Client.prototype._emitResult = function (pq) {
@@ -441,7 +441,7 @@ Client.prototype._readPipelineResults = function (queries, cb) {
       }
 
       if (status === 'PGRES_TUPLES_OK' || status === 'PGRES_COMMAND_OK' || status === 'PGRES_EMPTY_QUERY') {
-        currentResult = self._consumeQueryResults(pq)
+        currentResult = self._consumeQueryResults(pq, queries[queryIndex].arrayMode)
         continue
       }
     }

--- a/packages/pg/lib/native/client.js
+++ b/packages/pg/lib/native/client.js
@@ -337,7 +337,7 @@ Client.prototype._pulsePipelinedQueryQueue = function () {
     nativeQueries.push(query)
 
     const values = query.values ? query.values.map(utils.prepareValue) : null
-    const pipelineEntry = { text: query.text, name: query.name }
+    const pipelineEntry = { text: query.text, name: query.name, arrayMode: query._arrayMode }
     if (values) {
       pipelineEntry.values = values
     }

--- a/packages/pg/test/integration/client/pipelining-tests.js
+++ b/packages/pg/test/integration/client/pipelining-tests.js
@@ -35,6 +35,21 @@ suite.test('pipeline with parameterized queries', async function () {
   await client.end()
 })
 
+suite.test('pipeline preserves row mode for each query', async function () {
+  const client = new helper.Client({ pipeline: true })
+  await client.connect()
+
+  const [arrayResult, objectResult] = await Promise.all([
+    client.query({ text: 'SELECT $1::int AS num', values: [10], rowMode: 'array' }),
+    client.query({ text: 'SELECT $1::int AS num', values: [20] }),
+  ])
+
+  assert.deepStrictEqual(arrayResult.rows, [[10]])
+  assert.deepStrictEqual(objectResult.rows, [{ num: 20 }])
+
+  await client.end()
+})
+
 suite.test('pipeline with named prepared statements', async function () {
   const client = helper.client(undefined, { pipeline: true })
 


### PR DESCRIPTION
## What changed

Native pipeline entries now retain each query's array mode, and `pg-native` uses that mode when it builds the corresponding pipeline result.

The regression test mixes `rowMode: 'array'` and the default object mode in one connected pipeline batch, so it also verifies that row mode does not leak between queries.

## Why

The non-pipeline native path applies `NativeQuery._arrayMode` before reading a result, but the pipeline path dropped that per-query value. A `rowMode: 'array'` query therefore returned object rows when `pipeline: true`.

This is observable downstream in drizzle-team/drizzle-orm#6118: interpreted mapping produced `undefined` fields and JIT mapping threw `TypeError: object is not iterable`.

## Verification

- New integration test fails on `ff9d775` in native mode (object row returned instead of `[10]`).
- The focused pipeline integration file passes in both JavaScript and native modes after the fix.
- The original Drizzle reproduction passes for native direct queries plus interpreted and JIT mapping, with and without pipelining.
- Repository-wide ESLint passes; the three changed files pass Prettier check.
- The `pg` unit suite passes.

The canonical full `yarn test` matrix was not completed locally: its Yarn 1 workspace install caches unrelated multi-platform optional binaries beyond this executor's bounded disk budget. GitHub CI remains the authoritative full matrix.

## Compatibility

No public API is added or changed. The native pipeline path now matches the existing per-query `rowMode` behavior of the non-pipeline and JavaScript clients.

## AI assistance

Codex was used for investigation, implementation, and test execution. No human-review attestation is made.
