### PR TITLE
Report the parse error to pipelined queries that reused the failed statement

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -437,6 +437,16 @@ class Client extends EventEmitter {
     this._activeQuery = null
     if (activeQuery.name) {
       delete this.connection.submittedNamedStatements[activeQuery.name]
+      // pipelined queries already on the wire skipped their own Parse relying on this one.
+      // If it failed before parseComplete the backend will answer them with
+      // 'prepared statement does not exist', so hand them the original error instead.
+      if (!this.connection.parsedStatements[activeQuery.name]) {
+        for (const query of this._sentQueryQueue) {
+          if (query.name === activeQuery.name) {
+            query._pipelineParseError = msg
+          }
+        }
+      }
     }
     activeQuery.handleError(msg, this.connection)
   }

--- a/packages/pg/lib/query.js
+++ b/packages/pg/lib/query.js
@@ -120,6 +120,10 @@ class Query extends EventEmitter {
   }
 
   handleError(err, connection) {
+    // the named statement this query relied on was never created (26000): report why
+    if (this._pipelineParseError && err && err.code === '26000') {
+      err = this._pipelineParseError
+    }
     // need to sync after error during a prepared statement
     if (this._canceledDueToError) {
       err = this._canceledDueToError

--- a/packages/pg/test/integration/client/pipelining-tests.js
+++ b/packages/pg/test/integration/client/pipelining-tests.js
@@ -123,6 +123,29 @@ suite.test(
     }
 )
 
+// Two pipelined queries share a statement name and the parse fails: the second skipped
+// its own Parse, so the backend answers 'prepared statement does not exist'. The client
+// must report the original parse error to it instead.
+suite.test(
+  'named statement parse failure reports the real error to the queries behind it',
+  !helper.args.native &&
+    async function () {
+      const client = helper.client(undefined, { pipeline: true })
+
+      const results = await Promise.allSettled([
+        client.query({ name: 'shared-bad', text: 'SELECT no_such_column_xyz' }),
+        client.query({ name: 'shared-bad', text: 'SELECT no_such_column_xyz' }),
+      ])
+
+      assert.equal(results[0].status, 'rejected')
+      assert.equal(results[1].status, 'rejected')
+      assert.ok(results[0].reason.message.includes('no_such_column_xyz'), results[0].reason.message)
+      assert.ok(results[1].reason.message.includes('no_such_column_xyz'), results[1].reason.message)
+
+      await client.end()
+    }
+)
+
 // #14: query_timeout with pipelining
 // When an already-sent pipelined query times out, the connection is destroyed
 // to unblock the pipeline — subsequent queries error rather than hanging.


### PR DESCRIPTION
When a named statement fails to parse, pipelined queries already on the wire that skipped their own Parse for that name receive `prepared statement "x" does not exist` from the backend, an error about pg internals instead of the real one.

The client now marks those queries when the parse error arrives and hands them the original error, the same one they get without pipelining.

Regression test in `pipelining-tests.js`, it fails on master.
