### PR TITLE
fix: support callback as second argument to `CloudflareSocket.write`

### DIFF
--- a/packages/pg-cloudflare/src/index.ts
+++ b/packages/pg-cloudflare/src/index.ts
@@ -82,15 +82,15 @@ export class CloudflareSocket extends EventEmitter {
     this.emit('data', Buffer.from(value))
   }
 
+  write(data: Uint8Array | string, callback?: (error?: unknown) => void): true | void
+  write(data: Uint8Array | string, encoding?: BufferEncoding, callback?: (error?: unknown) => void): true | void
   write(
     data: Uint8Array | string,
-    encoding: BufferEncoding | ((...args: unknown[]) => void) = 'utf8',
-    callback: (...args: unknown[]) => void = () => {}
-  ) {
-    if (typeof encoding === 'function') {
-      callback = encoding
-      encoding = 'utf8'
-    }
+    encodingOrCallback: BufferEncoding | ((error?: unknown) => void) = 'utf8',
+    callback: (error?: unknown) => void = () => {}
+  ): true | void {
+    const encoding = typeof encodingOrCallback === 'function' ? 'utf8' : encodingOrCallback
+    if (typeof encodingOrCallback === 'function') callback = encodingOrCallback
     if (data.length === 0) return callback()
     if (typeof data === 'string') data = Buffer.from(data, encoding)
 
@@ -111,10 +111,7 @@ export class CloudflareSocket extends EventEmitter {
   end(data = Buffer.alloc(0), encoding: BufferEncoding = 'utf8', callback: (...args: unknown[]) => void = () => {}) {
     log('ending CF socket')
     this.write(data, encoding, (err) => {
-      this._cfSocket
-        ?.close()
-        .then(() => this._emitClose())
-        .catch((e) => this.emit('error', e))
+      this._cfSocket?.close()
       if (callback) callback(err)
     })
     return this
@@ -145,19 +142,14 @@ export class CloudflareSocket extends EventEmitter {
   _addClosedHandler() {
     this._cfSocket!.closed.then(() => {
       if (!this._upgrading) {
-        this._emitClose()
+        log('CF socket closed')
+        this._cfSocket = null
+        this.emit('close')
       } else {
         this._upgrading = false
         this._upgraded = true
       }
     }).catch((e) => this.emit('error', e))
-  }
-
-  private _emitClose() {
-    if (!this._cfSocket) return
-    log('CF socket closed')
-    this._cfSocket = null
-    this.emit('close')
   }
 }
 

--- a/packages/pg-cloudflare/src/index.ts
+++ b/packages/pg-cloudflare/src/index.ts
@@ -84,9 +84,13 @@ export class CloudflareSocket extends EventEmitter {
 
   write(
     data: Uint8Array | string,
-    encoding: BufferEncoding = 'utf8',
+    encoding: BufferEncoding | ((...args: unknown[]) => void) = 'utf8',
     callback: (...args: unknown[]) => void = () => {}
   ) {
+    if (typeof encoding === 'function') {
+      callback = encoding
+      encoding = 'utf8'
+    }
     if (data.length === 0) return callback()
     if (typeof data === 'string') data = Buffer.from(data, encoding)
 
@@ -107,7 +111,10 @@ export class CloudflareSocket extends EventEmitter {
   end(data = Buffer.alloc(0), encoding: BufferEncoding = 'utf8', callback: (...args: unknown[]) => void = () => {}) {
     log('ending CF socket')
     this.write(data, encoding, (err) => {
-      this._cfSocket?.close()
+      this._cfSocket
+        ?.close()
+        .then(() => this._emitClose())
+        .catch((e) => this.emit('error', e))
       if (callback) callback(err)
     })
     return this
@@ -138,14 +145,19 @@ export class CloudflareSocket extends EventEmitter {
   _addClosedHandler() {
     this._cfSocket!.closed.then(() => {
       if (!this._upgrading) {
-        log('CF socket closed')
-        this._cfSocket = null
-        this.emit('close')
+        this._emitClose()
       } else {
         this._upgrading = false
         this._upgraded = true
       }
     }).catch((e) => this.emit('error', e))
+  }
+
+  private _emitClose() {
+    if (!this._cfSocket) return
+    log('CF socket closed')
+    this._cfSocket = null
+    this.emit('close')
   }
 }
 

--- a/packages/pg-esm-test/pg-cloudflare.test.js
+++ b/packages/pg-esm-test/pg-cloudflare.test.js
@@ -19,44 +19,17 @@ describe('pg-cloudflare', () => {
     assert.doesNotThrow(() => socket.end())
   })
 
-  it('should emit close when the underlying close call resolves', async () => {
-    const socket = new CloudflareSocket()
-    const underlyingSocket = {
-      closed: new Promise(() => {}),
-      close: () => Promise.resolve(),
-    }
-    socket._cfSocket = underlyingSocket
-    socket._addClosedHandler()
-
-    const close = new Promise((resolve) => socket.once('close', resolve))
-    socket.end()
-
-    await close
-    assert.equal(socket._cfSocket, null)
-  })
-
-  it('should support the write(data, callback) overload', async () => {
+  it('should call the write(data, callback) callback exactly once', async () => {
     const socket = new CloudflareSocket()
     socket._cfWriter = { write: () => Promise.resolve() }
 
-    await new Promise((resolve) => socket.write(Buffer.from('x'), resolve))
-  })
+    let callbackCount = 0
+    socket.write(Buffer.from('x'), (error) => {
+      assert.ifError(error)
+      callbackCount++
+    })
 
-  it('should emit close only once when both close signals resolve', async () => {
-    const socket = new CloudflareSocket()
-    const underlyingSocket = {
-      closed: Promise.resolve(),
-      close: () => Promise.resolve(),
-    }
-    socket._cfSocket = underlyingSocket
-    socket._addClosedHandler()
-
-    let closeCount = 0
-    socket.on('close', () => closeCount++)
-    socket.end()
-
-    await underlyingSocket.closed
     await new Promise((resolve) => setImmediate(resolve))
-    assert.equal(closeCount, 1)
+    assert.equal(callbackCount, 1)
   })
 })

--- a/packages/pg-esm-test/pg-cloudflare.test.js
+++ b/packages/pg-esm-test/pg-cloudflare.test.js
@@ -23,13 +23,18 @@ describe('pg-cloudflare', () => {
     const socket = new CloudflareSocket()
     socket._cfWriter = { write: () => Promise.resolve() }
 
-    let callbackCount = 0
+    let resolve
+    const promise = new Promise((resolvePromise) => {
+      resolve = resolvePromise
+    })
+    let called = false
     socket.write(Buffer.from('x'), (error) => {
       assert.ifError(error)
-      callbackCount++
+      assert(!called)
+      called = true
+      resolve()
     })
 
-    await new Promise((resolve) => setImmediate(resolve))
-    assert.equal(callbackCount, 1)
+    await promise
   })
 })

--- a/packages/pg-esm-test/pg-cloudflare.test.js
+++ b/packages/pg-esm-test/pg-cloudflare.test.js
@@ -18,4 +18,45 @@ describe('pg-cloudflare', () => {
 
     assert.doesNotThrow(() => socket.end())
   })
+
+  it('should emit close when the underlying close call resolves', async () => {
+    const socket = new CloudflareSocket()
+    const underlyingSocket = {
+      closed: new Promise(() => {}),
+      close: () => Promise.resolve(),
+    }
+    socket._cfSocket = underlyingSocket
+    socket._addClosedHandler()
+
+    const close = new Promise((resolve) => socket.once('close', resolve))
+    socket.end()
+
+    await close
+    assert.equal(socket._cfSocket, null)
+  })
+
+  it('should support the write(data, callback) overload', async () => {
+    const socket = new CloudflareSocket()
+    socket._cfWriter = { write: () => Promise.resolve() }
+
+    await new Promise((resolve) => socket.write(Buffer.from('x'), resolve))
+  })
+
+  it('should emit close only once when both close signals resolve', async () => {
+    const socket = new CloudflareSocket()
+    const underlyingSocket = {
+      closed: Promise.resolve(),
+      close: () => Promise.resolve(),
+    }
+    socket._cfSocket = underlyingSocket
+    socket._addClosedHandler()
+
+    let closeCount = 0
+    socket.on('close', () => closeCount++)
+    socket.end()
+
+    await underlyingSocket.closed
+    await new Promise((resolve) => setImmediate(resolve))
+    assert.equal(closeCount, 1)
+  })
 })


### PR DESCRIPTION
`Connection.end()` calls `write(data, callback)`. `CloudflareSocket.write` previously treated the callback as an encoding, so it never ran.

This adds explicit overloads for `write(data, callback)` and `write(data, encoding, callback)`. The runtime dispatch stays in the existing `write` method; close and event behavior are unchanged.

Validation:

- focused `pg-cloudflare` runtime test: 3 passed;
- `yarn build`, `yarn lint`, Prettier, and `git diff --check`: passed;
- type fixture: valid overloads compile, while `write(data, callback, callback)` fails with TS2345.

The full PostgreSQL/libpq integration suite and a real Cloudflare Worker E2E were not run locally.

Prepared with Codex assistance.
