### PR TITLE
fix: use pg-protocol CommonJS entrypoint

### DIFF
--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -2,7 +2,7 @@
 
 const EventEmitter = require('events').EventEmitter
 
-const { parse, serialize } = require('pg-protocol')
+const { parse, serialize } = require('pg-protocol/dist/index.js')
 const stream = require('./stream')
 const { getStream } = stream
 

--- a/packages/pg/lib/index.js
+++ b/packages/pg/lib/index.js
@@ -7,7 +7,7 @@ const Result = require('./result')
 const utils = require('./utils')
 const Pool = require('pg-pool')
 const TypeOverrides = require('./type-overrides')
-const { DatabaseError } = require('pg-protocol')
+const { DatabaseError } = require('pg-protocol/dist/index.js')
 const { escapeIdentifier, escapeLiteral } = require('./utils')
 
 const poolFactory = (Client) => {

--- a/packages/pg/test/unit/protocol-import-tests.js
+++ b/packages/pg/test/unit/protocol-import-tests.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const assert = require('assert')
+const fs = require('fs')
+const helper = require('./test-helper')
+const suite = new helper.Suite()
+const test = suite.test.bind(suite)
+
+const connectionSource = fs.readFileSync(require.resolve('../../lib/connection'), 'utf8')
+const indexSource = fs.readFileSync(require.resolve('../../lib'), 'utf8')
+
+test('uses the exported pg-protocol CommonJS entrypoint', function () {
+  require.resolve('pg-protocol/dist/index.js')
+  assert.match(connectionSource, /require\('pg-protocol\/dist\/index\.js'\)/)
+  assert.match(indexSource, /require\('pg-protocol\/dist\/index\.js'\)/)
+})


### PR DESCRIPTION
Fixes #3700.

## Problem

When the Cloudflare Vitest/Vite worker pipeline inlines both `pg` and `pg-protocol`, the CommonJS `pg` entry can resolve the bare `pg-protocol` import through its ESM condition. Loading that ESM wrapper from `pg`'s CommonJS files then fails before any tests run:

```text
SyntaxError: Cannot use import statement outside a module
at pg/lib/connection.js?mf_vitest_no_cjs_esm_shim:5:30
```

I reproduced this with the standalone fixture from #3700 using released `pg@8.23.0`, `pg-protocol@1.16.0`, `@cloudflare/vitest-pool-workers@0.16.18`, and Vitest 4.1.9.

## Fix

- load `pg-protocol/dist/index.js` explicitly from `pg`'s two CommonJS entry files;
- add a unit regression that verifies the subpath is exported and both call sites keep using it.

This remains package-manager independent: `pg-protocol` exposes `./dist/*.js` through its public `exports` map, and `pg` currently depends on `pg-protocol ^1.16.0`.

## Tests

- published standalone worker fixture: fails before the patch, passes 1/1 after it;
- `make test-unit` from `packages/pg`;
- `yarn lint`;
- `yarn build`;
- Prettier check for all changed files;
- `git diff --check`.

The full PostgreSQL/Node matrix was not run locally; it is left to CI. The repository's existing Cloudflare integration test also gets past module collection with the worker inline settings after the patch, then stops at this executor's unavailable PostgreSQL endpoint.

Implementation and test preparation were assisted by Codex. The reproduction and all reported checks above were run against this branch.
