### PR TITLE
fix: add default error listeners to clients and pools

### DIFF
--- a/packages/pg-pool/index.js
+++ b/packages/pg-pool/index.js
@@ -66,6 +66,7 @@ function makeIdleListener(pool, client) {
 class Pool extends EventEmitter {
   constructor(options, Client) {
     super()
+    this.on('error', NOOP)
     this.options = Object.assign({}, options)
 
     if (options != null && 'password' in options) {

--- a/packages/pg-pool/test/events.js
+++ b/packages/pg-pool/test/events.js
@@ -7,6 +7,11 @@ const it = require('mocha').it
 const Pool = require('../')
 
 describe('events', function () {
+  it('does not throw when an error has no listener', function () {
+    const pool = new Pool()
+    expect(() => pool.emit('error', new Error('problem'))).not.to.throwError()
+  })
+
   it('emits connect before callback', function (done) {
     const pool = new Pool()
     let emittedClient = false

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -50,6 +50,7 @@ function coerceNumberOrDefault(value, defaultValue) {
 class Client extends EventEmitter {
   constructor(config) {
     super()
+    this.on('error', () => {})
 
     this.connectionParameters = new ConnectionParameters(config)
     this.user = this.connectionParameters.user

--- a/packages/pg/lib/native/client.js
+++ b/packages/pg/lib/native/client.js
@@ -22,6 +22,7 @@ const queryQueueLengthDeprecationNotice = nodeUtils.deprecate(
 
 const Client = (module.exports = function (config) {
   EventEmitter.call(this)
+  this.on('error', () => {})
   config = config || {}
 
   this._Promise = config.Promise || global.Promise

--- a/packages/pg/test/unit/client/configuration-tests.js
+++ b/packages/pg/test/unit/client/configuration-tests.js
@@ -60,6 +60,13 @@ test('client settings', function () {
   })
 })
 
+test('emitting an error without a listener does not throw', function () {
+  const client = new Client()
+  assert.doesNotThrow(function () {
+    client.emit('error', new Error('expected'))
+  })
+})
+
 test('initializing from a config string', function () {
   test('uses connectionString property', function () {
     const client = new Client({


### PR DESCRIPTION
## Summary

- add default no-op `error` listeners to `Pool` and both `Client` implementations
- prevent an emitted error from crashing an otherwise unconfigured client or pool
- add regression coverage for the pure JavaScript client and pool

Fixes #3630