### PR TITLE
fix(pg-cloudflare): prevent Client.end() from hanging

### DIFF
--- a/packages/pg-cloudflare/src/index.ts
+++ b/packages/pg-cloudflare/src/index.ts
@@ -107,7 +107,7 @@ export class CloudflareSocket extends EventEmitter {
   end(data = Buffer.alloc(0), encoding: BufferEncoding = 'utf8', callback: (...args: unknown[]) => void = () => {}) {
     log('ending CF socket')
     this.write(data, encoding, (err) => {
-      this._cfSocket!.close()
+      this._cfSocket?.close()
       if (callback) callback(err)
     })
     return this

--- a/packages/pg-cloudflare/src/index.ts
+++ b/packages/pg-cloudflare/src/index.ts
@@ -84,9 +84,13 @@ export class CloudflareSocket extends EventEmitter {
 
   write(
     data: Uint8Array | string,
-    encoding: BufferEncoding = 'utf8',
+    encoding: BufferEncoding | ((...args: unknown[]) => void) = 'utf8',
     callback: (...args: unknown[]) => void = () => {}
   ) {
+    if (typeof encoding === 'function') {
+      callback = encoding
+      encoding = 'utf8'
+    }
     if (data.length === 0) return callback()
     if (typeof data === 'string') data = Buffer.from(data, encoding)
 
@@ -104,10 +108,27 @@ export class CloudflareSocket extends EventEmitter {
     return true
   }
 
-  end(data = Buffer.alloc(0), encoding: BufferEncoding = 'utf8', callback: (...args: unknown[]) => void = () => {}) {
+  end(
+    data = Buffer.alloc(0),
+    encoding: BufferEncoding | ((...args: unknown[]) => void) = 'utf8',
+    callback: (...args: unknown[]) => void = () => {}
+  ) {
+    if (typeof encoding === 'function') {
+      callback = encoding
+      encoding = 'utf8'
+    }
     log('ending CF socket')
     this.write(data, encoding, (err) => {
-      this._cfSocket?.close()
+      const socket = this._cfSocket
+      const closePromise = socket?.close()
+      closePromise
+        ?.then(() => {
+          if (this._cfSocket === socket) {
+            this._cfSocket = null
+            this.emit('close')
+          }
+        })
+        .catch((e) => this.emit('error', e))
       if (callback) callback(err)
     })
     return this
@@ -136,16 +157,21 @@ export class CloudflareSocket extends EventEmitter {
   }
 
   _addClosedHandler() {
-    this._cfSocket!.closed.then(() => {
-      if (!this._upgrading) {
-        log('CF socket closed')
-        this._cfSocket = null
-        this.emit('close')
-      } else {
-        this._upgrading = false
-        this._upgraded = true
-      }
-    }).catch((e) => this.emit('error', e))
+    const socket = this._cfSocket!
+    socket.closed
+      .then(() => {
+        if (!this._upgrading) {
+          log('CF socket closed')
+          if (this._cfSocket === socket) {
+            this._cfSocket = null
+            this.emit('close')
+          }
+        } else {
+          this._upgrading = false
+          this._upgraded = true
+        }
+      })
+      .catch((e) => this.emit('error', e))
   }
 }
 

--- a/packages/pg-esm-test/pg-cloudflare.test.js
+++ b/packages/pg-esm-test/pg-cloudflare.test.js
@@ -18,4 +18,36 @@ describe('pg-cloudflare', () => {
 
     assert.doesNotThrow(() => socket.end())
   })
+
+  it('should invoke callbacks passed as the write encoding argument', async () => {
+    const socket = new CloudflareSocket()
+    socket._cfSocket = { close() {} }
+    socket._cfWriter = { write: async () => {} }
+
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('write callback was not called')), 100)
+      socket.write(Buffer.from('terminate'), () => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+  })
+
+  it('should emit close when ending a socket whose closed promise never settles', async () => {
+    const socket = new CloudflareSocket()
+    socket._cfSocket = {
+      closed: new Promise(() => {}),
+      close: async () => {},
+    }
+    socket._addClosedHandler()
+
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('close event was not emitted')), 100)
+      socket.once('close', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+      socket.end()
+    })
+  })
 })

--- a/packages/pg-esm-test/pg-cloudflare.test.js
+++ b/packages/pg-esm-test/pg-cloudflare.test.js
@@ -6,4 +6,16 @@ describe('pg-cloudflare', () => {
   it('should export CloudflareSocket constructor', () => {
     assert.ok(new CloudflareSocket())
   })
+
+  it('should safely end after the underlying socket has closed', async () => {
+    const socket = new CloudflareSocket()
+    const underlyingSocket = { closed: Promise.resolve() }
+    socket._cfSocket = underlyingSocket
+    socket._addClosedHandler()
+
+    await underlyingSocket.closed
+    assert.equal(socket._cfSocket, null)
+
+    assert.doesNotThrow(() => socket.end())
+  })
 })

--- a/packages/pg-esm-test/pg-cloudflare.test.js
+++ b/packages/pg-esm-test/pg-cloudflare.test.js
@@ -19,6 +19,25 @@ describe('pg-cloudflare', () => {
     assert.doesNotThrow(() => socket.end())
   })
 
+  it('should call the write(data, callback) callback exactly once', async () => {
+    const socket = new CloudflareSocket()
+    socket._cfWriter = { write: () => Promise.resolve() }
+
+    let resolve
+    const promise = new Promise((resolvePromise) => {
+      resolve = resolvePromise
+    })
+    let called = false
+    socket.write(Buffer.from('x'), (error) => {
+      assert.ifError(error)
+      assert(!called)
+      called = true
+      resolve()
+    })
+
+    await promise
+  })
+
   it('should emit close when ending a socket whose closed promise never settles', async () => {
     const socket = new CloudflareSocket()
     socket._cfSocket = {


### PR DESCRIPTION
Fixes https://github.com/brianc/node-postgres/issues/3152

## Summary

- complete Cloudflare shutdown when Socket.close() resolves but Socket.closed never settles
- emit close once, with an identity guard preventing a duplicate event from the normal closed handler
- add a regression test for a socket that never settles its closed promise

The callback overload used by Connection.end() is already present in the current base branch via https://github.com/brianc/node-postgres/pull/3747.

## Validation

- yarn lint
- yarn workspace pg-cloudflare build
- yarn workspace pg-esm-test test --test-name-pattern=pg-cloudflare (12 passed)
- GitHub CI: lint and all 11 Node/PostgreSQL matrix jobs passed

The PR is limited to pg-cloudflare shutdown behavior and its focused ESM test.